### PR TITLE
shutter buff

### DIFF
--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -5,9 +5,9 @@
 	icon = 'icons/obj/doors/shutters.dmi'
 	layer = SHUTTER_LAYER
 	closingLayer = SHUTTER_LAYER_CLOSED
-	damage_deflection = 20
-	armor = list(MELEE = 20, BULLET = 20, LASER = 20, ENERGY = 75, BOMB = 25, BIO = 100, FIRE = 100, ACID = 70)
-	max_integrity = 100
+	damage_deflection = 35 // enough to occasionally stop a basic slasher with its 30 - 48 structure damage
+	armor = list(MELEE = 35, BULLET = 20, LASER = 20, ENERGY = 75, BOMB = 25, BIO = 100, FIRE = 100, ACID = 70)
+	max_integrity = 300
 	recipe_type = /datum/crafting_recipe/shutters
 
 /obj/machinery/door/poddoor/shutters/preopen


### PR DESCRIPTION
## About The Pull Request

simply lets a roller door occasionally able to halt a slasher or two for a few seconds at least

integrity: orginal (100) -> new (300)
damage_deflect: orginal (20) -> new (35) -- Slashers supposdly do a minimum of 30 damage and a maximum of 48.
armor: original (20) [MELEE] -> new (35) [MELEE]

## Why It's Good For The Game

Shutters (airlocks that cost 5 plasteel and don't open when you walk into them) are mostly designed to stop traitors with insuls and emags in base TG, thus they have lower armour values to allow them to be destroyed more easily. In DS13 they're mostly used to halt necro mobs but they don't do that pretty much at all. This allows them to do that a bit better.

## Changelog

:cl:
balance: Shutter doors are more powerful now
/:cl:

