### PR TITLE
Adds screams for necromorphs

### DIFF
--- a/deadspace/code/necromorph/necromorphs/subtypes/brute.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/brute.dm
@@ -91,6 +91,14 @@
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/necromorph/brute,
 	)
 
+/datum/species/necromorph/brute/get_scream_sound(mob/living/carbon/human/necromorph/brute)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/brute/brute_pain_1.ogg',
+		'deadspace/sound/effects/creatures/necromorph/brute/brute_pain_2.ogg',
+		'deadspace/sound/effects/creatures/necromorph/brute/brute_pain_3.ogg',
+		'deadspace/sound/effects/creatures/necromorph/brute/brute_pain_extreme.ogg',
+	)
+
 #define WINDUP_TIME 1.25 SECONDS
 
 /datum/action/cooldown/necro/shoot/brute

--- a/deadspace/code/necromorph/necromorphs/subtypes/divider.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/divider.dm
@@ -32,3 +32,11 @@
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/necromorph/divider,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/necromorph/divider,
 	)
+
+/datum/species/necromorph/divider/get_scream_sound(mob/living/carbon/human/necromorph/divider)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/divider/divider_shout_1.ogg',
+		'deadspace/sound/effects/creatures/necromorph/divider/divider_shout_2.ogg',
+		'deadspace/sound/effects/creatures/necromorph/divider/divider_shout_3.ogg',
+		'deadspace/sound/effects/creatures/necromorph/divider/divider_shout_4.ogg',
+	)

--- a/deadspace/code/necromorph/necromorphs/subtypes/e_slasher.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/e_slasher.dm
@@ -48,6 +48,13 @@
 		'deadspace/sound/effects/creatures/necromorph/slasher_enhanced/eslasher_death_3.ogg'
 	)
 
+/datum/species/necromorph/slasher/enhanced/get_scream_sound(mob/living/carbon/human/necromorph/slasher/enhanced)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/slasher_enhanced/eslasher_pain_extreme.ogg',
+		'deadspace/sound/effects/creatures/necromorph/slasher_enhanced/eslasher_shout_3.ogg',
+		'deadspace/sound/effects/creatures/necromorph/slasher_enhanced/eslasher_shout_long_5.ogg',
+	)
+
 /datum/action/cooldown/necro/charge/slasher/enhanced
 	cooldown_time = 20 SECONDS
 	charge_delay = 0.75 SECONDS

--- a/deadspace/code/necromorph/necromorphs/subtypes/exploder.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/exploder.dm
@@ -54,3 +54,12 @@
 		'deadspace/sound/effects/creatures/necromorph/exploder/exploder_death_2.ogg',
 		'deadspace/sound/effects/creatures/necromorph/exploder/exploder_death_3.ogg'
 	)
+
+/datum/species/necromorph/exploder/get_scream_sound(mob/living/carbon/human/necromorph/exploder)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/exploder/exploder_pain_1.ogg',
+		'deadspace/sound/effects/creatures/necromorph/exploder/exploder_pain_2.ogg',
+		'deadspace/sound/effects/creatures/necromorph/exploder/exploder_pain_3.ogg',
+		'deadspace/sound/effects/creatures/necromorph/exploder/exploder_pain_4.ogg',
+		'deadspace/sound/effects/creatures/necromorph/exploder/exploder_pain_5.ogg',
+	)

--- a/deadspace/code/necromorph/necromorphs/subtypes/hunter.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/hunter.dm
@@ -80,6 +80,13 @@
 		'deadspace/sound/effects/footstep/ubermorph_footstep_4.ogg'
 	)
 
+/datum/species/necromorph/hunter/get_scream_sound(mob/living/carbon/human/necromorph/hunter)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/ubermorph/ubermorph_pain_5.ogg',
+		'deadspace/sound/effects/creatures/necromorph/ubermorph/ubermorph_pain_6.ogg',
+		'deadspace/sound/effects/creatures/necromorph/ubermorph/ubermorph_shout_long_3.ogg',
+	)
+
 /datum/species/necromorph/hunter/apply_damage(damage, damagetype, def_zone, blocked, mob/living/carbon/human/necromorph/H, forced, spread_damage, sharpness, attack_direction)
 	if(H.health - damage <= 0)
 		return H.handle_death_check()

--- a/deadspace/code/necromorph/necromorphs/subtypes/infector.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/infector.dm
@@ -29,3 +29,10 @@
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/necromorph/infector,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/necromorph/infector,
 	)
+
+/datum/species/necromorph/infector/get_scream_sound(mob/living/carbon/human/necromorph/infector)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/infector/infector_shout_long_1.ogg',
+		'deadspace/sound/effects/creatures/necromorph/infector/infector_shout_long_2.ogg',
+		'deadspace/sound/effects/creatures/necromorph/infector/infector_shout_long_3.ogg',
+	)

--- a/deadspace/code/necromorph/necromorphs/subtypes/leaper.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/leaper.dm
@@ -48,3 +48,10 @@
 		BODY_ZONE_L_LEG = /obj/item/bodypart/leg/left/necromorph/leaper,
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/necromorph/leaper,
 	)
+
+/datum/species/necromorph/leaper/get_scream_sound(mob/living/carbon/human/necromorph/leaper)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/leaper/leaper_pain_5.ogg',
+		'deadspace/sound/effects/creatures/necromorph/leaper/leaper_pain_6.ogg',
+		'deadspace/sound/effects/creatures/necromorph/leaper/leaper_pain_7.ogg',
+	)

--- a/deadspace/code/necromorph/necromorphs/subtypes/lurker.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/lurker.dm
@@ -31,3 +31,10 @@
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/necromorph/lurker,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/necromorph/lurker,
 	)
+
+/datum/species/necromorph/lurker/get_scream_sound(mob/living/carbon/human/necromorph/lurker)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/lurker/lurker_shout_long_2.ogg',
+		'deadspace/sound/effects/creatures/necromorph/lurker/lurker_shout_long_3.ogg',
+		'deadspace/sound/effects/creatures/necromorph/lurker/lurker_shout_4.ogg',
+	)

--- a/deadspace/code/necromorph/necromorphs/subtypes/puker.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/puker.dm
@@ -58,6 +58,14 @@
 		'deadspace/sound/effects/creatures/necromorph/puker/puker_death_3.ogg'
 	)
 
+/datum/species/necromorph/puker/get_scream_sound(mob/living/carbon/human/necromorph/puker)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/puker/puker_pain_4.ogg',
+		'deadspace/sound/effects/creatures/necromorph/puker/puker_shout_1.ogg',
+		'deadspace/sound/effects/creatures/necromorph/puker/puker_shout_4.ogg',
+		'deadspace/sound/effects/creatures/necromorph/puker/puker_shout_long_4.ogg',
+	)
+
 /datum/action/cooldown/necro/shoot/puker_longshot
 	name = "Long shot"
 	desc = "A powerful projectile for longrange shooting."

--- a/deadspace/code/necromorph/necromorphs/subtypes/slasher.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/slasher.dm
@@ -40,6 +40,14 @@
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/necromorph/slasher,
 	)
 
+/datum/species/necromorph/slasher/get_scream_sound(mob/living/carbon/human/necromorph/slasher)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/slasher/slasher_shout_1.ogg',
+		'deadspace/sound/effects/creatures/necromorph/slasher/slasher_shout_2.ogg',
+		'deadspace/sound/effects/creatures/necromorph/slasher/slasher_shout_3.ogg',
+		'deadspace/sound/effects/creatures/necromorph/slasher/slasher_shout_4.ogg',
+	)
+
 /datum/action/cooldown/necro/charge/slasher
 	cooldown_time = 12 SECONDS
 	charge_delay = 1 SECONDS

--- a/deadspace/code/necromorph/necromorphs/subtypes/spitter.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/spitter.dm
@@ -44,6 +44,12 @@
 		'deadspace/sound/effects/creatures/necromorph/spitter/spitter_death_3.ogg'
 	)
 
+/datum/species/necromorph/spitter/get_scream_sound(mob/living/carbon/human/necromorph/spitter)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/spitter/spitter_pain_extreme.ogg',
+		'deadspace/sound/effects/creatures/necromorph/spitter/spitter_pain_extreme_2.ogg',
+	)
+
 /datum/action/cooldown/necro/shoot/spitter_longshoot
 	name = "Long shot"
 	desc = "A powerful projectile for longrange shooting."

--- a/deadspace/code/necromorph/necromorphs/subtypes/tripod.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/tripod.dm
@@ -31,3 +31,11 @@
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/necromorph/tripod,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/necromorph/tripod,
 	)
+
+/datum/species/necromorph/tripod/get_scream_sound(mob/living/carbon/human/necromorph/tripod)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/tripod/tripod_shout_1.ogg',
+		'deadspace/sound/effects/creatures/necromorph/tripod/tripod_shout_4.ogg',
+		'deadspace/sound/effects/creatures/necromorph/tripod/tripod_shout_long_3.ogg',
+		'deadspace/sound/effects/creatures/necromorph/tripod/tripod_shout_long_5.ogg',
+	)

--- a/deadspace/code/necromorph/necromorphs/subtypes/twitcher.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/twitcher.dm
@@ -31,3 +31,11 @@
 		BODY_ZONE_R_LEG = /obj/item/bodypart/leg/right/necromorph/twitcher,
 		BODY_ZONE_CHEST = /obj/item/bodypart/chest/necromorph/twitcher,
 	)
+
+/datum/species/necromorph/twitcher/get_scream_sound(mob/living/carbon/human/necromorph/twitcher)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/twitcher/twitcher_shout_long_2.ogg',
+		'deadspace/sound/effects/creatures/necromorph/twitcher/twitcher_shout_long_5.ogg',
+		'deadspace/sound/effects/creatures/necromorph/twitcher/twitcher_shout_long_2.ogg',
+		'deadspace/sound/effects/creatures/necromorph/twitcher/twitcher_shout_1.ogg',
+	)

--- a/deadspace/code/necromorph/necromorphs/subtypes/ubermorph.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/ubermorph.dm
@@ -42,6 +42,13 @@
 		'deadspace/sound/effects/footstep/ubermorph_footstep_4.ogg'
 	)
 
+/datum/species/necromorph/ubermorph/get_scream_sound(mob/living/carbon/human/necromorph/ubermorph)
+	return pick(
+		'deadspace/sound/effects/creatures/necromorph/ubermorph/ubermorph_pain_5.ogg',
+		'deadspace/sound/effects/creatures/necromorph/ubermorph/ubermorph_pain_6.ogg',
+		'deadspace/sound/effects/creatures/necromorph/ubermorph/ubermorph_shout_long_3.ogg',
+	)
+
 /datum/action/cooldown/necro/regenerate/ubermorph
 	name = "Regenerate"
 	desc = "Regrows a missing limb and restores some of your health."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds necromorph screams for when the scream emote is proced on a necromorph, mostly from bone fractures. Uses only existing sound files for the necro subtypes in question, so variety can vary subtype to subtype.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Necromorphs no longer scream like people, they scream like necromorphs.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Necromorphs don't scream like humans anymore
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
