### PR TITLE
More Survival Supplies in Survival Box

### DIFF
--- a/code/game/objects/items/food/donkpocket.dm
+++ b/code/game/objects/items/food/donkpocket.dm
@@ -2,7 +2,7 @@
 
 /obj/item/food/donkpocket
 	name = "\improper Donk-pocket"
-	desc = "The food of choice for the seasoned traitor."
+	desc = "The food of choice for the seasoned space colonist."
 	icon_state = "donkpocket"
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/protein = 2)
 	microwaved_type = /obj/item/food/donkpocket/warm
@@ -17,7 +17,7 @@
 
 /obj/item/food/donkpocket/warm
 	name = "warm Donk-pocket"
-	desc = "The heated food of choice for the seasoned traitor."
+	desc = "The heated food of choice for the seasoned space colonist."
 	food_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/protein = 2, /datum/reagent/medicine/tricordrazine = 6)
 	microwaved_type = null
 	tastes = list("meat" = 2, "dough" = 2, "laziness" = 1)

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -115,6 +115,7 @@
 	var/mask_type = /obj/item/clothing/mask/breath
 	var/internal_type = /obj/item/tank/internals/emergency_oxygen
 	var/medipen_type = /obj/item/reagent_containers/hypospray/medipen
+	new /obj/item/food/donkpocket
 
 /obj/item/storage/box/survival/PopulateContents()
 	if(isplasmaman(loc))

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -115,7 +115,7 @@
 	var/mask_type = /obj/item/clothing/mask/breath
 	var/internal_type = /obj/item/tank/internals/emergency_oxygen
 	var/medipen_type = /obj/item/reagent_containers/hypospray/medipen
-	new /obj/item/food/donkpocket
+	new /obj/item/food/donkpocket(src)
 
 /obj/item/storage/box/survival/PopulateContents()
 	if(isplasmaman(loc))

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -115,9 +115,10 @@
 	var/mask_type = /obj/item/clothing/mask/breath
 	var/internal_type = /obj/item/tank/internals/emergency_oxygen
 	var/medipen_type = /obj/item/reagent_containers/hypospray/medipen
-	new /obj/item/food/donkpocket(src)
+
 
 /obj/item/storage/box/survival/PopulateContents()
+
 	if(isplasmaman(loc))
 		new /obj/item/tank/internals/plasmaman/belt(src)
 	else if(isvox(loc))
@@ -132,6 +133,9 @@
 	if(HAS_TRAIT(SSstation, STATION_TRAIT_PREMIUM_INTERNALS))
 		new /obj/item/flashlight/flare(src)
 		new /obj/item/radio/off(src)
+	new /obj/item/food/donkpocket(src)
+	new /obj/item/flashlight/glowstick(src)
+
 
 /obj/item/storage/box/survival/radio/PopulateContents()
 	..() // we want the survival stuff too.

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -135,6 +135,7 @@
 		new /obj/item/radio/off(src)
 	new /obj/item/food/donkpocket(src)
 	new /obj/item/flashlight/glowstick(src)
+	new /obj/item/crowbar(src)
 
 
 /obj/item/storage/box/survival/radio/PopulateContents()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds food back into the emergency storage box (a donk pocket). Also a glowstick and crowbar for when power goes out inevitably. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Not enough chef players and people were starving in some rounds and  also not enough food in maint and there was food in the 1.0 emergency storage boxes. crowbar lets people open doors when power is out and glowstick lets them see a little bit.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Food ,glowstick, and crowbar to emergency storage box
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
