### PR TITLE
Add more Necromorphs to nests and disabling Exploders

### DIFF
--- a/deadspace/code/necromorph/necromorphs/subtypes/e_slasher.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/e_slasher.dm
@@ -12,6 +12,7 @@
 	desc = "The frontline soldier of the necromorph horde. Slow when not charging, but its blade arms make for powerful melee attacks"
 	ui_icon = 'deadspace/icons/necromorphs/slasher_enhanced.dmi'
 	necromorph_type_path = /mob/living/carbon/human/necromorph/slasher/enhanced
+	nest_allowed = TRUE
 	tier = 2
 	biomass_cost = 125
 	biomass_spent_required = 680

--- a/deadspace/code/necromorph/necromorphs/subtypes/exploder.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/exploder.dm
@@ -26,7 +26,7 @@
 		/datum/action/cooldown/necro/shout,
 	)
 	minimap_icon = "exploder"
-	implemented = TRUE
+	implemented = FALSE //Explode doesn't work so they're worthless
 
 /datum/species/necromorph/exploder
 	name = "Exploder"

--- a/deadspace/code/necromorph/necromorphs/subtypes/puker.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/puker.dm
@@ -10,6 +10,7 @@
 	desc = "A tough and flexible elite who fights by dousing enemies in acid, and is effective at all ranges. Good for crowd control and direct firefights"
 	ui_icon = 'deadspace/icons/necromorphs/puker/puker.dmi'
 	necromorph_type_path = /mob/living/carbon/human/necromorph/puker
+	nest_allowed = TRUE
 	tier = 2
 	biomass_cost = 125
 	biomass_spent_required = 680

--- a/deadspace/code/necromorph/necromorphs/subtypes/spitter.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/spitter.dm
@@ -10,6 +10,7 @@
 	desc = "A midline skirmisher with the ability to spit acid at medium range. Works best when accompanied by slashers to protect it from attacks. Weak and fragile in direct combat."
 	ui_icon = 'deadspace/icons/necromorphs/spitter.dmi'
 	necromorph_type_path = /mob/living/carbon/human/necromorph/spitter
+	nest_allowed = TRUE
 	tier = 1
 	biomass_cost = 50
 	biomass_spent_required = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Nests just had e slasher and regular slasher as spawnable options. Added the remaining lower tiers.
Also removes Exploder as they cant do anything at the moment

## Why It's Good For The Game
Adds in the remaininig t1 and t2 Necromorphs to the nest pool. Exploders are a waste of bio at the moment.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Added : Slashers, Pukers, Spitters and E-Slashers to the nest spawn option
removed: Exploders from spawning until they are in working order
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
