### PR TITLE
Removes humanoid covers for necromorphs, and changes other covers

### DIFF
--- a/deadspace/code/necromorph/bodyparts/bodyparts.dm
+++ b/deadspace/code/necromorph/bodyparts/bodyparts.dm
@@ -16,6 +16,8 @@
 	wound_resistance = 10
 	acceptable_bodytype = BODYTYPE_NECROMORPH
 	can_be_disabled = FALSE
+	icon_bloodycover = null
+	icon_dmg_overlay = null
 
 /obj/item/bodypart/head/necromorph
 	name = BODY_ZONE_HEAD
@@ -34,6 +36,8 @@
 	is_dimorphic = FALSE
 	can_be_disabled = FALSE
 	show_organs_on_examine = TRUE
+	icon_bloodycover = null
+	icon_dmg_overlay = null
 
 /obj/item/bodypart/head/necromorph/attempt_dismemberment(brute as num, burn as num, sharpness)
 	if((sharpness & SHARP_EDGED) && (brute_dam + brute) >= max_damage * DROPLIMB_THRESHOLD_EDGE)
@@ -63,6 +67,8 @@
 	px_y = 0
 	can_be_disabled = FALSE
 	wound_resistance = 0
+	icon_bloodycover = null
+	icon_dmg_overlay = null
 
 /obj/item/bodypart/arm/left/necromorph/attempt_dismemberment(brute as num, burn as num, sharpness)
 	if((sharpness & SHARP_EDGED) && (brute_dam + brute) >= max_damage * DROPLIMB_THRESHOLD_EDGE)
@@ -92,6 +98,8 @@
 	px_y = 0
 	can_be_disabled = FALSE
 	wound_resistance = 0
+	icon_bloodycover = null
+	icon_dmg_overlay = null
 
 /obj/item/bodypart/arm/right/necromorph/attempt_dismemberment(brute as num, burn as num, sharpness)
 	if((sharpness & SHARP_EDGED) && (brute_dam + brute) >= max_damage * DROPLIMB_THRESHOLD_EDGE)
@@ -121,6 +129,8 @@
 	px_y = 12
 	can_be_disabled = FALSE
 	wound_resistance = 0
+	icon_bloodycover = null
+	icon_dmg_overlay = null
 
 /obj/item/bodypart/leg/left/necromorph/attempt_dismemberment(brute as num, burn as num, sharpness)
 	if((sharpness & SHARP_EDGED) && (brute_dam + brute) >= max_damage * DROPLIMB_THRESHOLD_EDGE)
@@ -152,6 +162,8 @@
 	px_y = 12
 	can_be_disabled = FALSE
 	wound_resistance = 0
+	icon_bloodycover = null
+	icon_dmg_overlay = null
 
 /obj/item/bodypart/leg/right/necromorph/attempt_dismemberment(brute as num, burn as num, sharpness)
 	if((sharpness & SHARP_EDGED) && (brute_dam + brute) >= max_damage * DROPLIMB_THRESHOLD_EDGE)

--- a/deadspace/code/necromorph/necromorphs/species.dm
+++ b/deadspace/code/necromorph/necromorphs/species.dm
@@ -48,7 +48,6 @@
 	inherent_traits = list(
 		TRAIT_CAN_STRIP,
 		TRAIT_NOHUNGER,
-		NOEYESPRITES,
 	)
 
 	say_mod = "roars"
@@ -65,7 +64,8 @@
 		AGENDER,
 		HAS_FLESH,
 		HAS_BONE,
-		NOAUGMENTS
+		NOAUGMENTS,
+		NOEYESPRITES,
 	)
 
 	inherent_traits = list()

--- a/deadspace/code/necromorph/necromorphs/species.dm
+++ b/deadspace/code/necromorph/necromorphs/species.dm
@@ -48,6 +48,7 @@
 	inherent_traits = list(
 		TRAIT_CAN_STRIP,
 		TRAIT_NOHUNGER,
+		NOEYESPRITES,
 	)
 
 	say_mod = "roars"
@@ -71,6 +72,7 @@
 	inherent_biotypes = MOB_ORGANIC|MOB_UNDEAD|MOB_HUMANOID
 	inherent_factions = list(FACTION_NECROMORPH)
 	species_mob_size = MOB_SIZE_HUMAN
+	fire_overlay = "generic_burning"
 
 /datum/species/necromorph/check_roundstart_eligible()
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Necromorphs on fire now default to the generic fire overlay, rather then the humanoid one.
- Necromorphs no longer have two sets of peepers to stare at you with.
- Necromorphs no longer use humanoid damage overlays and humanoid blood covers.

Upstream is also removing husking by fire, which will fix Necromorphs turning into humanoid husks when that gets merged.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Fixes silly oversights caused by humanoid overlays.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Necromorphs on fire now default to the generic fire overlay, rather then the humanoid one.
fix: Necromorphs no longer have two sets of peepers to stare at you with.
fix: Necromorphs no longer use humanoid damage overlays and humanoid blood covers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

