### PR TITLE
Mining point Rebalance

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -17,7 +17,7 @@
 
 	var/points = 0
 	var/ore_multiplier = 1
-	var/point_upgrade = 1
+	var/point_upgrade = 1.25 //you don't get that long to mine in ds13 before the "monsters" show up
 	var/list/ore_values = list(/datum/material/iron = 1, /datum/material/glass = 1,  /datum/material/plasma = 15,  /datum/material/silver = 16, /datum/material/gold = 18, /datum/material/titanium = 30, /datum/material/uranium = 30, /datum/material/diamond = 50, /datum/material/bluespace = 50, /datum/material/bananium = 60)
 	/// Variable that holds a timer which is used for callbacks to `send_console_message()`. Used for preventing multiple calls to this proc while the ORM is eating a stack of ores.
 	var/console_notify_timer

--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -17,7 +17,7 @@
 
 	var/points = 0
 	var/ore_multiplier = 1
-	var/point_upgrade = 1.25 //you don't get that long to mine in ds13 before the "monsters" show up
+	var/point_upgrade = 1.2 //you don't get that long to mine in ds13 before the "monsters" show up
 	var/list/ore_values = list(/datum/material/iron = 1, /datum/material/glass = 1,  /datum/material/plasma = 15,  /datum/material/silver = 16, /datum/material/gold = 18, /datum/material/titanium = 30, /datum/material/uranium = 30, /datum/material/diamond = 50, /datum/material/bluespace = 50, /datum/material/bananium = 60)
 	/// Variable that holds a timer which is used for callbacks to `send_console_message()`. Used for preventing multiple calls to this proc while the ORM is eating a stack of ores.
 	var/console_notify_timer

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -47,7 +47,7 @@
 		new /datum/data/mining_equipment("Jump Boots", /obj/item/clothing/shoes/bhop, 2500),
 		new /datum/data/mining_equipment("Ice Hiking Boots", /obj/item/clothing/shoes/winterboots/ice_boots, 2500),
 		new /datum/data/mining_equipment("Standard Mining RIG", /obj/item/mod/control/pre_equipped/ds/standard_miner, 1000), //you'd only need one of these if theres already 30 other miners who took the free ones from the locker
-		new /datum/data/mining_equipment("Intermediate Mining RIG", /obj/item/mod/control/pre_equipped/ds/intermediate_miner, 5000),
+		new /datum/data/mining_equipment("Intermediate Mining RIG", /obj/item/mod/control/pre_equipped/ds/intermediate_miner, 5500),
 		new /datum/data/mining_equipment("Advanced Mining RIG", /obj/item/mod/control/pre_equipped/ds/advanced_miner, 8000), //only possible to get if theres not a lot of other miners
 		new /datum/data/mining_equipment("Luxury Shelter Capsule", /obj/item/survivalcapsule/luxury, 3000),
 		new /datum/data/mining_equipment("Luxury Bar Capsule", /obj/item/survivalcapsule/luxuryelite, 10000),

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -46,9 +46,9 @@
 		new /datum/data/mining_equipment("Super Resonator", /obj/item/resonator/upgraded, 2500),
 		new /datum/data/mining_equipment("Jump Boots", /obj/item/clothing/shoes/bhop, 2500),
 		new /datum/data/mining_equipment("Ice Hiking Boots", /obj/item/clothing/shoes/winterboots/ice_boots, 2500),
-		new /datum/data/mining_equipment("Standard Mining RIG", /obj/item/mod/control/pre_equipped/ds/standard_miner, 2500),
-		new /datum/data/mining_equipment("Intermediate Mining RIG", /obj/item/mod/control/pre_equipped/ds/intermediate_miner, 7500),
-		new /datum/data/mining_equipment("Advanced Mining RIG", /obj/item/mod/control/pre_equipped/ds/advanced_miner, 10000),
+		new /datum/data/mining_equipment("Standard Mining RIG", /obj/item/mod/control/pre_equipped/ds/standard_miner, 1000), //you'd only need one of these if theres already 30 other miners who took the free ones from the locker
+		new /datum/data/mining_equipment("Intermediate Mining RIG", /obj/item/mod/control/pre_equipped/ds/intermediate_miner, 5000),
+		new /datum/data/mining_equipment("Advanced Mining RIG", /obj/item/mod/control/pre_equipped/ds/advanced_miner, 8000), //only possible to get if theres not a lot of other miners
 		new /datum/data/mining_equipment("Luxury Shelter Capsule", /obj/item/survivalcapsule/luxury, 3000),
 		new /datum/data/mining_equipment("Luxury Bar Capsule", /obj/item/survivalcapsule/luxuryelite, 10000),
 		new /datum/data/mining_equipment("Nanotrasen Minebot", /mob/living/simple_animal/hostile/mining_drone, 800),

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -48,7 +48,7 @@
 		new /datum/data/mining_equipment("Ice Hiking Boots", /obj/item/clothing/shoes/winterboots/ice_boots, 2500),
 		new /datum/data/mining_equipment("Standard Mining RIG", /obj/item/mod/control/pre_equipped/ds/standard_miner, 1000), //you'd only need one of these if theres already 30 other miners who took the free ones from the locker
 		new /datum/data/mining_equipment("Intermediate Mining RIG", /obj/item/mod/control/pre_equipped/ds/intermediate_miner, 5500),
-		new /datum/data/mining_equipment("Advanced Mining RIG", /obj/item/mod/control/pre_equipped/ds/advanced_miner, 11000), //only possible to get if theres not a lot of other miners
+		new /datum/data/mining_equipment("Advanced Mining RIG", /obj/item/mod/control/pre_equipped/ds/advanced_miner, 9000), //only possible to get if theres not a lot of other miners
 		new /datum/data/mining_equipment("Luxury Shelter Capsule", /obj/item/survivalcapsule/luxury, 3000),
 		new /datum/data/mining_equipment("Luxury Bar Capsule", /obj/item/survivalcapsule/luxuryelite, 10000),
 		new /datum/data/mining_equipment("Nanotrasen Minebot", /mob/living/simple_animal/hostile/mining_drone, 800),

--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -48,7 +48,7 @@
 		new /datum/data/mining_equipment("Ice Hiking Boots", /obj/item/clothing/shoes/winterboots/ice_boots, 2500),
 		new /datum/data/mining_equipment("Standard Mining RIG", /obj/item/mod/control/pre_equipped/ds/standard_miner, 1000), //you'd only need one of these if theres already 30 other miners who took the free ones from the locker
 		new /datum/data/mining_equipment("Intermediate Mining RIG", /obj/item/mod/control/pre_equipped/ds/intermediate_miner, 5500),
-		new /datum/data/mining_equipment("Advanced Mining RIG", /obj/item/mod/control/pre_equipped/ds/advanced_miner, 8000), //only possible to get if theres not a lot of other miners
+		new /datum/data/mining_equipment("Advanced Mining RIG", /obj/item/mod/control/pre_equipped/ds/advanced_miner, 11000), //only possible to get if theres not a lot of other miners
 		new /datum/data/mining_equipment("Luxury Shelter Capsule", /obj/item/survivalcapsule/luxury, 3000),
 		new /datum/data/mining_equipment("Luxury Bar Capsule", /obj/item/survivalcapsule/luxuryelite, 10000),
 		new /datum/data/mining_equipment("Nanotrasen Minebot", /mob/living/simple_animal/hostile/mining_drone, 800),


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I feel like the amount of mining points is too low and the cost of the rigs is too high for how long you get to mine (you get attacked by necromorphs around the 30 minute mark of the round so between waking up in dorms and getting prepped you only get 25 minutes to mine). Daedlus and tg mining points are balanced around longer rounds with longer time to mine.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Encourages more mining, increases the ability of miners to get useful gear by playing, and benefits the game in high pop by letting people who couldn't manage to get a rig get one.  
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: increased points obtained by depositing ores
balance: decreased rig cost, especially the standard rig 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
