### PR TITLE
Sets up burnmod for necros

### DIFF
--- a/deadspace/code/necromorph/necromorphs/species.dm
+++ b/deadspace/code/necromorph/necromorphs/species.dm
@@ -13,6 +13,7 @@
 	bodytype = BODYTYPE_HUMANOID|BODYTYPE_ORGANIC|BODYTYPE_NECROMORPH
 
 	max_bodypart_count = 6
+	burnmod = 1.2
 
 	examine_limb_id = SPECIES_NECROMORPH
 	exotic_bloodtype = "X"

--- a/deadspace/code/necromorph/necromorphs/subtypes/hunter.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/hunter.dm
@@ -68,6 +68,7 @@
 
 	id = SPECIES_NECROMORPH_HUNTER
 	speedmod = 1.6
+	burnmod = 1.3
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/necromorph/hunter,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/necromorph/hunter,

--- a/deadspace/code/necromorph/necromorphs/subtypes/tripod.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/tripod.dm
@@ -23,6 +23,7 @@
 	name = "Tripod"
 	id = SPECIES_NECROMORPH_TRIPOD
 	speedmod = 1.5
+	burnmod = 1
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/necromorph/tripod,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/necromorph/tripod,

--- a/deadspace/code/necromorph/necromorphs/subtypes/twitcher.dm
+++ b/deadspace/code/necromorph/necromorphs/subtypes/twitcher.dm
@@ -23,6 +23,7 @@
 	name = "Twitcher"
 	id = SPECIES_NECROMORPH_TWITCHER
 	speedmod = 0.8
+	burnmod = 1.1
 	bodypart_overrides = list(
 		BODY_ZONE_L_ARM = /obj/item/bodypart/arm/left/necromorph/twitcher,
 		BODY_ZONE_R_ARM = /obj/item/bodypart/arm/right/necromorph/twitcher,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Sets up the burnmod damage increases for the rest of necros, since some didn't have it set up at all. Stats are based on 1.0 version.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Mmm necro grill flambe.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Necros get hurt by fire more, depending on subtype.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
