### PR TITLE
Recycable necros, maw fixes

### DIFF
--- a/deadspace/code/biomass/source_types.dm
+++ b/deadspace/code/biomass/source_types.dm
@@ -23,7 +23,7 @@
 	for(var/mob/living/target as anything in maw.buckled_mobs)
 		if(isnecromorph(target))
 			maw.bite_necro(target, delta_time)
-		if(ishuman(target))
+		else if(ishuman(target))
 			maw.bite_human(target, delta_time)
 		else
 			maw.bite_living(target, delta_time)

--- a/deadspace/code/biomass/source_types.dm
+++ b/deadspace/code/biomass/source_types.dm
@@ -21,6 +21,8 @@
 /datum/biomass_source/maw/absorb_biomass(delta_time)
 	var/obj/structure/necromorph/maw/maw = source
 	for(var/mob/living/target as anything in maw.buckled_mobs)
+		if(isnecromorph(target))
+			maw.bite_necro(target, delta_time)
 		if(ishuman(target))
 			maw.bite_human(target, delta_time)
 		else

--- a/deadspace/code/corruption/structures/maw.dm
+++ b/deadspace/code/corruption/structures/maw.dm
@@ -65,21 +65,44 @@
 	processing_biomass += target.mob_size * 5
 	qdel(target)
 
+/obj/structure/necromorph/maw/proc/bite_necro(mob/living/carbon/human/necromorph/target, delta_time) //Basically copied bite_human with less efficiency
+	if(length(target.bodyparts) <= 1)
+		var/obj/item/bodypart/part = target.bodyparts[1]
+		processing_biomass += part.biomass
+		qdel(target)
+		return
+
+	var/obj/item/bodypart/part = pick(target.bodyparts)
+	var/iteration = 0
+	while(istype(part, /obj/item/bodypart/chest) && iteration++ < 5)
+		part = pick(target.bodyparts - part)
+
+	if(iteration >= 5)
+		stack_trace("Maw tried to bite a necro but couldn't find a non-chest bodypart")
+		return
+
+	// If damage is above 80%
+	if(part.get_damage() >= (part.max_damage * LIMB_DISMEMBERMENT_PERCENT) - 1)
+		processing_biomass += part.biomass
+		part.drop_limb(FALSE, TRUE)
+		qdel(part)
+	else
+		processing_biomass += part.biomass
+		// Damage shouldn't be above or equal to 80%
+		part.receive_damage(
+			min(
+				MAW_DAMAGE_PER_SECOND * delta_time,
+				(part.max_damage * LIMB_DISMEMBERMENT_PERCENT) - part.get_damage() - 1
+			), 0, sharpness = SHARP_EDGED|SHARP_POINTY
+		)
 /obj/structure/necromorph/maw/is_buckle_possible(mob/living/target, force, check_loc)
 	if(!..())
-		return FALSE
-	if(isnecromorph(target))
 		return FALSE
 	return TRUE
 
 /obj/structure/necromorph/maw/user_buckle_mob(mob/living/M, mob/user, check_loc)
-	if(isnecromorph(M))
-		to_chat(user, span_warning("[src] refuses to consume [M]!"))
-		return FALSE
-
 	if(!do_after_mob(user, M, 5 SECONDS, IGNORE_HELD_ITEM|DO_PUBLIC, TRUE, CALLBACK(src, PROC_REF(buckle_mob_check), M)))
 		return
-
 	return ..()
 
 /obj/structure/necromorph/maw/proc/buckle_mob_check(mob/living/buckling)

--- a/deadspace/code/corruption/structures/maw.dm
+++ b/deadspace/code/corruption/structures/maw.dm
@@ -46,7 +46,7 @@
 		part.drop_limb(FALSE, TRUE)
 		qdel(part)
 	else
-		processing_biomass += part.biomass * 1.2
+		processing_biomass += 0.1
 		// Damage shouldn't be above or equal to 80%
 		part.receive_damage(
 			min(
@@ -87,7 +87,6 @@
 		part.drop_limb(FALSE, TRUE)
 		qdel(part)
 	else
-		processing_biomass += part.biomass
 		// Damage shouldn't be above or equal to 80%
 		part.receive_damage(
 			min(
@@ -98,9 +97,14 @@
 /obj/structure/necromorph/maw/is_buckle_possible(mob/living/target, force, check_loc)
 	if(!..())
 		return FALSE
+	if(issilicon(target))
+		return FALSE
 	return TRUE
 
 /obj/structure/necromorph/maw/user_buckle_mob(mob/living/M, mob/user, check_loc)
+	if(issilicon(M))
+		to_chat(user, span_warning("[src] refuses to consume [M]!"))
+		return FALSE
 	if(!do_after_mob(user, M, 5 SECONDS, IGNORE_HELD_ITEM|DO_PUBLIC, TRUE, CALLBACK(src, PROC_REF(buckle_mob_check), M)))
 		return
 	return ..()

--- a/deadspace/code/necromorph/bodyparts/brute.dm
+++ b/deadspace/code/necromorph/bodyparts/brute.dm
@@ -7,6 +7,7 @@
 	px_x = 0
 	px_y = 0
 	wound_resistance = 10
+	biomass = 81
 
 /obj/item/bodypart/head/necromorph/brute
 	name = BODY_ZONE_HEAD
@@ -17,6 +18,7 @@
 	px_x = 0
 	px_y = -8
 	wound_resistance = 5
+	biomass = 15 //pea brain, not much biomass
 
 /obj/item/bodypart/arm/left/necromorph/brute
 	name = "left arm"
@@ -29,6 +31,7 @@
 	px_x = -6
 	px_y = 0
 	wound_resistance = 0
+	biomass = 21
 
 /obj/item/bodypart/arm/right/necromorph/brute
 	name = "right arm"
@@ -41,6 +44,7 @@
 	px_x = 6
 	px_y = 0
 	wound_resistance = 0
+	biomass = 21
 
 /obj/item/bodypart/leg/left/necromorph/brute
 	name = "left leg"
@@ -53,6 +57,7 @@
 	px_x = -2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 21
 
 /obj/item/bodypart/leg/right/necromorph/brute
 	name = "right leg"
@@ -65,3 +70,4 @@
 	px_x = 2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 21

--- a/deadspace/code/necromorph/bodyparts/e_slasher.dm
+++ b/deadspace/code/necromorph/bodyparts/e_slasher.dm
@@ -7,6 +7,7 @@
 	px_x = 0
 	px_y = 0
 	wound_resistance = 10
+	biomass = 17.5
 
 /obj/item/bodypart/head/necromorph/slasher/enhanced
 	name = BODY_ZONE_HEAD
@@ -17,6 +18,7 @@
 	px_x = 0
 	px_y = -8
 	wound_resistance = 5
+	biomass = 15
 
 /obj/item/bodypart/arm/left/necromorph/slasher/enhanced
 	name = "left blade"
@@ -29,6 +31,7 @@
 	px_x = -6
 	px_y = 0
 	wound_resistance = 0
+	biomass = 7.5
 
 /obj/item/bodypart/arm/right/necromorph/slasher/enhanced
 	name = "right blade"
@@ -41,6 +44,7 @@
 	px_x = 6
 	px_y = 0
 	wound_resistance = 0
+	biomass = 7.5
 
 /obj/item/bodypart/leg/left/necromorph/slasher/enhanced
 	name = "left leg"
@@ -53,6 +57,7 @@
 	px_x = -2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 7.5
 
 /obj/item/bodypart/leg/right/necromorph/slasher/enhanced
 	name = "right leg"
@@ -65,3 +70,4 @@
 	px_x = 2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 7.5

--- a/deadspace/code/necromorph/bodyparts/exploder.dm
+++ b/deadspace/code/necromorph/bodyparts/exploder.dm
@@ -7,6 +7,7 @@
 	px_x = 0
 	px_y = 0
 	wound_resistance = 10
+	biomass = 15
 
 /obj/item/bodypart/head/necromorph/exploder
 	name = BODY_ZONE_HEAD
@@ -17,6 +18,7 @@
 	px_x = 0
 	px_y = -8
 	wound_resistance = 5
+	biomass = 7.5
 
 //This is an arm actually. It's just used for walking
 /obj/item/bodypart/leg/left/necromorph/exploder
@@ -30,6 +32,7 @@
 	px_x = -2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 10 //Assuming it doesn't explode, it's packed with biomass
 	integrity_failure = 0.25
 	var/list/datum/action/cooldown/necro/exploding_actions
 
@@ -74,3 +77,4 @@
 	px_x = 2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 5

--- a/deadspace/code/necromorph/bodyparts/hunter.dm
+++ b/deadspace/code/necromorph/bodyparts/hunter.dm
@@ -7,6 +7,7 @@
 	px_x = 0
 	px_y = 0
 	wound_resistance = 10
+	biomass = 90 //Most biomass stored in chest due to regeneration
 
 /obj/item/bodypart/head/necromorph/hunter
 	name = BODY_ZONE_HEAD
@@ -17,6 +18,7 @@
 	px_x = 0
 	px_y = -8
 	wound_resistance = 5
+	biomass = 30
 
 /obj/item/bodypart/arm/left/necromorph/hunter
 	name = "left blade"
@@ -29,6 +31,7 @@
 	px_x = -6
 	px_y = 0
 	wound_resistance = 0
+	biomass = 20
 
 /obj/item/bodypart/arm/right/necromorph/hunter
 	name = "right blade"
@@ -41,6 +44,7 @@
 	px_x = 6
 	px_y = 0
 	wound_resistance = 0
+	biomass = 20
 
 /obj/item/bodypart/leg/left/necromorph/hunter
 	name = "left leg"
@@ -53,6 +57,7 @@
 	px_x = -2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 20
 
 /obj/item/bodypart/leg/right/necromorph/hunter
 	name = "right leg"
@@ -65,3 +70,4 @@
 	px_x = 2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 20

--- a/deadspace/code/necromorph/bodyparts/puker.dm
+++ b/deadspace/code/necromorph/bodyparts/puker.dm
@@ -7,6 +7,7 @@
 	px_x = 0
 	px_y = 0
 	wound_resistance = 10
+	biomass = 17.5
 
 /obj/item/bodypart/head/necromorph/puker
 	name = BODY_ZONE_HEAD
@@ -17,6 +18,7 @@
 	px_x = 0
 	px_y = -8
 	wound_resistance = 5
+	biomass = 15
 
 /obj/item/bodypart/arm/left/necromorph/puker
 	name = "left blade"
@@ -29,6 +31,7 @@
 	px_x = -6
 	px_y = 0
 	wound_resistance = 0
+	biomass = 7.5
 
 /obj/item/bodypart/arm/right/necromorph/puker
 	name = "right blade"
@@ -41,6 +44,7 @@
 	px_x = 6
 	px_y = 0
 	wound_resistance = 0
+	biomass = 7.5
 
 /obj/item/bodypart/leg/left/necromorph/puker
 	name = "left leg"
@@ -53,6 +57,7 @@
 	px_x = -2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 7.5
 
 /obj/item/bodypart/leg/right/necromorph/puker
 	name = "right leg"
@@ -65,3 +70,4 @@
 	px_x = 2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 7.5

--- a/deadspace/code/necromorph/bodyparts/slasher.dm
+++ b/deadspace/code/necromorph/bodyparts/slasher.dm
@@ -7,6 +7,7 @@
 	px_x = 0
 	px_y = 0
 	wound_resistance = 10
+	biomass = 5
 
 /obj/item/bodypart/head/necromorph/slasher
 	name = BODY_ZONE_HEAD
@@ -17,6 +18,7 @@
 	px_x = 0
 	px_y = -8
 	wound_resistance = 5
+	biomass = 1.5
 
 /obj/item/bodypart/arm/left/necromorph/slasher
 	name = "left blade"
@@ -29,6 +31,7 @@
 	px_x = -6
 	px_y = 0
 	wound_resistance = 0
+	biomass = 1.5
 
 /obj/item/bodypart/arm/right/necromorph/slasher
 	name = "right blade"
@@ -41,6 +44,7 @@
 	px_x = 6
 	px_y = 0
 	wound_resistance = 0
+	biomass = 1.5
 
 /obj/item/bodypart/leg/left/necromorph/slasher
 	name = "left leg"
@@ -53,6 +57,7 @@
 	px_x = -2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 1.5
 
 /obj/item/bodypart/leg/right/necromorph/slasher
 	name = "right leg"
@@ -65,3 +70,4 @@
 	px_x = 2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 1.5

--- a/deadspace/code/necromorph/bodyparts/slasher.dm
+++ b/deadspace/code/necromorph/bodyparts/slasher.dm
@@ -7,7 +7,7 @@
 	px_x = 0
 	px_y = 0
 	wound_resistance = 10
-	biomass = 5
+	biomass = 10
 
 /obj/item/bodypart/head/necromorph/slasher
 	name = BODY_ZONE_HEAD
@@ -18,7 +18,7 @@
 	px_x = 0
 	px_y = -8
 	wound_resistance = 5
-	biomass = 1.5
+	biomass = 7
 
 /obj/item/bodypart/arm/left/necromorph/slasher
 	name = "left blade"
@@ -31,7 +31,7 @@
 	px_x = -6
 	px_y = 0
 	wound_resistance = 0
-	biomass = 1.5
+	biomass = 2
 
 /obj/item/bodypart/arm/right/necromorph/slasher
 	name = "right blade"
@@ -44,7 +44,7 @@
 	px_x = 6
 	px_y = 0
 	wound_resistance = 0
-	biomass = 1.5
+	biomass = 2
 
 /obj/item/bodypart/leg/left/necromorph/slasher
 	name = "left leg"
@@ -57,7 +57,7 @@
 	px_x = -2
 	px_y = 12
 	wound_resistance = 0
-	biomass = 1.5
+	biomass = 2
 
 /obj/item/bodypart/leg/right/necromorph/slasher
 	name = "right leg"
@@ -70,4 +70,4 @@
 	px_x = 2
 	px_y = 12
 	wound_resistance = 0
-	biomass = 1.5
+	biomass = 2

--- a/deadspace/code/necromorph/bodyparts/spitter.dm
+++ b/deadspace/code/necromorph/bodyparts/spitter.dm
@@ -7,6 +7,7 @@
 	px_x = 0
 	px_y = 0
 	wound_resistance = 10
+	biomass = 10
 
 /obj/item/bodypart/head/necromorph/spitter
 	name = BODY_ZONE_HEAD
@@ -17,6 +18,7 @@
 	px_x = 0
 	px_y = -8
 	wound_resistance = 5
+	biomass = 7
 
 /obj/item/bodypart/arm/left/necromorph/spitter
 	name = "left blade"
@@ -29,6 +31,7 @@
 	px_x = -6
 	px_y = 0
 	wound_resistance = 0
+	biomass = 2
 
 /obj/item/bodypart/arm/right/necromorph/spitter
 	name = "right blade"
@@ -41,6 +44,7 @@
 	px_x = 6
 	px_y = 0
 	wound_resistance = 0
+	biomass = 2
 
 /obj/item/bodypart/leg/left/necromorph/spitter
 	name = "left leg"
@@ -53,6 +57,7 @@
 	px_x = -2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 2
 
 /obj/item/bodypart/leg/right/necromorph/spitter
 	name = "right leg"
@@ -65,3 +70,4 @@
 	px_x = 2
 	px_y = 12
 	wound_resistance = 0
+	biomass = 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Maw biomass calculations fixed, maws will no longer produce a insane amount of biomass from one body, nor not produce enough from a human.
- Maws can now eat necros, and recycle 50% of the spawning cost of said necro as a result. Bodies with more health take longer to recycle.
- Silicons can no longer be eaten by maws.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Gives a simple and effective way of recycling necromorphs, and fixes various maw calculations that were hampering gameplay. See "spawning a ubermorph in under a hour" problem.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
add: Necromorphs can now be recycled by maws, with a 50% efficiency
balance: Maws cannot eat silicons anymore
fix: Maws now give the correct biomass when eating a human
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
