### PR TITLE
Armour Penetration

### DIFF
--- a/deadspace/code/necromorph/necromorphs/necro_defense.dm
+++ b/deadspace/code/necromorph/necromorphs/necro_defense.dm
@@ -17,7 +17,9 @@
 	visible_message(span_danger("[user.name] slashes [src]!"), \
 					span_userdanger("[user.name] slashes you!"), span_hear("You hear a cutting of the flesh!"), COMBAT_MESSAGE_RANGE, user)
 	to_chat(user, span_danger("You slash [src]!"))
-	adjustBruteLoss(dealt_damage)
+	var/zone_attacked = ran_zone(user.zone_selected)
+	var/armor_block = run_armor_check(zone_attacked, MELEE)
+	apply_damage(dealt_damage, BRUTE, zone_attacked, armor_block)
 	log_combat(user, src, "attacked")
 	updatehealth()
 
@@ -41,7 +43,7 @@
 	var/obj/item/bodypart/affecting = get_bodypart(ran_zone(user.zone_selected))
 	if(!affecting)
 		affecting = get_bodypart(BODY_ZONE_CHEST)
-	var/armor_block = run_armor_check(affecting, MELEE,"","",10)
+	var/armor_block = run_armor_check(affecting, MELEE)
 
 	playsound(loc, 'sound/weapons/slice.ogg', 25, TRUE, -1)
 	visible_message(span_danger("[user] slashes at [src]!"), \

--- a/deadspace/code/necromorph/necromorphs/necro_defense.dm
+++ b/deadspace/code/necromorph/necromorphs/necro_defense.dm
@@ -21,7 +21,6 @@
 	var/armor_block = run_armor_check(zone_attacked, MELEE)
 	apply_damage(dealt_damage, BRUTE, zone_attacked, armor_block)
 	log_combat(user, src, "attacked")
-	updatehealth()
 
 /mob/living/carbon/human/attack_necromorph(mob/living/carbon/human/necromorph/user, list/modifiers, dealt_damage)
 	if(check_shields(user, 0, "the [user.name]"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes 10% armour penetration from necromorphs and adds proper armour checks when attacking living things

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Removed 10% armour penetration from necromorphs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
