### PR TITLE
Blocking for melee and ranged weapons

### DIFF
--- a/_maps/map_files/AegisVII/AegisVII_Low.dmm
+++ b/_maps/map_files/AegisVII/AegisVII_Low.dmm
@@ -1703,7 +1703,7 @@
 /area/station/cargo/warehouse)
 "mD" = (
 /obj/structure/table/reinforced,
-/obj/item/plasma_modified,
+/obj/item/chainsaw/plasma_industrial,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "mG" = (
@@ -2629,7 +2629,7 @@
 /area/station/maintenance/fore/lesser)
 "um" = (
 /obj/structure/rack,
-/obj/item/plasma_modified,
+/obj/item/chainsaw/plasma_industrial,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "un" = (
@@ -2878,7 +2878,7 @@
 /area/station/maintenance/port/lesser)
 "wT" = (
 /obj/structure/rack,
-/obj/item/plasma_modified,
+/obj/item/chainsaw/plasma_industrial,
 /obj/effect/spawner/random/deadspace/ammo,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)

--- a/_maps/map_files/AegisVII/AegisVII_Middle.dmm
+++ b/_maps/map_files/AegisVII/AegisVII_Middle.dmm
@@ -11666,7 +11666,7 @@
 /obj/effect/turf_decal/box,
 /obj/structure/closet/crate/large/ds,
 /obj/effect/spawner/random/maintenance/two,
-/obj/item/plasma_modified,
+/obj/item/chainsaw/plasma_industrial,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "fwj" = (
@@ -19134,7 +19134,7 @@
 /obj/effect/spawner/random/medical/minor_healing,
 /obj/effect/spawner/random/food_or_drink/snack,
 /obj/effect/turf_decal/box,
-/obj/item/plasma_modified,
+/obj/item/chainsaw/plasma_industrial,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "laZ" = (
@@ -35298,7 +35298,7 @@
 "xEG" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/bot,
-/obj/item/plasma_modified,
+/obj/item/chainsaw/plasma_industrial,
 /turf/open/floor/deadspace/mono,
 /area/station/commons/storage/primary)
 "xEM" = (

--- a/code/game/objects/items/fireaxe.dm
+++ b/code/game/objects/items/fireaxe.dm
@@ -10,6 +10,7 @@
 	desc = "Truly, the weapon of a madman. Who would think to fight fire with an axe?"
 	force = 5
 	throwforce = 15
+	block_chance = 40 //Truely a engineers favorite chopping stick
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
 	attack_verb_continuous = list("attacks", "chops", "cleaves", "tears", "lacerates", "cuts")
@@ -56,6 +57,11 @@
 		if(istype(A, /obj/structure/window) || istype(A, /obj/structure/grille))
 			var/obj/structure/W = A
 			W.atom_destruction("fireaxe")
+
+/obj/item/fireaxe/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(wielded) //Can only block if being wielded
+		return ..()
+	return 0
 
 /*
  * Bone Axe

--- a/code/game/objects/items/melee/baton.dm
+++ b/code/game/objects/items/melee/baton.dm
@@ -14,6 +14,7 @@
 	stamina_cost = 21
 	stamina_critical_chance = 5
 	force = 12
+	block_chance = 20
 
 	/// Whether this baton is active or not
 	var/active = TRUE

--- a/code/game/objects/items/spear.dm
+++ b/code/game/objects/items/spear.dm
@@ -8,6 +8,8 @@
 	force = 10
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
+	var/wielded = FALSE
+	block_chance = 20 //Doesn't get as much block as other twohanded due to makeshift creation
 	throwforce = 20
 	throw_speed = 4
 	embedding = list("impact_pain_mult" = 2, "remove_pain_mult" = 4, "jostle_chance" = 2.5)
@@ -29,6 +31,17 @@
 	AddComponent(/datum/component/two_handed, force_unwielded=10, force_wielded=18, icon_wielded="[icon_prefix]1")
 	update_appearance()
 
+/obj/item/spear/proc/on_wield(obj/item/source, mob/user)
+	SIGNAL_HANDLER
+
+	wielded = TRUE
+
+/// triggered on unwield of two handed item
+/obj/item/spear/proc/on_unwield(obj/item/source, mob/user)
+	SIGNAL_HANDLER
+
+	wielded = FALSE
+
 /obj/item/spear/update_icon_state()
 	icon_state = "[icon_prefix]0"
 	return ..()
@@ -37,12 +50,18 @@
 	user.visible_message(span_suicide("[user] begins to sword-swallow \the [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return BRUTELOSS
 
+/obj/item/spear/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(wielded) //Can only block if being wielded
+		return ..()
+	return 0
+
 /obj/item/spear/CheckParts(list/parts_list)
 	var/obj/item/shard/tip = locate() in parts_list
 	if(tip)
 		if (istype(tip, /obj/item/shard/plasma))
 			force = 11
 			throwforce = 21
+			block_chance = 22
 			icon_prefix = "spearplasma"
 			AddComponent(/datum/component/two_handed, force_unwielded=11, force_wielded=19, icon_wielded="[icon_prefix]1")
 		else if (istype(tip, /obj/item/shard/titanium))
@@ -50,6 +69,7 @@
 			throwforce = 21
 			throw_range = 8
 			throw_speed = 5
+			block_chance = 25
 			icon_prefix = "speartitanium"
 			AddComponent(/datum/component/two_handed, force_unwielded=13, force_wielded=18, icon_wielded="[icon_prefix]1")
 		else if (istype(tip, /obj/item/shard/plastitanium))
@@ -57,6 +77,7 @@
 			throwforce = 22
 			throw_range = 9
 			throw_speed = 5
+			block_chance = 26 //Ever so slightly more nimble then titanium
 			icon_prefix = "spearplastitanium"
 			AddComponent(/datum/component/two_handed, force_unwielded=13, force_wielded=20, icon_wielded="[icon_prefix]1")
 		update_appearance()
@@ -69,8 +90,9 @@
 	icon_state = "spearbomb0"
 	base_icon_state = "spearbomb"
 	icon_prefix = "spearbomb"
+	block_chance = 0 //You probably don't want to block with a explosive
 	var/obj/item/grenade/explosive = null
-	var/wielded = FALSE // track wielded status on item
+	wielded = FALSE // track wielded status on item
 
 /obj/item/spear/explosive/Initialize(mapload)
 	. = ..()
@@ -78,18 +100,6 @@
 	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, PROC_REF(on_unwield))
 	set_explosive(new /obj/item/grenade/iedcasing/spawned()) //For admin-spawned explosive lances
 	AddComponent(/datum/component/two_handed, force_unwielded=10, force_wielded=18, icon_wielded="[icon_prefix]1")
-
-/// triggered on wield of two handed item
-/obj/item/spear/explosive/proc/on_wield(obj/item/source, mob/user)
-	SIGNAL_HANDLER
-
-	wielded = TRUE
-
-/// triggered on unwield of two handed item
-/obj/item/spear/explosive/proc/on_unwield(obj/item/source, mob/user)
-	SIGNAL_HANDLER
-
-	wielded = FALSE
 
 /obj/item/spear/explosive/proc/set_explosive(obj/item/grenade/G)
 	if(explosive)
@@ -191,6 +201,7 @@
 	desc = "A haphazardly-constructed yet still deadly weapon. The pinnacle of modern technology."
 	force = 12
 	throwforce = 22
+	block_chance = 23 //Slightly better then makeshift glass spear
 	armour_penetration = 15 //Enhanced armor piercing
 
 /obj/item/spear/bonespear/Initialize(mapload)
@@ -207,6 +218,7 @@
 	name = "bamboo spear"
 	desc = "A haphazardly-constructed bamboo stick with a sharpened tip, ready to poke holes into unsuspecting people."
 	throwforce = 22	//Better to throw
+	block_chance = 10 //And you thought glass and rods were flimsy
 
 /obj/item/spear/bamboospear/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/tools/crowbar.dm
+++ b/code/game/objects/items/tools/crowbar.dm
@@ -56,6 +56,7 @@
 	name = "crowbar"
 	desc = "It's a big crowbar. It doesn't fit in your pockets, because it's big."
 	force = 12
+	block_chance = 12 //You could use this to block in a emergency, maybe
 	w_class = WEIGHT_CLASS_NORMAL
 	throw_speed = 3
 	throw_range = 3

--- a/code/modules/hydroponics/hydroitemdefines.dm
+++ b/code/modules/hydroponics/hydroitemdefines.dm
@@ -481,6 +481,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	flags_1 = CONDUCT_1
 	force = 12
+	block_chance = 15
 	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 15
 	throw_speed = 4

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -63,6 +63,7 @@
 	icon_state = "handdrill"
 	slot_flags = ITEM_SLOT_BELT
 	toolspeed = 0.6 //available from roundstart, faster than a pickaxe.
+	block_chance = 15 //It's big, but pretty unwieldy in a fight
 	usesound = 'sound/weapons/drill.ogg'
 	hitsound = 'sound/weapons/drill.ogg'
 	desc = "An electric mining drill for the especially scrawny."
@@ -118,6 +119,7 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 8
 	throwforce = 4
+	block_chance = 18 //It's basically a quarterstaff with a metal bit on the end
 	tool_behaviour = TOOL_SHOVEL
 	toolspeed = 1
 	usesound = 'sound/effects/shovel_dig.ogg'

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -195,6 +195,7 @@
 	item_flags = SURGICAL_TOOL
 
 	force = 15
+	block_chance = 10 //You could probably block with this in a emergency
 	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 9
 	throw_speed = 2

--- a/deadspace/code/modules/tools/medical.dm
+++ b/deadspace/code/modules/tools/medical.dm
@@ -9,7 +9,7 @@
 	hitsound = 'sound/weapons/blade1.ogg'
 	slot_flags = ITEM_SLOT_POCKETS | ITEM_SLOT_BELT
 	force = 2
-
+	block_chance = 0 //handled in on_transform
 	tool_behaviour = null
 	toolspeed = null
 
@@ -29,12 +29,14 @@
 	if(active)
 		tool_behaviour = TOOL_SAW
 		sharpness = SHARP_EDGED
+		block_chance = 15
 		toolspeed = 1
 		icon_state = "bonecutter_on"
 	else
 		icon_state = "bonecutter_off"
 		tool_behaviour = initial(tool_behaviour)
 		toolspeed = initial(toolspeed)
+		block_chance = initial(block_chance)
 
 	playsound(user ? user : src, active ? 'sound/weapons/saberon.ogg' : 'sound/weapons/saberoff.ogg', 5, TRUE)
 	return COMPONENT_NO_DEFAULT_MESSAGE

--- a/deadspace/code/modules/tools/medical.dm
+++ b/deadspace/code/modules/tools/medical.dm
@@ -16,7 +16,7 @@
 /obj/item/circular_saw/bonecutter/Initialize(mapload)
 	. = ..()
 	AddComponent(/datum/component/transforming, \
-		force_on = 15, \
+		force_on = 18, \
 		throwforce_on = 8, \
 		hitsound_on = hitsound, \
 		w_class_on = WEIGHT_CLASS_NORMAL, \
@@ -29,7 +29,7 @@
 	if(active)
 		tool_behaviour = TOOL_SAW
 		sharpness = SHARP_EDGED
-		block_chance = 15
+		block_chance = 20
 		toolspeed = 1
 		icon_state = "bonecutter_on"
 	else

--- a/deadspace/code/modules/tools/mining.dm
+++ b/deadspace/code/modules/tools/mining.dm
@@ -9,6 +9,7 @@
 	hitsound = 'sound/weapons/blade1.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT
+	block_chance = 10
 	force = 2
 
 	tool_behaviour = null
@@ -48,6 +49,7 @@
 	lefthand_file = 'deadspace/icons/mob/onmob/items/lefthand.dmi'
 	righthand_file = 'deadspace/icons/mob/onmob/items/righthand.dmi'
 	flags_1 = CONDUCT_1
+	block_chance = 35 //Will only block while wielded
 	force = 1
 	var/force_on = 24
 	w_class = WEIGHT_CLASS_HUGE
@@ -96,6 +98,11 @@
 		playsound(src, 'sound/weapons/genhit1.ogg', 100, TRUE)
 	return(BRUTELOSS)
 
+/obj/item/plasma_modified/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(wielded) //Can only block if being wielded
+		return ..()
+	return 0
+
 /obj/item/plasma_modified/attack_self(mob/user)
 	on = !on
 	to_chat(user, "As you press the power button from [src], [on ? "it begins to whirr." : "the energy retracts."]")
@@ -129,6 +136,7 @@
 	slot_flags = ITEM_SLOT_POCKETS | ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_NORMAL
 	force = 2
+	block_chance = 0 //handled in the on_transform
 	custom_materials = list(/datum/material/iron=1000)
 	attack_verb_continuous = list("hits", "pierces", "slices", "attacks")
 	attack_verb_simple = list("hit", "pierce", "slice", "attack")
@@ -152,12 +160,14 @@
 	if(active)
 		tool_behaviour = TOOL_MINING
 		sharpness = SHARP_EDGED
+		block_chance = 15
 		toolspeed = 0.5
 		icon_state = "rocksaw_on"
 	else
 		icon_state = "rocksaw_off"
 		tool_behaviour = initial(tool_behaviour)
 		toolspeed = initial(toolspeed)
+		block_chance = initial(block_chance)
 
 	playsound(user ? user : src, active ? 'sound/weapons/saberon.ogg' : 'sound/weapons/saberoff.ogg', 5, TRUE)
 	return COMPONENT_NO_DEFAULT_MESSAGE

--- a/deadspace/code/modules/tools/mining.dm
+++ b/deadspace/code/modules/tools/mining.dm
@@ -9,7 +9,7 @@
 	hitsound = 'sound/weapons/blade1.ogg'
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT
-	block_chance = 10
+	block_chance = 0
 	force = 2
 
 	tool_behaviour = null
@@ -31,27 +31,30 @@
 	if(active)
 		tool_behaviour = TOOL_MINING
 		sharpness = SHARP_EDGED
+		block_chance = 20
 		toolspeed = 0.5
 		icon_state = "plasma_saw_on"
 	else
 		icon_state = "plasma_saw_off"
 		tool_behaviour = initial(tool_behaviour)
 		toolspeed = initial(toolspeed)
+		block_chance = initial(block_chance)
 
 	playsound(user ? user : src, active ? 'sound/weapons/saberon.ogg' : 'sound/weapons/saberoff.ogg', 5, TRUE)
 	return COMPONENT_NO_DEFAULT_MESSAGE
 
-/obj/item/plasma_modified
-	name = "Modified Plasma Saw"
-	desc = "This modified Plasma Saw is designed to cut through the strongest materials. Flesh and bone stands no chance."
+/obj/item/chainsaw/plasma_industrial
+	name = "Industrial Plasma Saw"
+	desc = "This industrial grade Plasma Saw is designed to cut through the strongest materials. Flesh and bone stands no chance."
 	icon = 'deadspace/icons/obj/tools/mining.dmi'
 	icon_state = "plasmasaw_off"
 	lefthand_file = 'deadspace/icons/mob/onmob/items/lefthand.dmi'
 	righthand_file = 'deadspace/icons/mob/onmob/items/righthand.dmi'
 	flags_1 = CONDUCT_1
-	block_chance = 35 //Will only block while wielded
+	block_chance = 0
+	var/block_on = 35 //Can only block when it is on
 	force = 1
-	var/force_on = 24
+	force_on = 24
 	w_class = WEIGHT_CLASS_HUGE
 	throwforce = 13
 	throw_speed = 2
@@ -60,33 +63,13 @@
 	attack_verb_continuous = list("saws", "tears", "lacerates", "cuts", "chops", "dices")
 	attack_verb_simple = list("saw", "tear", "lacerate", "cut", "chop", "dice")
 	sharpness = SHARP_EDGED
-	actions_types = list(/datum/action/item_action/startplasma_modified)
+	actions_types = list(/datum/action/item_action/chainsaw/startplasma_industrial)
 	tool_behaviour = TOOL_SAW
 	toolspeed = 0.5
-	var/on = FALSE
-	var/wielded = FALSE // track wielded status on item
-
-/obj/item/plasma_modified/Initialize(mapload)
-	. = ..()
-	RegisterSignal(src, COMSIG_TWOHANDED_WIELD, PROC_REF(on_wield))
-	RegisterSignal(src, COMSIG_TWOHANDED_UNWIELD, PROC_REF(on_unwield))
-
-	AddComponent(/datum/component/butchering, 30, 100, 0, 'sound/weapons/blade1.ogg', TRUE)
-	AddComponent(/datum/component/two_handed, require_twohands=TRUE)
-
-/// triggered on wield of two handed item
-/obj/item/plasma_modified/proc/on_wield(obj/item/source, mob/user)
-	SIGNAL_HANDLER
-
-	wielded = TRUE
-
-/// triggered on unwield of two handed item
-/obj/item/plasma_modified/proc/on_unwield(obj/item/source, mob/user)
-	SIGNAL_HANDLER
-
+	on = FALSE
 	wielded = FALSE
 
-/obj/item/plasma_modified/suicide_act(mob/living/carbon/user)
+/obj/item/chainsaw/plasma_industrial/suicide_act(mob/living/carbon/user)
 	if(on)
 		user.visible_message(span_suicide("[user] begins to tear [user.p_their()] head off with [src]! It looks like [user.p_theyre()] trying to commit suicide!"))
 		playsound(src, 'sound/weapons/blade1.ogg', 100, TRUE)
@@ -98,16 +81,17 @@
 		playsound(src, 'sound/weapons/genhit1.ogg', 100, TRUE)
 	return(BRUTELOSS)
 
-/obj/item/plasma_modified/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(wielded) //Can only block if being wielded
+/obj/item/chainsaw/plasma_industrial/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(wielded | on) //Can only block if being wielded and on
 		return ..()
 	return 0
 
-/obj/item/plasma_modified/attack_self(mob/user)
+/obj/item/chainsaw/plasma_industrial/attack_self(mob/user)
 	on = !on
-	to_chat(user, "As you press the power button from [src], [on ? "it begins to whirr." : "the energy retracts."]")
+	to_chat(user, "As you press the power button on the [src], [on ? "producing a spinning blade of energy." : "the energy retracts."]")
 	force = on ? force_on : initial(force)
 	throwforce = on ? force_on : initial(force)
+	block_chance = on ? block_on : initial(block_chance)
 	icon_state = "plasmasaw_[on ? "on" : "off"]"
 	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
 	butchering.butchering_enabled = on
@@ -121,7 +105,7 @@
 		user.update_held_items()
 	update_action_buttons()
 
-/datum/action/item_action/startplasma_modified
+/datum/action/item_action/chainsaw/startplasma_industrial
 	name = "Press the power button"
 
 /obj/item/pickaxe/rock
@@ -160,7 +144,7 @@
 	if(active)
 		tool_behaviour = TOOL_MINING
 		sharpness = SHARP_EDGED
-		block_chance = 15
+		block_chance = 25 //Rock saws in lore were good at blocking necro attacks, so it gets more then usual
 		toolspeed = 0.5
 		icon_state = "rocksaw_on"
 	else

--- a/deadspace/code/modules/tools/mining.dm
+++ b/deadspace/code/modules/tools/mining.dm
@@ -88,7 +88,7 @@
 
 /obj/item/chainsaw/plasma_industrial/attack_self(mob/user)
 	on = !on
-	to_chat(user, "As you press the power button on the [src], [on ? "producing a spinning blade of energy." : "the energy retracts."]")
+	to_chat(user, "You press the power button on the [src], [on ? "producing a spinning blade of energy." : "the energy retracts."]")
 	force = on ? force_on : initial(force)
 	throwforce = on ? force_on : initial(force)
 	block_chance = on ? block_on : initial(block_chance)

--- a/deadspace/code/modules/weapons/guns/deadspace.dm
+++ b/deadspace/code/modules/weapons/guns/deadspace.dm
@@ -18,6 +18,7 @@
 	var/wielded = FALSE
 	var/can_fire_one_handed = TRUE
 	var/one_handed_penalty = 20
+	block_chance = 15 //Twohanded guns can only block while wielding, and not as well as twohanded melee
 
 /obj/item/gun/ballistic/deadspace/ui_action_click(mob/user, actiontype)
 	if(istype(actiontype, /datum/action/item_action/toggle_firemode))
@@ -77,6 +78,11 @@
 /obj/item/gun/ballistic/deadspace/twohanded/update_icon_state()
 	icon_state = base_icon_state
 	return ..()
+
+/obj/item/gun/ballistic/deadspace/twohanded/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	if(wielded) //Can only block if being wielded
+		return ..()
+	return 0
 
 /obj/item/gun/ballistic/deadspace/insert_magazine(mob/user, obj/item/ammo_box/magazine/AM, display_message = TRUE)
 	if(!istype(AM, mag_type))

--- a/deadspace/code/modules/weapons/guns/seeker.dm
+++ b/deadspace/code/modules/weapons/guns/seeker.dm
@@ -22,6 +22,7 @@ Seeker Rifles
 	suppressed = TRUE
 	can_unsuppress = FALSE
 	slot_flags = ITEM_SLOT_BACK|ITEM_SLOT_SUITSTORE
+	block_chance = 10 //The seeker sucks quite a bit at blocking compared to other guns
 	one_handed_penalty = 50
 	recoil = 2
 	burst_size = 1

--- a/deadspace/code/modules/weapons/handheld/melee.dm
+++ b/deadspace/code/modules/weapons/handheld/melee.dm
@@ -9,3 +9,4 @@
 	worn_icon = 'deadspace/icons/obj/clothing/belt_overlays.dmi'
 	desc = "A clean, pristine blade used for spiritual and religious purposes"
 	slot_flags = list (ITEM_SLOT_POCKETS, ITEM_SLOT_BELT)
+	block_chance = 30 //Surprisingly good at blocking

--- a/deadspace/code/modules/weapons/handheld/melee.dm
+++ b/deadspace/code/modules/weapons/handheld/melee.dm
@@ -9,4 +9,4 @@
 	worn_icon = 'deadspace/icons/obj/clothing/belt_overlays.dmi'
 	desc = "A clean, pristine blade used for spiritual and religious purposes"
 	slot_flags = list (ITEM_SLOT_POCKETS, ITEM_SLOT_BELT)
-	block_chance = 30 //Surprisingly good at blocking
+	block_chance = 22 //Surprisingly good at blocking

--- a/deadspace/code/modules/weapons/handheld/two_handed.dm
+++ b/deadspace/code/modules/weapons/handheld/two_handed.dm
@@ -22,12 +22,3 @@
 /obj/item/fireaxe/hugewrench/suicide_act(mob/user)
 	user.visible_message(span_suicide("[user] wrench [user.p_them()]self from head to toe! It looks like [user.p_theyre()] trying to commit suicide!"))
 	return (BRUTELOSS)
-
-/obj/item/fireaxe/hugewrench/afterattack(atom/A, mob/user, proximity)
-	. = ..()
-	if(!proximity)
-		return
-	if(wielded) //destroys windows and grilles in one hit
-		if(istype(A, /obj/structure/window) || istype(A, /obj/structure/grille))
-			var/obj/structure/W = A
-			W.atom_destruction("fireaxe")

--- a/deadspace/code/necromorph/necromorphs/necro_defense.dm
+++ b/deadspace/code/necromorph/necromorphs/necro_defense.dm
@@ -25,9 +25,11 @@
 
 /mob/living/carbon/human/attack_necromorph(mob/living/carbon/human/necromorph/user, list/modifiers, dealt_damage)
 	if(check_shields(user, 0, "the [user.name]"))
-		visible_message(span_danger("[user] attempts to touch [src]!"), \
-						span_danger("[user] attempts to touch you!"), span_hear("You hear a swoosh!"), null, user)
-		to_chat(user, span_warning("You attempt to touch [src]!"))
+		visible_message(span_danger("[user] tries to hit [src]!"), \
+						span_danger("[user] tries to hit you!"), span_hear("You hear a swoosh!"), null, user)
+		user.play_necro_sound(SOUND_ATTACK, VOLUME_HIGH, 1, 3)
+		user.do_attack_animation(src, user.attack_effect)
+		playsound(loc, 'sound/weapons/slashmiss.ogg', 50, TRUE, -1)
 		return FALSE
 
 	user.do_attack_animation(src, user.attack_effect)

--- a/deadspace/code/necromorph/necromorphs/necro_defense.dm
+++ b/deadspace/code/necromorph/necromorphs/necro_defense.dm
@@ -29,6 +29,7 @@
 						span_danger("[user] tries to hit you!"), span_hear("You hear a swoosh!"), null, user)
 		user.play_necro_sound(SOUND_ATTACK, VOLUME_HIGH, 1, 3)
 		user.do_attack_animation(src, user.attack_effect)
+		user.changeNext_move(CLICK_CD_MELEE)
 		playsound(loc, 'sound/weapons/slashmiss.ogg', 50, TRUE, -1)
 		return FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
- Introduces block chances to most commonly found weapons
- necromorph_attack block reaction cleaned up
- plasma_modified turned to plasma_industrial, changed to child of chainsaw
- Slightly increased bonecutter damage, due to basically being a small version of the industrial plasma saw
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes humans more durable to be more inline with 1.0, while not having as much irritation compared to 1.0's system.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
balance: Most melee weapons and two handed ranged weapons have block chances now
balance: Bonecutter damage slightly increased
qol: Modified plasma saw name changed to industrial plasma saw
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
