### PR TITLE
Necro organ removal, update_health, removing med_hud update, stump fix

### DIFF
--- a/code/modules/surgery/bodyparts/stump.dm
+++ b/code/modules/surgery/bodyparts/stump.dm
@@ -20,6 +20,8 @@
 	ADD_TRAIT(stump, TRAIT_PARALYSIS, STUMP_TRAIT)
 	stump.update_disabled()
 	stump.bodypart_flags = IS_ORGANIC_LIMB(src) ? BP_HAS_BLOOD|BP_HAS_ARTERY : NONE
+	if(bodypart_flags & BP_NO_PAIN)
+		stump.bodypart_flags |= BP_NO_PAIN
 	stump.is_stump = TRUE
 
 	stump.held_index = held_index

--- a/deadspace/code/datums/components/regenerate.dm
+++ b/deadspace/code/datums/components/regenerate.dm
@@ -44,7 +44,8 @@
 
 	var/mob/living/carbon/human/necromorph/owner = parent
 
-	regenerating_limbs = owner.get_missing_limbs().Cut(max_limbs)
+	regenerating_limbs = owner.get_missing_limbs()
+	regenerating_limbs.len = max_limbs //Reduces the list size to however many limbs the var is set to
 
 	//Special effect:
 	//If the user is missing two or more limbs, play a special sound

--- a/deadspace/code/necromorph/necromorphs/necromorph.dm
+++ b/deadspace/code/necromorph/necromorphs/necromorph.dm
@@ -25,9 +25,8 @@
 	if(status_flags & GODMODE)
 		return
 
-	set_health(maxHealth - getOxyLoss() - getToxLoss() - getFireLoss() - getBruteLoss() - getCloneLoss())
+	set_health(maxHealth - getFireLoss() - getBruteLoss() - getCloneLoss())
 	update_stat()
-	med_hud_set_health()
 	SEND_SIGNAL(src, COMSIG_CARBON_HEALTH_UPDATE)
 
 	dna?.species.spec_updatehealth(src)
@@ -81,8 +80,6 @@
 	update_mob_action_buttons()
 	update_damage_hud()
 	update_health_hud()
-	med_hud_set_health()
-	med_hud_set_status()
 	release_all_grabs()
 
 	set_ssd_indicator(FALSE)
@@ -126,7 +123,6 @@
 	update_damage_hud()
 	update_health_hud()
 	update_stamina_hud()
-	med_hud_set_status()
 
 /// Check if the necromorph should die
 /mob/living/carbon/human/necromorph/proc/handle_death_check()

--- a/deadspace/code/necromorph/necromorphs/species.dm
+++ b/deadspace/code/necromorph/necromorphs/species.dm
@@ -60,7 +60,6 @@
 		TRAIT_RESISTCOLD,
 		TRAIT_DISCOORDINATED_TOOL_USER,
 		TRAIT_PIERCEIMMUNE,
-		TRAIT_IGNOREDAMAGESLOWDOWN,
 		TRAIT_NOSOFTCRIT,
 		TRAIT_NOHUNGER,
 		TRAIT_NO_PAINSHOCK,
@@ -84,6 +83,11 @@
 		NOBLOODOVERLAY,
 		NOAUGMENTS,
 	)
+
+	organs = list(
+		ORGAN_SLOT_EYES = /obj/item/organ/eyes,
+		ORGAN_SLOT_TONGUE = /obj/item/organ/tongue,
+	) //Necros are mostly just biomass, little to no guts
 
 	inherent_biotypes = MOB_ORGANIC|MOB_UNDEAD|MOB_HUMANOID
 	inherent_factions = list(FACTION_NECROMORPH)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Removes un-needed necro organs
- Tweaks update_health for necros to be inline with immunities
- Removes med_hud checks from necro due to TRAIT_FAKEDEATH
- Stumps no longer cause pain if the limb it came from had the trait BP_NO_PAIN
- Hunter/uber regenerates their limbs properly

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: Stumps no longer cause terrible pain to necros
fix: Necros no longer die when their head is removed
fix: Hunter/Uber regenerates limbs again
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
