### PR TITLE
Swing Fix

### DIFF
--- a/deadspace/code/necromorph/abilities/swing.dm
+++ b/deadspace/code/necromorph/abilities/swing.dm
@@ -88,9 +88,15 @@
 		stages[i] = list()
 
 	for(var/turf/T as anything in RANGE_TURFS(range, our_loc)-our_loc)
+		if(get_dist_euclidian(our_loc, T) > range)
+			continue
 		var/angle_to_turf = SIMPLIFY_DEGREES(ATAN2(T.x - our_loc.x, T.y - our_loc.y))
-		if(angle_to_turf >= smallest_angle && angle_to_turf <= biggest_angle && get_dist_euclidian(our_loc, T) <= range)
-			stages[ROUND_UP(SIMPLIFY_DEGREES(angle_to_turf - smallest_angle)/30)] += T
+		if(smallest_angle > biggest_angle)
+			if(angle_to_turf < smallest_angle && angle_to_turf > biggest_angle)
+				continue
+		else if (angle_to_turf < smallest_angle || angle_to_turf > biggest_angle)
+			continue
+		stages[ROUND_UP(SIMPLIFY_DEGREES(angle_to_turf - smallest_angle)/30)] += T
 
 	// 1 is right, -1 is left
 	var/hand_modifier = (owner.active_hand_index % 2) ? - 1 : 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes a bug in math that made swing ability useless when attacking east 

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

:cl:
fix: fixed necromorph swing ability
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
