### PR TITLE
Map tweaks + manual cabling

### DIFF
--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -209,7 +209,7 @@
 /area/station/hallway/primary/central)
 "afp" = (
 /obj/structure/cable/yellow{
-	icon_state = "68"
+	icon_state = "12"
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
@@ -262,6 +262,17 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
+"aht" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "ahD" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -414,9 +425,17 @@
 /turf/open/floor/engine,
 /area/station/science/misc_lab/range)
 "alq" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/rack,
 /obj/effect/spawner/random/clothing/costume,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "alr" = (
@@ -446,6 +465,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/commons/dorms/barracks/male)
 "ami" = (
@@ -791,11 +813,6 @@
 /obj/structure/railing,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"avf" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "avk" = (
 /obj/structure/railing{
 	dir = 4
@@ -815,6 +832,15 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
+"avn" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "avB" = (
 /turf/open/openspace,
 /area/station/commons/lounge)
@@ -857,12 +883,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"awG" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "awR" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -1034,7 +1054,7 @@
 /area/station/hallway/primary/port)
 "aBf" = (
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "3"
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
@@ -1083,6 +1103,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hos)
+"aDj" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "aDk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/light/directional/south,
@@ -1511,6 +1537,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/commons/dorms/barracks/female)
 "aQM" = (
@@ -2224,16 +2253,6 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
-"bhV" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
-	},
-/obj/structure/cable/red{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "bid" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/door/airlock/command/glass{
@@ -2333,7 +2352,7 @@
 "blf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
@@ -2601,6 +2620,12 @@
 /obj/item/gun/ballistic/automatic/pistol/rivet,
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
+"brq" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "brD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 5
@@ -2684,6 +2709,19 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore/lesser)
+"btI" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "buf" = (
 /obj/machinery/door/airlock/hydroponics/glass{
 	name = "Abandoned Hydroponics";
@@ -2821,13 +2859,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"bxd" = (
-/obj/structure/cable/multiz,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "bxp" = (
 /obj/machinery/power/floodlight,
 /obj/effect/turf_decal/box,
@@ -3362,12 +3393,6 @@
 /obj/item/bikehorn/rubberducky,
 /turf/open/water,
 /area/station/maintenance/port/lesser)
-"bMB" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "bMD" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "sciencehallwayshutter";
@@ -3775,14 +3800,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
-"bWp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "bWt" = (
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
@@ -3875,7 +3892,7 @@
 "bYx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "4"
 	},
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
@@ -4023,6 +4040,12 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"cbT" = (
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "ccb" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
@@ -4117,6 +4140,16 @@
 /obj/structure/chair/office,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
+"cfG" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "cfJ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -4124,6 +4157,20 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"cfN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "cge" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -4299,8 +4346,10 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
 "clQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/female)
 "clS" = (
@@ -4428,10 +4477,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
-"cpL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "cqa" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -5094,6 +5139,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
+"cGR" = (
+/obj/structure/cable/yellow{
+	icon_state = "24"
+	},
+/turf/open/floor/plating,
+/area/aegis/surface)
 "cGY" = (
 /obj/structure/cable/red{
 	icon_state = "12"
@@ -5252,8 +5303,10 @@
 	},
 /area/station/hallway/primary/fore)
 "cKy" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "cKB" = (
@@ -5526,6 +5579,18 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/deadspace/grater,
 /area/station/medical/morgue)
+"cSm" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "cSt" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/grater,
@@ -5795,6 +5860,24 @@
 	dir = 4
 	},
 /area/station/security/brig)
+"dao" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "daK" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/chief_medical_officer,
@@ -5971,22 +6054,16 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
-"diZ" = (
-/obj/machinery/light/small/directional/west,
-/turf/open/floor/iron,
-/area/station/maintenance/fore/lesser)
-"djb" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
 	icon_state = "1"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"diZ" = (
+/obj/machinery/light/small/directional/west,
+/turf/open/floor/iron,
+/area/station/maintenance/fore/lesser)
 "djs" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/ce)
@@ -6058,13 +6135,6 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"dkE" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "dkR" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -6590,8 +6660,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
-	dir = 8
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -6869,6 +6940,11 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
+"dIe" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "dIj" = (
 /obj/structure/sign/warning{
 	sign_change_name = "Warning: LIVE FIRING"
@@ -6925,12 +7001,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "dJx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
@@ -7182,16 +7259,14 @@
 	},
 /area/aegis/mining)
 "dSu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/area/aegis/surface)
 "dSB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -7383,6 +7458,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/mono,
 /area/station/commons/dorms/cryo)
+"dWn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/station/commons/lounge)
 "dWo" = (
 /obj/structure/rack{
 	icon = 'icons/obj/stationobjs.dmi';
@@ -7487,6 +7568,13 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"dZb" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "dZl" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
@@ -7963,6 +8051,19 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"emc" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/white,
+/area/station/service/kitchen)
 "emt" = (
 /obj/structure/railing/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9102,12 +9203,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
-"eQU" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "eRc" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/deadspace/random/slides{
@@ -9290,7 +9385,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "3"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
@@ -9348,7 +9443,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
@@ -9695,6 +9790,16 @@
 /obj/machinery/light/broken/directional/east,
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
+"fjd" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "fjl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
 	dir = 10
@@ -10007,6 +10112,13 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
+"fqe" = (
+/obj/structure/cable/multiz,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "fqh" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10154,14 +10266,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
-"fvm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "fvJ" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/table,
@@ -10298,20 +10402,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
-"fAT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "fBk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/misc/asteroid,
@@ -10380,16 +10470,6 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
-"fDl" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "fDt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -10454,6 +10534,13 @@
 "fEk" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/storage/tools)
+"fEn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/service/janitor)
 "fEo" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/mineral/titanium/survival/pod,
@@ -10557,6 +10644,18 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/storage/primary)
+"fJP" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "fKL" = (
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
@@ -11013,6 +11112,12 @@
 "fUM" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/commons/storage/primary)
+"fVi" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "fVp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -11046,6 +11151,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
+"fVH" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "fWv" = (
 /obj/machinery/computer/piratepad_control/civilian,
 /turf/open/floor/deadspace/random/rectangles,
@@ -11235,10 +11346,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "gbS" = (
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "gcw" = (
 /obj/machinery/door/airlock/mining{
 	dir = 1;
@@ -11695,14 +11806,13 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
+	},
+/area/station/security/brig)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -11731,11 +11841,6 @@
 "gqU" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
-"grs" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "grv" = (
 /obj/machinery/telephone,
@@ -11829,6 +11934,9 @@
 "guQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/clothing/costume,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "gva" = (
@@ -11878,11 +11986,10 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
@@ -12887,6 +12994,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"had" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/security/warden)
 "hal" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -13263,17 +13377,6 @@
 "hnF" = (
 /turf/open/water/beach,
 /area/station/hallway/primary/port)
-"hnJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
 "hoj" = (
 /obj/machinery/light/directional/north,
 /obj/structure/rack,
@@ -13985,6 +14088,13 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"hFV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "hFY" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -14072,19 +14182,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
-"hHk" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "hHl" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet/secure_closet/brig{
@@ -14655,12 +14752,6 @@
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/deadspace/hardwood,
 /area/aegis/telecomms/high)
-"hXr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/brig)
 "hXv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14830,16 +14921,15 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
 	icon_state = "3"
 	},
+/obj/structure/cable/red{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
+/area/station/engineering/supermatter/room)
 "idy" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor{
@@ -14917,9 +15007,18 @@
 /area/aegis/surface)
 "ieR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
+"ieW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/male)
 "ieZ" = (
 /obj/structure/sign/directions/supply{
 	dir = 4;
@@ -15360,16 +15459,20 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "iol" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
+"ion" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15417,13 +15520,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/primary/central/aft)
-"ipO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/service/janitor)
 "iqf" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -15622,11 +15718,10 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "iwD" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "iwK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -15839,11 +15934,9 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
-/obj/structure/cable/yellow{
-	icon_state = "144"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "iCm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate/large/ds/green_horizontal,
@@ -16259,7 +16352,7 @@
 "iLi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/fore/greater)
@@ -16712,6 +16805,14 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central/aft)
+"iUB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "iVk" = (
 /obj/structure/table,
 /obj/machinery/power/data_terminal,
@@ -16946,7 +17047,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
@@ -17000,12 +17104,16 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jdI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/maintenance/fore/greater)
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/ce)
 "jdK" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -17313,12 +17421,6 @@
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/deadspace/hardwood,
 /area/aegis/telecomms)
-"jlp" = (
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "jlu" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17811,14 +17913,6 @@
 	},
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
-"jvq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "jvw" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18520,6 +18614,17 @@
 	dir = 1
 	},
 /area/station/hallway/primary/starboard)
+"jPF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "jPR" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/plating,
@@ -18669,15 +18774,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
-"jUa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
 "jUL" = (
 /obj/structure/sign/cec/deck{
 	pixel_y = 34
@@ -18904,12 +19000,6 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"kaK" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "kaO" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/iron/dark,
@@ -18983,15 +19073,6 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"kcK" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "kdk" = (
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/fax_machine,
@@ -19471,11 +19552,12 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "kpk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "129"
+	icon_state = "5"
 	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "kpy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -19488,12 +19570,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -19549,17 +19631,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
-"krx" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "krD" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/upper)
@@ -19927,20 +19998,27 @@
 /obj/structure/rack,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
-"kDP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"kDM" = (
+/obj/structure/cable/yellow{
+	icon_state = "40"
 	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
+"kDN" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
+"kDP" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "3"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/area/station/engineering/main)
 "kEv" = (
 /obj/item/megaphone,
 /obj/structure/table/wood,
@@ -20122,6 +20200,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"kJM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "kJN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
@@ -20225,14 +20311,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"kMK" = (
+"kMM" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig/upper)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "kMN" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -20526,6 +20613,15 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
+"kTE" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "kTJ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -20919,10 +21015,10 @@
 /area/station/science/breakroom)
 "ldv" = (
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "129"
 	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -21206,6 +21302,17 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
+"lke" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "lku" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -21216,6 +21323,13 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
+"lld" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "lli" = (
 /obj/machinery/power/floodlight,
 /turf/open/floor/plating,
@@ -21245,6 +21359,13 @@
 	dir = 8
 	},
 /area/station/security/checkpoint/science)
+"llL" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "llM" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4
@@ -21272,6 +21393,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/hardwood,
 /area/station/service/chapel/office)
+"lml" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "lmo" = (
 /obj/structure/table,
 /obj/effect/turf_decal/delivery,
@@ -21338,17 +21468,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"lnX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "lnY" = (
 /obj/structure/flora/rock/icy,
 /turf/open/misc/ironsand,
@@ -21713,7 +21832,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -21862,8 +21984,10 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "lEu" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
 "lEI" = (
@@ -22702,11 +22826,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
-"mcV" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "mcZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
@@ -22792,11 +22911,11 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
 "mfG" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "5"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
@@ -22927,15 +23046,6 @@
 	dir = 9
 	},
 /area/station/hallway/primary/fore)
-"mjn" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "mjp" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -23208,18 +23318,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
-"mri" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "mrm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -23343,7 +23441,7 @@
 /area/station/hallway/primary/fore)
 "mtQ" = (
 /obj/structure/cable/yellow{
-	icon_state = "24"
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/aegis/surface)
@@ -23471,6 +23569,21 @@
 /obj/structure/chair,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
+"mxC" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "mxH" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -23724,6 +23837,12 @@
 /obj/effect/spawner/random/techstorage/security_all,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"mDM" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "mEk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -24302,9 +24421,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "mXc" = (
@@ -24583,7 +24699,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "ncO" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "ncT" = (
@@ -24634,15 +24752,6 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
-"net" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "ney" = (
 /turf/closed/wall/r_wall,
 /area/mine/storage)
@@ -25141,16 +25250,6 @@
 /obj/structure/closet/crate/large/ds/green_horizontal,
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
-"nwG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
 "nxn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -25318,8 +25417,10 @@
 	c_tag = "Locker Room"
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/closet/masks,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "nAP" = (
@@ -25380,12 +25481,15 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "nBX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 4
-	},
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "nCk" = (
 /obj/effect/turf_decal/box,
@@ -25582,24 +25686,6 @@
 	},
 /turf/open/floor/plating,
 /area/aegis/surface)
-"nIh" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "P-Sec Brig";
-	req_access_txt = "63";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig)
 "nIi" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -26014,6 +26100,14 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/ai_monitored/security/armory)
+"nTb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "nTe" = (
 /obj/machinery/door/airlock/mining{
 	dir = 4;
@@ -26281,14 +26375,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"ocB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "ocF" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -26307,7 +26393,7 @@
 /area/station/command/bridge)
 "ocO" = (
 /obj/structure/cable/yellow{
-	icon_state = "40"
+	icon_state = "12"
 	},
 /turf/open/misc/ironsand,
 /area/aegis/surface)
@@ -26858,6 +26944,9 @@
 "oqy" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
 	icon_state = "2"
 	},
 /turf/open/floor/plating,
@@ -26936,6 +27025,13 @@
 "osC" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
+"osK" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "osQ" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
@@ -27623,12 +27719,6 @@
 /obj/item/cautery,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
-"oNL" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "oOD" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/medical/glass{
@@ -28328,18 +28418,6 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
-"phf" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "phm" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -28535,15 +28613,9 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "pmS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "pnj" = (
 /obj/structure/railing{
 	dir = 6
@@ -28805,15 +28877,6 @@
 	dir = 4
 	},
 /area/station/security/courtroom)
-"puP" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "puQ" = (
 /obj/structure/table/wood,
 /obj/machinery/fax_machine,
@@ -28876,6 +28939,17 @@
 /obj/structure/table/wood/fancy/red,
 /turf/open/floor/wood,
 /area/station/service/chapel)
+"pxr" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "pxs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -29379,17 +29453,6 @@
 /obj/effect/landmark/navigate_destination/court,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
-"pKl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
-"pKo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
 "pKp" = (
 /obj/machinery/computer/arcade{
 	dir = 4
@@ -29421,13 +29484,13 @@
 /obj/structure/closet/crate/large,
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
-"pLu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"pLy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/computer)
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/commons/dorms/barracks/male)
 "pLD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -29509,17 +29572,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
-"pMR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "pNe" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint #2";
@@ -29575,8 +29627,10 @@
 	name = "Clothing storage"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "pNV" = (
@@ -29760,9 +29814,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
@@ -30189,7 +30240,7 @@
 "qfF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
@@ -30368,16 +30419,6 @@
 	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/command/heads_quarters/captain/private)
-"qkK" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/white,
-/area/station/service/kitchen)
 "qkV" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -30617,20 +30658,6 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/aegis/mining)
-"qpR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "qqk" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/water,
@@ -30852,7 +30879,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -30887,6 +30914,13 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/male)
+"qwh" = (
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "qwp" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/right,
@@ -30922,6 +30956,20 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
+"qxn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "qxy" = (
 /obj/structure/cable/yellow{
 	icon_state = "3"
@@ -31209,15 +31257,13 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qHk" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -31308,6 +31354,14 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"qJS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "qKI" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/autoname/directional/west,
@@ -31334,7 +31388,9 @@
 	spawn_loot_count = 2;
 	spawn_loot_split = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "qLm" = (
@@ -31391,12 +31447,8 @@
 /area/station/security/range)
 "qMP" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "qMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -31576,19 +31628,20 @@
 /obj/item/book/manual/wiki/robotics_cyborgs,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
+"qSa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "qSh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 9
 	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
-"qSj" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "qSo" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
@@ -31684,15 +31737,10 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "qUM" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/structure/cable/red{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/area/aegis/surface)
 "qVj" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
@@ -32269,6 +32317,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
+"rlH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/maintenance/fore/greater)
 "rlP" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_center,
@@ -32351,12 +32406,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
-"rnW" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "rop" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock/pile/icy,
@@ -33333,10 +33382,10 @@
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
 "rQA" = (
-/obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+	dir = 4
 	},
+/obj/structure/lattice,
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -33813,13 +33862,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
-"shq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "shF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mob_spawn/corpse/human/charredskeleton,
@@ -33957,7 +33999,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "slP" = (
@@ -34309,14 +34353,19 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "swY" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/area/aegis/surface)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -34487,11 +34536,17 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "sBG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "sCc" = (
 /obj/structure/lattice,
 /turf/open/misc/asteroid{
@@ -34608,6 +34663,15 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
+"sEG" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "sEI" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/spawner/random/vending/colavend,
@@ -34684,6 +34748,12 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"sIn" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "sIt" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -35194,11 +35264,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
-"sWp" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
 "sWE" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/deadspace/heavy,
@@ -35821,13 +35886,14 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "trK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "trL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -35847,18 +35913,6 @@
 "tsl" = (
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/security/courtroom)
-"tsn" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "tsG" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/camera/directional/east{
@@ -35877,6 +35931,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"tsL" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "ttp" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/east,
@@ -36961,12 +37027,6 @@
 /obj/structure/table,
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/female)
-"uau" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "uaz" = (
 /obj/structure/table/reinforced/rglass,
 /obj/effect/floor_decal/ds/spline/fancy/wood/cee,
@@ -37482,16 +37542,10 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
 "upb" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/ce)
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "upl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -37695,12 +37749,6 @@
 "utU" = (
 /turf/closed/wall/r_wall,
 /area/station/service/bar)
-"uuj" = (
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "uum" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -37783,6 +37831,20 @@
 	dir = 1
 	},
 /area/aegis/mining)
+"uwH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "uwQ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -38139,15 +38201,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
-/area/station/engineering/monitoring)
+/area/station/maintenance/solars/port/fore)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38405,17 +38463,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -38923,6 +38976,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"vdL" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "vdT" = (
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/deadspace/random/maint_left,
@@ -39355,16 +39414,16 @@
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
 /area/station/science/breakroom)
+"vrh" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "vri" = (
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
-"vrs" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/security/warden)
 "vrv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39705,12 +39764,6 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"vAW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/station/commons/lounge)
 "vBq" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/cee{
 	dir = 4
@@ -39765,6 +39818,12 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
+"vCr" = (
+/obj/structure/cable/yellow{
+	icon_state = "68"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "vCt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -39936,9 +39995,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "vHV" = (
@@ -39964,6 +40020,12 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
+"vIp" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "vIJ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -40707,13 +40769,6 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"wcD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "wcH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/pdapainter/engineering,
@@ -41042,9 +41097,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "wnd" = (
@@ -41099,6 +41151,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/office)
+"woD" = (
+/obj/structure/cable/yellow{
+	icon_state = "132"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "woF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 5
@@ -41136,11 +41194,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpg" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "wpl" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
@@ -41224,10 +41282,10 @@
 /area/station/cargo/drone_bay)
 "wrl" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
 	},
-/turf/open/floor/plating,
-/area/aegis/surface)
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41278,10 +41336,6 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
-"wsH" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "wtg" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -41306,11 +41360,15 @@
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "wtM" = (
-/obj/structure/cable/yellow{
-	icon_state = "132"
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41899,18 +41957,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/service/janitor)
-"wJG" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
 "wKa" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
@@ -42417,6 +42463,15 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/maintenance/fore/lesser)
+"xaW" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "xba" = (
 /obj/structure/closet/secure_closet/ds/medical3,
 /turf/open/floor/deadspace/bathroom,
@@ -43783,7 +43838,7 @@
 "xLY" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/security/warden)
@@ -43885,6 +43940,12 @@
 "xOZ" = (
 /turf/closed/wall/r_wall,
 /area/mine/living_quarters)
+"xPb" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "xPd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -43893,12 +43954,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
-"xPh" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "xPq" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/command_all,
@@ -44121,8 +44176,8 @@
 /area/station/hallway/primary/starboard)
 "xYm" = (
 /obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "xYs" = (
@@ -44285,6 +44340,16 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
+"ydG" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "yey" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/grater,
@@ -44424,12 +44489,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "144"
 	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
@@ -44557,15 +44621,6 @@
 "yll" = (
 /turf/open/floor/catwalk_floor,
 /area/station/command/bridge)
-"ylm" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "ylW" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/bag/money,
@@ -78114,7 +78169,7 @@ iWf
 gAV
 aHO
 aHO
-cOf
+ieW
 iWf
 aHO
 gAV
@@ -78271,7 +78326,7 @@ mwV
 hfO
 mwV
 mwV
-lTz
+pLy
 mwV
 mwV
 hfO
@@ -78899,7 +78954,7 @@ nFb
 sFi
 hFa
 sNO
-alq
+guQ
 sNO
 sWE
 sFi
@@ -79056,7 +79111,7 @@ foz
 sFi
 ykX
 sNO
-alq
+guQ
 sNO
 xsV
 sFi
@@ -79212,7 +79267,7 @@ veo
 veo
 sFi
 nAH
-ncO
+xPb
 alq
 sNO
 dIR
@@ -80967,8 +81022,8 @@ tyr
 dmW
 hEO
 mui
+emc
 vHE
-qkK
 eEt
 qYZ
 fXZ
@@ -81419,7 +81474,7 @@ fnR
 sMY
 tQS
 hnk
-ipO
+fEn
 msD
 ayh
 npi
@@ -81430,7 +81485,7 @@ kBk
 ruP
 bwu
 jaQ
-ocB
+kJM
 nAc
 wVk
 ijf
@@ -82005,11 +82060,11 @@ qVP
 qVP
 wuy
 wuy
-gbS
-gbS
-gbS
-gbS
-gbS
+qUM
+qUM
+qUM
+qUM
+qUM
 wuy
 wuy
 wuy
@@ -82081,7 +82136,7 @@ reE
 khL
 qbh
 qbh
-dSu
+mWE
 akB
 qyr
 qVP
@@ -82161,24 +82216,24 @@ wuy
 wuy
 wuy
 wuy
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
 wuy
 wuy
 vRZ
@@ -82233,11 +82288,11 @@ vky
 vky
 vky
 vky
-iol
+jPF
 vky
 tCw
 aQM
-mfG
+kMM
 nqY
 daa
 qyr
@@ -82314,29 +82369,29 @@ qVP
 qVP
 qVP
 wuy
-gbS
-gbS
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
+qUM
+qUM
+qwh
+qwh
+qwh
+qwh
+qwh
+qwh
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
+qUM
 qnp
-kpP
-kpP
-kpP
-kpP
-kpP
-gbS
-gbS
+qwh
+qwh
+qwh
+qwh
+qwh
+qUM
+qUM
 wuy
 vRZ
 bzI
@@ -82384,7 +82439,7 @@ uej
 bNV
 bNV
 bNV
-dSu
+mWE
 bNV
 bNV
 bNV
@@ -82392,7 +82447,7 @@ bNV
 bNV
 bNV
 bNV
-dSu
+mWE
 bNV
 bNV
 bNV
@@ -82471,29 +82526,29 @@ qVP
 qVP
 qVP
 wuy
-gbS
-kpP
+qUM
+qwh
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-gbS
-gbS
-gbS
+qUM
+qUM
+qUM
 dsu
-gbS
-gbS
-gbS
+qUM
+qUM
+qUM
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-kpP
-gbS
+qwh
+qUM
 wuy
 vRZ
 uho
@@ -82541,7 +82596,7 @@ vHk
 mct
 vmQ
 bHR
-dSu
+mWE
 qWQ
 qyr
 qyr
@@ -82549,7 +82604,7 @@ qyr
 qyr
 qyr
 uck
-dSu
+mWE
 daa
 qyr
 qyr
@@ -82628,29 +82683,29 @@ qVP
 qVP
 qVP
 wuy
-gbS
-kpP
-swY
-swY
-swY
-swY
-swY
-swY
-gbS
-gbS
-gbS
+qUM
+qwh
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qUM
+qUM
+qUM
 nGf
-gbS
-gbS
-gbS
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
-gbS
+qUM
+qUM
+qUM
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qwh
+qUM
 wuy
 vRZ
 ham
@@ -82698,15 +82753,15 @@ qyr
 qyr
 qyr
 bHR
-qpR
-nBX
+cfN
+gqh
 tWq
-hXr
+wpg
 cVO
 weY
 qyr
 bHR
-dSu
+mWE
 daa
 qSo
 qSo
@@ -82785,14 +82840,14 @@ qVP
 qVP
 qVP
 wuy
-gbS
-kpP
-swY
-swY
-swY
-swY
-swY
-swY
+qUM
+qwh
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 sCc
 sCc
 sCc
@@ -82800,14 +82855,14 @@ dsu
 sCc
 sCc
 sCc
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
-gbS
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qwh
+qUM
 wuy
 vRZ
 vRZ
@@ -82855,7 +82910,7 @@ kGp
 dSB
 aSO
 bHR
-dSu
+mWE
 qpF
 trI
 iee
@@ -82863,7 +82918,7 @@ qam
 fGV
 qyr
 bHR
-dSu
+mWE
 daa
 qKU
 qKU
@@ -82942,29 +82997,29 @@ qVP
 qVP
 qVP
 wuy
-gbS
-gbS
-swY
-swY
-swY
-swY
-swY
-swY
-gbS
-gbS
-gbS
+qUM
+qUM
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qUM
+qUM
+qUM
 nGf
-gbS
-gbS
-gbS
-swY
-swY
-swY
-swY
-swY
-swY
-gbS
-gbS
+qUM
+qUM
+qUM
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qUM
+qUM
 wuy
 qVP
 qVP
@@ -83007,12 +83062,12 @@ bJz
 wqD
 bJz
 bJz
+vrh
 oqy
-qHk
-qHk
-fDl
+oqy
+fjd
 bHR
-dSu
+mWE
 jYt
 qyr
 qyr
@@ -83020,7 +83075,7 @@ qyr
 qyr
 qyr
 tfu
-kDP
+swY
 igw
 fpu
 fpu
@@ -83099,29 +83154,29 @@ qVP
 qVP
 qVP
 wuy
-gbS
-kpP
-swY
-swY
-swY
-swY
-swY
-swY
-gbS
-gbS
-gbS
+qUM
+qwh
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qUM
+qUM
+qUM
 nGf
-gbS
-gbS
-gbS
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
-gbS
+qUM
+qUM
+qUM
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qwh
+qUM
 wuy
 qVP
 qVP
@@ -83164,20 +83219,20 @@ pfG
 pfG
 pfG
 pfG
-nIh
+dao
 uSt
 kVO
 kVf
 sXZ
 bHX
-nBX
+gqh
 tWq
-hXr
+wpg
 dHZ
 weY
 qyr
 bHR
-dSu
+mWE
 daa
 qKU
 qKU
@@ -83256,14 +83311,14 @@ qVP
 qVP
 qVP
 wuy
-gbS
-kpP
-swY
-swY
-swY
-swY
-swY
-swY
+qUM
+qwh
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 sCc
 sCc
 sCc
@@ -83271,13 +83326,13 @@ dsu
 sCc
 sCc
 sCc
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qwh
 sCc
 wuy
 qVP
@@ -83326,7 +83381,7 @@ qyr
 qyr
 qyr
 bHR
-dSu
+mWE
 lQE
 bqe
 iee
@@ -83334,7 +83389,7 @@ qam
 wYH
 qyr
 bHR
-dSu
+mWE
 daa
 jNW
 jNW
@@ -83413,28 +83468,28 @@ qVP
 qVP
 qVP
 wuy
-gbS
-kpP
-swY
-swY
-swY
-swY
-swY
-swY
-gbS
-gbS
-gbS
+qUM
+qwh
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qUM
+qUM
+qUM
 nGf
-gbS
-gbS
-gbS
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
+qUM
+qUM
+qUM
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qwh
 dsu
 wuy
 qVP
@@ -83474,7 +83529,7 @@ rcl
 wUC
 aTw
 crJ
-xLY
+had
 svE
 crJ
 crJ
@@ -83491,7 +83546,7 @@ qyr
 qyr
 qyr
 uck
-krx
+pxr
 xIM
 pfC
 pXF
@@ -83570,28 +83625,28 @@ qVP
 qVP
 qVP
 wuy
-gbS
-gbS
-swY
-swY
-swY
-swY
-swY
-swY
-gbS
-gbS
-gbS
+qUM
+qUM
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qUM
+qUM
+qUM
 nGf
-gbS
-gbS
-gbS
-swY
-swY
-swY
-swY
-swY
-swY
-gbS
+qUM
+qUM
+qUM
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qUM
 sCc
 wuy
 qVP
@@ -83635,20 +83690,20 @@ veP
 esC
 tdg
 dAi
-xLY
+had
 gPB
 qbh
 qbh
 bHR
-kDP
-nBX
+swY
+gqh
 tWq
-hXr
+wpg
 aTa
 weY
 qyr
 bHR
-dSu
+mWE
 daa
 qyr
 qyr
@@ -83727,14 +83782,14 @@ qVP
 qVP
 qVP
 wuy
-gbS
-bMB
-swY
-swY
-swY
-swY
-swY
-swY
+qUM
+sIn
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 sCc
 sCc
 sCc
@@ -83742,13 +83797,13 @@ dsu
 sCc
 sCc
 sCc
-swY
-swY
-swY
-swY
-swY
-swY
-gbS
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qUM
 sCc
 wuy
 qVP
@@ -83797,7 +83852,7 @@ vky
 vky
 vky
 vky
-mWE
+qxn
 lQE
 aII
 iee
@@ -83805,7 +83860,7 @@ qam
 hHl
 qyr
 bHR
-dSu
+mWE
 daa
 qbh
 qbh
@@ -83884,27 +83939,27 @@ qVP
 qVP
 qVP
 wuy
-gbS
-bMB
-ylm
+qUM
+sIn
+iol
 jeU
-rQA
+dSu
 jeU
-rQA
-ylm
-gbS
-gbS
-gbS
+dSu
+iol
+qUM
+qUM
+qUM
 nGf
-gbS
-gbS
-gbS
-ylm
+qUM
+qUM
+qUM
+iol
 jeU
-rQA
+dSu
 jeU
-rQA
-ylm
+dSu
+iol
 sCc
 sCc
 wuy
@@ -83949,12 +84004,12 @@ psI
 pnG
 bpE
 faw
-vrs
+xLY
 uej
 bNV
 bNV
 bHR
-dSu
+mWE
 hor
 qyr
 qyr
@@ -83963,11 +84018,11 @@ qyr
 qyr
 uck
 odO
-pMR
-pMR
-pMR
-pMR
-pMR
+nBX
+nBX
+nBX
+nBX
+nBX
 cah
 ioB
 nPD
@@ -84044,10 +84099,10 @@ wuy
 wuy
 qQP
 lhT
-bhV
-bhV
-bhV
-bhV
+wtM
+wtM
+wtM
+wtM
 vTc
 qQP
 qQP
@@ -84057,10 +84112,10 @@ qQP
 qQP
 qQP
 pXJ
-qUM
-qUM
-qUM
-qUM
+idt
+idt
+idt
+idt
 rgW
 qQP
 wuy
@@ -84111,15 +84166,15 @@ qyr
 qyr
 qyr
 bHR
-kDP
-nBX
+swY
+gqh
 tWq
-hXr
+wpg
 fwd
 weY
 qyr
 bHR
-dSu
+mWE
 daa
 qnh
 qyr
@@ -84268,7 +84323,7 @@ vMZ
 gmr
 cPb
 oYf
-dSu
+mWE
 lQE
 tmp
 iee
@@ -84276,7 +84331,7 @@ qam
 kIo
 qyr
 bHR
-dSu
+mWE
 daa
 wAU
 sBj
@@ -84375,7 +84430,7 @@ isV
 tXh
 uzD
 bAy
-pmS
+dAF
 ogk
 qVP
 qVP
@@ -84425,7 +84480,7 @@ wie
 mny
 qyr
 bHR
-dSu
+mWE
 ebi
 qyr
 qyr
@@ -84433,7 +84488,7 @@ qyr
 qyr
 qyr
 uck
-dSu
+mWE
 daa
 mdl
 qyr
@@ -84532,7 +84587,7 @@ nzy
 sjI
 bIh
 lyZ
-dAF
+trK
 rUa
 qVP
 qVP
@@ -84582,7 +84637,7 @@ efK
 bwU
 qyr
 bHR
-dSu
+mWE
 qbh
 gPB
 qbh
@@ -84590,7 +84645,7 @@ qbh
 qbh
 qbh
 qbh
-dSu
+mWE
 qbh
 qbh
 kFF
@@ -84740,17 +84795,17 @@ nGw
 qyr
 nDq
 xLA
-pMR
+nBX
 ejX
-mfG
+kMM
 cPn
-mfG
-mfG
-mfG
+kMM
+kMM
+kMM
 pqx
+kMM
+kMM
 mfG
-mfG
-net
 wmg
 ust
 qyr
@@ -84907,7 +84962,7 @@ bNV
 vrG
 bNV
 bNV
-bWp
+dJx
 bNV
 bNV
 qyr
@@ -85002,8 +85057,8 @@ qMD
 gGE
 sVe
 yim
-jUa
-tsn
+avn
+sBG
 dOf
 qVP
 qVP
@@ -85378,7 +85433,7 @@ qVP
 qVP
 wCo
 gvH
-nwG
+ydG
 olT
 jdO
 wCo
@@ -85684,7 +85739,7 @@ lJw
 cFv
 syO
 pgS
-uau
+xYm
 joj
 woI
 eZS
@@ -85841,7 +85896,7 @@ dmE
 cFv
 crs
 fLg
-xYm
+vIp
 dYv
 woI
 qZi
@@ -86115,9 +86170,9 @@ uxc
 wCJ
 vVb
 vVb
-yhZ
-yhZ
-yhZ
+bYx
+bYx
+bYx
 mUn
 mUn
 mUn
@@ -86250,10 +86305,10 @@ xth
 xth
 xth
 xth
-qSj
-uGU
-uGU
-hHk
+llL
+cfG
+cfG
+btI
 eIL
 xth
 fdA
@@ -86275,7 +86330,7 @@ kPt
 oyt
 egd
 kNZ
-uuj
+brq
 mUn
 mUn
 mUn
@@ -86410,7 +86465,7 @@ cNx
 aJZ
 llM
 gMP
-kcK
+xaW
 tEB
 xth
 rRW
@@ -86422,17 +86477,17 @@ xdT
 sun
 ajy
 gWu
-jvq
+qHk
 ghX
 ojj
 qAi
 vVb
-pLu
+lld
 pWI
-bYx
-bYx
-bYx
-eQU
+uQN
+uQN
+uQN
+fVH
 mUn
 dpz
 mUn
@@ -86567,7 +86622,7 @@ bUh
 oRx
 tYl
 hpF
-phf
+cSm
 iVk
 xth
 nCJ
@@ -86579,7 +86634,7 @@ lSF
 gOY
 mHD
 nPN
-wmL
+fJP
 icl
 ojj
 tit
@@ -86589,7 +86644,7 @@ iqB
 gvY
 pkg
 cqi
-eQU
+fVH
 jDd
 dxU
 tsG
@@ -86736,7 +86791,7 @@ eQw
 sun
 dJK
 hJJ
-gqh
+wmL
 dCM
 ojj
 aVq
@@ -86746,7 +86801,7 @@ smA
 gvY
 mUn
 mUn
-eQU
+fVH
 lch
 gvY
 gvY
@@ -86893,7 +86948,7 @@ cLU
 cLU
 ojj
 hFY
-jvq
+qHk
 dJK
 ojj
 gFX
@@ -86902,8 +86957,8 @@ gFX
 gFX
 gFX
 kih
-ldv
 aBf
+wrl
 fsT
 gvY
 qVP
@@ -87050,7 +87105,7 @@ fpO
 gsG
 tuG
 xbE
-jvq
+qHk
 eFo
 iNX
 pIx
@@ -87183,23 +87238,23 @@ qVP
 gsG
 kud
 nQh
-gwR
-gwR
-gwR
-gwR
-gwR
-gwR
-gwR
+kDP
+kDP
+kDP
+kDP
+kDP
+kDP
+kDP
 eCA
 eCA
-mri
+tsL
 eCA
 eCA
 pAx
 gbr
-wJG
-ukz
 pSi
+ukz
+mxC
 tfP
 hPr
 jgb
@@ -87490,7 +87545,7 @@ tuc
 eSR
 rqy
 eSR
-wrl
+mtQ
 eSR
 qVP
 qVP
@@ -87498,7 +87553,7 @@ gsG
 jIe
 kxC
 ccb
-trK
+gwR
 ccb
 rib
 hmJ
@@ -87521,7 +87576,7 @@ djs
 djs
 ojj
 hFY
-jvq
+qHk
 dJK
 ojj
 pIx
@@ -87647,16 +87702,16 @@ tuc
 rqy
 tuc
 rqy
-wrl
+mtQ
 rqy
 qVP
 qVP
 gsG
 gsG
 gsG
-dkE
+dZb
 adK
-djb
+diA
 gsG
 gsG
 pMH
@@ -87667,18 +87722,18 @@ gsG
 rPz
 oDt
 hqb
-gwR
-gwR
+kDP
+kDP
 nau
 iqf
 sSt
 pmf
 jto
 xtH
-upb
+jdI
 fRQ
 xbE
-gqh
+wmL
 bZM
 ojj
 pIx
@@ -87804,7 +87859,7 @@ rqy
 rqy
 rqy
 rqy
-diA
+afp
 rqy
 qVP
 qVP
@@ -87832,10 +87887,10 @@ nJs
 jSE
 kPV
 mXQ
-upb
+jdI
 ktu
 xbE
-gqh
+wmL
 nAU
 ojj
 von
@@ -87961,7 +88016,7 @@ qVP
 rqy
 eSR
 rqy
-mtQ
+cGR
 jnM
 qVP
 qVP
@@ -88117,7 +88172,7 @@ qVP
 rqy
 rqy
 tuc
-iCe
+yhZ
 rqy
 srt
 qVP
@@ -88272,8 +88327,8 @@ rqy
 rqy
 rqy
 rqy
-oNL
-kpk
+kDN
+fVi
 rqy
 wyu
 qVP
@@ -88303,10 +88358,10 @@ huG
 aYV
 mrm
 upl
-upb
+jdI
 mKE
 jqC
-jvq
+qHk
 jzk
 uiB
 pIx
@@ -88426,9 +88481,9 @@ qVP
 rqy
 rqy
 rqy
-kaK
-iwD
-wpg
+aDj
+vdL
+ldv
 rqy
 rqy
 rqy
@@ -88460,10 +88515,10 @@ rDV
 iAC
 fRC
 bmS
-upb
+jdI
 pIG
 kNf
-jlp
+mDM
 lwr
 hPz
 xwH
@@ -88582,7 +88637,7 @@ rqy
 rqy
 rqy
 rqy
-iCe
+yhZ
 rqy
 qVP
 rqy
@@ -88738,7 +88793,7 @@ rqy
 rqy
 rqy
 rqy
-iCe
+yhZ
 rqy
 qVP
 qVP
@@ -88772,10 +88827,10 @@ cMl
 oaV
 vBz
 pee
-wsH
+iCe
 jgI
 cAY
-cpL
+qMP
 oTl
 sRF
 sRF
@@ -88894,7 +88949,7 @@ qVP
 rqy
 rqy
 tuc
-wtM
+woD
 qVP
 qVP
 qVP
@@ -88928,11 +88983,11 @@ vPr
 ebH
 fjl
 hfM
-dJx
-sWp
+hFV
+dIe
 tKf
 jYX
-pKl
+pmS
 qoR
 sRF
 keh
@@ -89051,7 +89106,7 @@ qVP
 rqy
 rqy
 tuc
-diA
+afp
 qVP
 qVP
 qVP
@@ -89208,7 +89263,7 @@ qVP
 rqy
 rqy
 tuc
-ocO
+kDM
 qVP
 qVP
 qVP
@@ -89238,7 +89293,7 @@ mpT
 eGf
 gkJ
 jZb
-wcD
+osK
 kEE
 ebH
 kRQ
@@ -89366,7 +89421,7 @@ qVP
 qVP
 rqy
 rqy
-afp
+vCr
 qVP
 qVP
 qVP
@@ -89395,8 +89450,8 @@ anZ
 eGf
 eAg
 sxb
-mcV
-grs
+iwD
+gbS
 gkJ
 eAg
 feG
@@ -89523,7 +89578,7 @@ qVP
 qVP
 qVP
 rqy
-xPh
+cbT
 rqy
 rqy
 rqy
@@ -89552,7 +89607,7 @@ aRD
 exz
 hFC
 gQv
-sBG
+ion
 tfU
 ohb
 ebH
@@ -89681,7 +89736,7 @@ rqy
 qVP
 qVP
 rqy
-afp
+vCr
 rqy
 rqy
 rqy
@@ -90157,7 +90212,7 @@ qVP
 qVP
 rqy
 rHU
-diA
+afp
 rqy
 rqy
 rqy
@@ -90314,7 +90369,7 @@ qVP
 qVP
 qVP
 rHU
-diA
+afp
 rqy
 rqy
 rqy
@@ -90471,7 +90526,7 @@ qVP
 qVP
 iHy
 ruE
-puP
+lml
 rqy
 rqy
 rqy
@@ -90626,9 +90681,9 @@ rqy
 rqy
 rqy
 rqy
-diA
+afp
 rEA
-quR
+aht
 rEA
 rEA
 sIt
@@ -90655,10 +90710,10 @@ naE
 mCH
 dvF
 hHs
-shq
+blf
 dwU
-blf
-blf
+kpP
+kpP
 rWy
 woN
 bDj
@@ -90783,9 +90838,9 @@ rqy
 rqy
 rqy
 rqy
-diA
+afp
 rek
-rnW
+uGU
 jJJ
 wAN
 sIt
@@ -90940,12 +90995,12 @@ qVP
 rqy
 rqy
 rqy
-awG
+ocO
 rEA
-mjn
+sEG
 jBo
 oYE
-idt
+quR
 ruE
 ieM
 rqy
@@ -91097,7 +91152,7 @@ qVP
 rqy
 tuc
 tuc
-diA
+afp
 rEA
 aQr
 oXp
@@ -111728,7 +111783,7 @@ wuy
 kBk
 dlm
 fLk
-vAW
+dWn
 uFg
 lse
 lse
@@ -112359,7 +112414,7 @@ wuy
 kBk
 avB
 pOx
-avf
+upb
 dRt
 bUr
 noU
@@ -113166,7 +113221,7 @@ hwG
 goF
 tgq
 fzN
-qfF
+kpk
 pAc
 bOE
 vvm
@@ -113323,7 +113378,7 @@ pyk
 pvH
 pYv
 aLQ
-pKo
+qfF
 pAc
 bOE
 nRK
@@ -113795,7 +113850,7 @@ wuy
 wuy
 jfa
 vVU
-kMK
+nTb
 wuT
 wuT
 mkD
@@ -115365,10 +115420,10 @@ kRE
 bmz
 bmz
 bmz
-uQN
 jbI
-jbI
-jbI
+kTE
+kTE
+kTE
 ikZ
 fyZ
 rKj
@@ -115528,7 +115583,7 @@ mpQ
 mpQ
 eJO
 mpQ
-eYM
+lke
 bCA
 qhL
 qhL
@@ -115684,8 +115739,8 @@ pyh
 ctS
 ctS
 pyh
-bxd
-fAT
+fqe
+uwH
 jfa
 czR
 ggl
@@ -115836,13 +115891,13 @@ prI
 pVm
 pyh
 oer
-hnJ
+lAk
 uuA
 qGr
 qQy
 pyh
 mpQ
-eYM
+lke
 mpQ
 mpQ
 mpQ
@@ -115993,16 +116048,16 @@ aDi
 jlE
 pyh
 hyP
-lAk
+qJS
 hch
 hch
 hQX
 pyh
 mpQ
-lnX
+eYM
 xbH
-qMP
 eWW
+iUB
 uUC
 mpQ
 jfa
@@ -116313,7 +116368,7 @@ sxJ
 jXz
 pyh
 mpQ
-fvm
+qSa
 cPJ
 tdy
 hFz
@@ -116473,7 +116528,7 @@ jjd
 xpH
 cPJ
 ncG
-iLi
+rlH
 pzN
 cPJ
 wuy
@@ -116630,7 +116685,7 @@ mpQ
 xpH
 cPJ
 vsE
-jdI
+iLi
 bmZ
 cPJ
 wuy

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -199,6 +199,10 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/misc/asteroid,
 /area/station/hallway/primary/fore)
+"afd" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "afk" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/greater)
@@ -208,9 +212,19 @@
 	},
 /area/station/hallway/primary/central)
 "afp" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "68"
+	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"afN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "afX" = (
 /turf/open/floor/deadspace/grille_spare1,
 /area/mine/storage)
@@ -1210,6 +1224,18 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse/upper)
+"aHr" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "aHO" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
@@ -1372,17 +1398,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/aft)
-"aNc" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "aNe" = (
 /obj/structure/railing{
 	dir = 10
@@ -1528,18 +1543,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/stone,
 /area/aegis/surface)
-"aRb" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "aRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -1650,9 +1653,11 @@
 /area/station/security/brig)
 "aSR" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "aSW" = (
@@ -2259,18 +2264,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"biA" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "biD" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -2327,13 +2320,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
-"bkq" = (
-/obj/structure/cable/multiz,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "bkr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2714,7 +2700,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -2822,7 +2808,9 @@
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "bwu" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "bwR" = (
@@ -2877,6 +2865,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"bxY" = (
+/obj/structure/cable/yellow{
+	icon_state = "132"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "bym" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/grater,
@@ -2888,13 +2882,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
-"byz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/maintenance/fore/greater)
 "byB" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/closet/crate/coffin,
@@ -2951,7 +2938,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "bzI" = (
@@ -3222,6 +3211,12 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
+"bGR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/station/commons/lounge)
 "bHy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -3334,13 +3329,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
-"bKO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/computer)
 "bKS" = (
 /obj/effect/landmark{
 	name = "ShuttleRepairPart"
@@ -3709,7 +3697,6 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/monitoring)
 "bUr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
@@ -3882,7 +3869,7 @@
 "bYx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "4"
 	},
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
@@ -3943,6 +3930,15 @@
 /obj/item/folder/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
+"bZO" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "cac" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/cee{
 	dir = 8
@@ -4164,10 +4160,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
 "cgN" = (
@@ -4601,14 +4599,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
-"ctC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "ctS" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced/grille,
@@ -4664,9 +4654,11 @@
 /area/station/commons/dorms/barracks/female)
 "cvi" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "cvu" = (
@@ -5572,11 +5564,13 @@
 /obj/item/radio/intercom/directional/east,
 /obj/structure/table/wood,
 /obj/machinery/telephone,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
@@ -5695,22 +5689,17 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "cWV" = (
 /obj/machinery/light/directional/east,
 /turf/open/misc/asteroid,
 /area/station/maintenance/disposal)
-"cXc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "cXA" = (
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
@@ -5744,6 +5733,13 @@
 /obj/item/plate_shard/marker_shard,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
+"cYv" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "cYy" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -5981,16 +5977,10 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/area/aegis/surface)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -6200,11 +6190,11 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/fore)
 "dpc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "dpo" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/right{
@@ -6453,6 +6443,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
+"dxJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "dxM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
@@ -6480,6 +6476,20 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/grass,
 /area/station/service/library)
+"dyi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "dyl" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -6591,9 +6601,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -6757,6 +6769,12 @@
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
 /area/mine/production)
+"dFO" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "dFV" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -6924,13 +6942,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "dJx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "8"
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
+/turf/open/floor/plating,
+/area/station/security/warden)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
@@ -6978,7 +6995,6 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/service/bar)
@@ -7183,15 +7199,11 @@
 	},
 /area/aegis/mining)
 "dSu" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "144"
 	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "dSB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -7306,13 +7318,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "dUe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/carpet/red,
-/area/station/security/office)
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "dUl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -7610,6 +7624,12 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
+"ecu" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "ecy" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/deadspace/random/slides{
@@ -7626,6 +7646,24 @@
 /obj/structure/closet/lasertag/blue,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"ecM" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "eda" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/firecloset,
@@ -7714,9 +7752,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "efF" = (
@@ -8563,9 +8603,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "eEa" = (
@@ -8593,9 +8635,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "eEx" = (
@@ -8826,6 +8870,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/engineering/monitoring)
 "eIZ" = (
@@ -8955,6 +9002,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"eNn" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "eNq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -9337,6 +9390,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "eYU" = (
@@ -9573,9 +9629,11 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/telephone/service,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/item/reagent_containers/glass/rag,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "ffE" = (
@@ -9994,8 +10052,13 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "fqh" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
 "fqq" = (
@@ -10101,6 +10164,13 @@
 	},
 /turf/open/floor/plating,
 /area/misc/testroom)
+"ftX" = (
+/obj/structure/cable/multiz,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "ful" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plating,
@@ -10252,7 +10322,6 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "fzI" = (
@@ -10533,14 +10602,11 @@
 /area/station/commons/dorms/cryo)
 "fLg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "fLk" = (
 /obj/structure/chair/stool/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/station/commons/lounge)
 "fLs" = (
@@ -10633,17 +10699,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
-"fNw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "fNB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -10810,9 +10865,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
 "fRe" = (
@@ -11045,9 +11102,11 @@
 	req_access_txt = "28"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "fYa" = (
@@ -11194,12 +11253,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "gbS" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "gcw" = (
 /obj/machinery/door/airlock/mining{
 	dir = 1;
@@ -11656,13 +11716,11 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "18"
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig/upper)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -11833,11 +11891,14 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/brig)
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "gxI" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_center,
@@ -12013,9 +12074,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "gDA" = (
@@ -12217,10 +12280,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/hallway/secondary/service)
 "gKQ" = (
@@ -12545,6 +12610,9 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "gTq" = (
@@ -12643,9 +12711,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/hallway/secondary/service)
 "gVA" = (
@@ -12886,12 +12956,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/central)
-"hbF" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "hbH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -12908,12 +12972,6 @@
 /obj/structure/bed/roller,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"hcc" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "hch" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -13163,6 +13221,15 @@
 "hku" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
+"hkQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "hkR" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron/dark/side,
@@ -13215,6 +13282,13 @@
 "hnk" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
+"hnl" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "hnF" = (
 /turf/open/water/beach,
 /area/station/hallway/primary/port)
@@ -13846,16 +13920,12 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "hDf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "8"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "hDv" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/customs)
@@ -14135,9 +14205,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -14146,6 +14218,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"hLl" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "hLv" = (
 /obj/machinery/button/door/directional/south{
 	id = "window command blast";
@@ -14571,20 +14649,6 @@
 /obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"hWp" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "hWr" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
@@ -14627,6 +14691,13 @@
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
+"hXO" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "hXP" = (
 /mob/living/simple_animal/mouse/gray,
 /turf/open/floor/plating,
@@ -14691,12 +14762,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/male)
-"iaa" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "iae" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -14779,12 +14844,11 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "3"
 	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "idy" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor{
@@ -14975,6 +15039,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
+"ihd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "ihh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -15041,9 +15112,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "ijk" = (
@@ -15210,18 +15286,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
-"ilJ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "ilN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -15312,11 +15376,17 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "iol" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "6"
 	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15562,9 +15632,15 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "iwD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "iwK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -15782,11 +15858,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "iCm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate/large/ds/green_horizontal,
@@ -15831,9 +15904,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/hallway/secondary/service)
 "iDw" = (
@@ -15944,17 +16019,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"iFU" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "iGf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -15982,6 +16046,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
+"iGQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "iGV" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/engine_smes)
@@ -16208,7 +16286,7 @@
 "iLi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/fore/greater)
@@ -16858,9 +16936,14 @@
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/female)
 "jaQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "jaR" = (
@@ -16889,9 +16972,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "jbL" = (
@@ -16944,15 +17024,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jdI" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/red{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "jdK" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -17164,9 +17243,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/hallway/secondary/service)
 "jjd" = (
@@ -17820,6 +17901,15 @@
 "jxc" = (
 /turf/closed/wall/r_wall,
 /area/station/service/chapel/monastery)
+"jxf" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "jxk" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plating,
@@ -17836,10 +17926,10 @@
 	},
 /area/station/hallway/primary/central/aft)
 "jxH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/structure/chair/stool/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "jyl" = (
@@ -18144,9 +18234,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "jIe" = (
@@ -18165,6 +18257,12 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"jIA" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "jIB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -18808,8 +18906,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "jZs" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
 "jZu" = (
@@ -18892,6 +18992,10 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"kda" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "kdk" = (
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/fax_machine,
@@ -18914,6 +19018,16 @@
 /obj/effect/spawner/random/food_or_drink/snack,
 /turf/open/floor/plating,
 /area/aegis/surface)
+"kdT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "keh" = (
 /obj/machinery/power/smes/engineering{
 	input_level = 60000;
@@ -19239,13 +19353,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"kkt" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "kky" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -19277,6 +19384,7 @@
 "klD" = (
 /obj/structure/table/wood/poker,
 /obj/machinery/roulette,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "klS" = (
@@ -19367,14 +19475,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
-"koC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "koO" = (
 /obj/machinery/light/directional/north,
 /turf/open/misc/asteroid,
@@ -19400,15 +19500,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "5"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -19684,6 +19781,18 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/female)
+"kzw" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "kzI" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -20046,6 +20155,17 @@
 /obj/machinery/rnd/production/circuit_imprinter/robotics,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
+"kKm" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "kLe" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
@@ -20425,12 +20545,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"kTS" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "kTT" = (
 /obj/machinery/newscaster/directional/west,
 /obj/structure/table/wood,
@@ -20661,6 +20775,15 @@
 	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/medical/morgue)
+"kZE" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "kZJ" = (
 /turf/closed/wall/r_wall,
 /area/station/service/chapel)
@@ -20816,14 +20939,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "ldv" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "5"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -21239,6 +21362,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"lnN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "lnY" = (
 /obj/structure/flora/rock/icy,
 /turf/open/misc/ironsand,
@@ -21520,12 +21650,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/service/chapel)
-"lyQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "lyS" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -21892,9 +22016,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "lIE" = (
@@ -22158,7 +22284,12 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "lQk" = (
@@ -22166,9 +22297,11 @@
 	dir = 1;
 	name = "Enginieering Airlock"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -22290,14 +22423,6 @@
 	},
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/female)
-"lTu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
 "lTv" = (
 /obj/machinery/door/airlock/mining,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -22420,13 +22545,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
-"lXX" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "lYG" = (
 /obj/structure/railing,
 /turf/open/openspace,
@@ -22481,9 +22599,11 @@
 	pixel_y = 21
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/service/hydroponics)
@@ -22526,9 +22646,11 @@
 	dir = 1;
 	name = "Enginieering Airlock"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -22691,6 +22813,11 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
+"mfY" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "mgj" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -23128,6 +23255,19 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"mrN" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "mrS" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/east,
@@ -23148,9 +23288,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
 "msp" = (
@@ -23211,7 +23353,9 @@
 	},
 /area/station/hallway/primary/fore)
 "mtQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "24"
+	},
 /turf/open/floor/plating,
 /area/aegis/surface)
 "mui" = (
@@ -23221,9 +23365,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "mun" = (
@@ -23578,8 +23724,10 @@
 /obj/structure/table/glass,
 /obj/item/food/grown/poppy/lily,
 /obj/machinery/telephone/service,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/service/hydroponics)
 "mDJ" = (
@@ -23650,6 +23798,10 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/exit)
+"mHB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "mHD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24034,13 +24186,13 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics - Desk"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "mTB" = (
@@ -24688,6 +24840,12 @@
 	},
 /turf/open/floor/plating,
 /area/aegis/surface)
+"nkB" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "nkV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -24720,6 +24878,14 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
+"nmw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "nmA" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/mono,
@@ -24810,6 +24976,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
+"npw" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "npG" = (
 /obj/structure/rack,
 /obj/item/clothing/under/shorts/red,
@@ -24912,6 +25084,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"nta" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "nth" = (
 /obj/machinery/light,
 /turf/open/misc/asteroid,
@@ -25120,9 +25303,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "nAk" = (
@@ -25219,14 +25404,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "nBX" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "nCk" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -25308,6 +25490,11 @@
 "nDA" = (
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"nDB" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "nED" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -25367,9 +25554,14 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "nHp" = (
@@ -25573,6 +25765,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "nNi" = (
@@ -25793,6 +25988,10 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/female)
+"nRT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "nSr" = (
 /obj/machinery/light/small/maintenance/directional/west,
 /obj/structure/table/wood,
@@ -25850,20 +26049,6 @@
 	},
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/male)
-"nUa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "nUc" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
@@ -26126,7 +26311,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "ocO" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
 /turf/open/misc/ironsand,
 /area/aegis/surface)
 "ocW" = (
@@ -26438,7 +26625,6 @@
 	},
 /area/station/security/checkpoint/science)
 "okQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "10"
 	},
@@ -26473,10 +26659,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore/lesser)
-"olt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "olT" = (
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -26487,12 +26669,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningdock/oresilo)
-"omf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "omq" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
@@ -26684,10 +26860,10 @@
 "oqy" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "3"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "2"
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
@@ -26878,6 +27054,11 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"own" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "owH" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/stripes/line{
@@ -26945,6 +27126,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/toilet/restrooms)
+"oym" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "oys" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -27271,24 +27457,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"oIA" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "P-Sec Brig";
-	req_access_txt = "63";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
+"oID" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "9"
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig)
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "oIM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -27873,10 +28049,7 @@
 /area/station/medical/medbay/central)
 "oYE" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "6"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -27986,12 +28159,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/hallway/primary/central)
-"pcr" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "pcv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28119,14 +28286,11 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "pfG" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/hallway/primary/central)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "pfH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -28165,7 +28329,6 @@
 /area/station/science/robotics/lab)
 "pgS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "phc" = (
@@ -28582,13 +28745,6 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/mine/hydroponics)
-"psT" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/security/warden)
 "psW" = (
 /turf/open/floor/carpet/red,
 /area/aegis/hanger)
@@ -28673,10 +28829,6 @@
 /obj/structure/railing/corner,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
-"pvp" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "pvH" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/button/door/directional/north{
@@ -29143,15 +29295,17 @@
 /obj/structure/railing,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
-"pIj" = (
+"pIe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "9"
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "pIk" = (
 /obj/item/wallframe/apc,
 /turf/open/floor/plating,
@@ -29500,6 +29654,16 @@
 "pPU" = (
 /turf/open/floor/deadspace/random/golf_brown,
 /area/misc/testroom)
+"pQg" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "pQi" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Control Room"
@@ -29766,11 +29930,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
-"pYn" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "pYv" = (
 /obj/effect/landmark/start/detective,
 /obj/structure/chair/office,
@@ -30036,6 +30195,13 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
+"qgJ" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "qgK" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 8
@@ -30052,6 +30218,20 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/deadspace/mono,
 /area/station/medical/exam_room)
+"qgR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "qgU" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Departure Lounge - Starboard Aft"
@@ -30636,6 +30816,21 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/ai_monitored/security/armory)
+"quL" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "quN" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/deadspace/grater,
@@ -30647,7 +30842,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -31004,11 +31199,14 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qHk" = (
-/obj/structure/cable/yellow{
-	icon_state = "6"
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -31370,13 +31568,6 @@
 /obj/item/book/manual/wiki/robotics_cyborgs,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
-"qRY" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "qSh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 9
@@ -31478,19 +31669,14 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "qUM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/hallway/primary/central)
 "qVj" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
@@ -31634,9 +31820,11 @@
 "qYZ" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "qZb" = (
@@ -31736,7 +31924,9 @@
 	dir = 8
 	},
 /obj/machinery/telephone/service,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "rca" = (
@@ -32339,6 +32529,14 @@
 	dir = 8
 	},
 /area/station/security/lockers)
+"rtX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "ruf" = (
 /obj/structure/rack,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32382,7 +32580,9 @@
 "ruP" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "rva" = (
@@ -32403,6 +32603,12 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/hanger)
+"rvF" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "rvT" = (
 /obj/machinery/light/cold/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -32605,6 +32811,14 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
+"rBW" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
+	},
+/area/station/security/brig)
 "rCd" = (
 /obj/structure/table,
 /obj/machinery/telephone/service,
@@ -32623,6 +32837,20 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
+"rCm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "rCD" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table,
@@ -32977,7 +33205,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "rML" = (
@@ -33228,18 +33458,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
-"rUG" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "rUK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -33296,16 +33514,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"rVJ" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "rVX" = (
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33357,6 +33565,17 @@
 /obj/machinery/power/floodlight,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
+"rXK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "rYJ" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -33458,15 +33677,6 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"scS" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "sdl" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/bot,
@@ -33771,6 +33981,18 @@
 /obj/effect/spawner/random/clothing/lizardboots,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"slV" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "smg" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -33835,6 +34057,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
 "snw" = (
@@ -34112,9 +34337,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "swY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -34538,13 +34765,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
-"sKg" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
 "sKh" = (
 /obj/structure/table,
 /turf/open/floor/stone,
@@ -34740,6 +34960,14 @@
 /obj/item/chainsaw/plasma_industrial,
 /turf/open/floor/deadspace/mono,
 /area/station/commons/storage/primary)
+"sPO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "sQr" = (
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -35289,7 +35517,7 @@
 "tfU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "tfW" = (
@@ -35615,6 +35843,10 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "trK" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -35974,15 +36206,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
-"tAR" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "tBf" = (
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -36022,6 +36245,13 @@
 	dir = 1
 	},
 /area/aegis/mining)
+"tCo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/maintenance/fore/greater)
 "tCv" = (
 /obj/structure/table,
 /turf/open/floor/deadspace/grater,
@@ -36068,10 +36298,6 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
-"tDb" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "tDg" = (
 /turf/open/floor/iron,
 /area/station/maintenance/fore/lesser)
@@ -36154,16 +36380,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/starboard/upper)
-"tHs" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
-	},
-/obj/structure/cable/red{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "tHX" = (
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/male)
@@ -36405,10 +36621,7 @@
 "tQQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
@@ -36456,6 +36669,12 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
+"tRt" = (
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "tRy" = (
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -36742,13 +36961,6 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/aft)
-"tZl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "tZt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36805,7 +37017,6 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "ubx" = (
@@ -37021,10 +37232,12 @@
 /turf/open/floor/iron/kitchen_coldroom,
 /area/station/medical/coldroom)
 "ujM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "ujU" = (
@@ -37263,8 +37476,10 @@
 /area/station/engineering/main)
 "uor" = (
 /obj/machinery/firealarm/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
 "uoA" = (
@@ -37284,10 +37499,10 @@
 /area/station/service/chapel/monastery)
 "upb" = (
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/turf/open/floor/plating,
+/area/aegis/surface)
 "upl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -37425,7 +37640,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "usC" = (
@@ -37783,9 +38000,6 @@
 "uBT" = (
 /obj/structure/chair/stool/directional/north,
 /obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/carpet/red,
 /area/station/commons/lounge)
 "uCa" = (
@@ -37930,20 +38144,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
+/area/aegis/surface)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38207,10 +38413,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -38293,6 +38499,14 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
+"uSz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "uSY" = (
 /obj/structure/table,
 /obj/item/clothing/head/cone{
@@ -38649,11 +38863,13 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "vbA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "vbE" = (
@@ -38729,7 +38945,9 @@
 /turf/open/floor/iron/ported/lino,
 /area/station/service/library)
 "vet" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "vew" = (
@@ -38878,12 +39096,6 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
-"vkv" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "vky" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39574,15 +39786,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
-"vDc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "vDM" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -39724,9 +39927,11 @@
 "vHE" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "vHV" = (
@@ -40596,7 +40801,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "wfv" = (
@@ -40649,19 +40856,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/customs)
-"wgV" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "wgZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -40922,13 +41116,18 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpg" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/area/station/security/brig)
+/turf/open/floor/iron/white,
+/area/station/service/kitchen)
 "wpl" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
@@ -41011,17 +41210,16 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "wrl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41096,10 +41294,15 @@
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "wtM" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
-/area/station/engineering/atmos)
+/area/station/engineering/supermatter/room)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41812,9 +42015,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/hallway/secondary/service)
 "wOR" = (
@@ -41892,9 +42097,14 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "wSH" = (
@@ -41968,9 +42178,11 @@
 /area/station/engineering/main)
 "wVk" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "wVm" = (
@@ -42121,20 +42333,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
-"wYf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "wYj" = (
 /obj/structure/railing{
 	dir = 10
@@ -42366,13 +42564,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
-"xdW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
 "xew" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -42843,11 +43034,6 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/aegis/surface)
-"xrd" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
 "xrA" = (
 /obj/structure/railing{
 	dir = 1
@@ -43573,7 +43759,7 @@
 "xLY" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "4"
 	},
 /turf/open/floor/plating,
 /area/station/security/warden)
@@ -43694,6 +43880,16 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
+"xPI" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "xPJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -43902,8 +44098,8 @@
 /area/station/hallway/primary/starboard)
 "xYm" = (
 /obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "xYs" = (
@@ -44159,9 +44355,14 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "ygF" = (
@@ -44200,14 +44401,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
+/area/aegis/surface)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
@@ -44335,6 +44533,13 @@
 "yll" = (
 /turf/open/floor/catwalk_floor,
 /area/station/command/bridge)
+"ylx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "ylW" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/bag/money,
@@ -80102,7 +80307,7 @@ cWK
 lPW
 nMS
 nMS
-eyr
+cWK
 gTp
 utU
 lzi
@@ -80736,7 +80941,7 @@ tyr
 dmW
 hEO
 mui
-vHE
+wpg
 vHE
 eEt
 qYZ
@@ -81199,7 +81404,7 @@ kBk
 ruP
 bwu
 jaQ
-jaQ
+uSz
 nAc
 wVk
 ijf
@@ -81774,11 +81979,11 @@ qVP
 qVP
 wuy
 wuy
-trK
-trK
-trK
-trK
-trK
+diA
+diA
+diA
+diA
+diA
 wuy
 wuy
 wuy
@@ -81930,24 +82135,24 @@ wuy
 wuy
 wuy
 wuy
-trK
-trK
-trK
-trK
-trK
-trK
-trK
-trK
-trK
-trK
-trK
-trK
-trK
-trK
-trK
-trK
-trK
-trK
+diA
+diA
+diA
+diA
+diA
+diA
+diA
+diA
+diA
+diA
+diA
+diA
+diA
+diA
+diA
+diA
+diA
+diA
 wuy
 wuy
 vRZ
@@ -81990,7 +82195,7 @@ mwp
 yfI
 cZh
 uEm
-dUe
+iCe
 xfD
 vky
 dAe
@@ -82002,7 +82207,7 @@ vky
 vky
 vky
 vky
-iCe
+pIe
 vky
 tCw
 aQM
@@ -82083,29 +82288,29 @@ qVP
 qVP
 qVP
 wuy
-trK
-trK
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-trK
-trK
-trK
-trK
-trK
-trK
-trK
+diA
+diA
+uGU
+uGU
+uGU
+uGU
+uGU
+uGU
+diA
+diA
+diA
+diA
+diA
+diA
+diA
 qnp
-gbS
-gbS
-gbS
-gbS
-gbS
-trK
-trK
+uGU
+uGU
+uGU
+uGU
+uGU
+diA
+diA
 wuy
 vRZ
 bzI
@@ -82240,29 +82445,29 @@ qVP
 qVP
 qVP
 wuy
-trK
-gbS
+diA
+uGU
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-trK
-trK
-trK
+diA
+diA
+diA
 dsu
-trK
-trK
-trK
+diA
+diA
+diA
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-gbS
-trK
+uGU
+diA
 wuy
 vRZ
 uho
@@ -82397,29 +82602,29 @@ qVP
 qVP
 qVP
 wuy
-trK
-gbS
+diA
+uGU
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-trK
-trK
-trK
+diA
+diA
+diA
 nGf
-trK
-trK
-trK
+diA
+diA
+diA
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-gbS
-trK
+uGU
+diA
 wuy
 vRZ
 ham
@@ -82467,10 +82672,10 @@ qyr
 qyr
 qyr
 bHR
-wYf
-wpg
+dyi
+rBW
 tWq
-gwR
+dFO
 cVO
 weY
 qyr
@@ -82554,8 +82759,8 @@ qVP
 qVP
 qVP
 wuy
-trK
-gbS
+diA
+uGU
 rQA
 rQA
 rQA
@@ -82575,8 +82780,8 @@ rQA
 rQA
 rQA
 rQA
-gbS
-trK
+uGU
+diA
 wuy
 vRZ
 vRZ
@@ -82711,29 +82916,29 @@ qVP
 qVP
 qVP
 wuy
-trK
-trK
+diA
+diA
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-trK
-trK
-trK
+diA
+diA
+diA
 nGf
-trK
-trK
-trK
+diA
+diA
+diA
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-trK
-trK
+diA
+diA
 wuy
 qVP
 qVP
@@ -82776,10 +82981,10 @@ bJz
 wqD
 bJz
 bJz
-lXX
-kpP
-kpP
+qgJ
 oqy
+oqy
+xPI
 bHR
 mWE
 jYt
@@ -82789,7 +82994,7 @@ qyr
 qyr
 qyr
 tfu
-qUM
+iGQ
 igw
 fpu
 fpu
@@ -82868,29 +83073,29 @@ qVP
 qVP
 qVP
 wuy
-trK
-gbS
+diA
+uGU
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-trK
-trK
-trK
+diA
+diA
+diA
 nGf
-trK
-trK
-trK
+diA
+diA
+diA
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-gbS
-trK
+uGU
+diA
 wuy
 qVP
 qVP
@@ -82926,22 +83131,22 @@ ohU
 wEZ
 wEZ
 lWL
-pfG
-pfG
+qUM
+qUM
 xPJ
-pfG
-pfG
-pfG
-pfG
-oIA
+qUM
+qUM
+qUM
+qUM
+ecM
 uSt
 kVO
 kVf
 sXZ
 bHX
-wpg
+rBW
 tWq
-gwR
+dFO
 dHZ
 weY
 qyr
@@ -83025,8 +83230,8 @@ qVP
 qVP
 qVP
 wuy
-trK
-gbS
+diA
+uGU
 rQA
 rQA
 rQA
@@ -83046,7 +83251,7 @@ rQA
 rQA
 rQA
 rQA
-gbS
+uGU
 sCc
 wuy
 qVP
@@ -83182,28 +83387,28 @@ qVP
 qVP
 qVP
 wuy
-trK
-gbS
+diA
+uGU
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-trK
-trK
-trK
+diA
+diA
+diA
 nGf
-trK
-trK
-trK
+diA
+diA
+diA
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-gbS
+uGU
 dsu
 wuy
 qVP
@@ -83243,7 +83448,7 @@ rcl
 wUC
 aTw
 crJ
-psT
+xLY
 svE
 crJ
 crJ
@@ -83260,7 +83465,7 @@ qyr
 qyr
 qyr
 uck
-iFU
+kKm
 xIM
 pfC
 pXF
@@ -83339,28 +83544,28 @@ qVP
 qVP
 qVP
 wuy
-trK
-trK
+diA
+diA
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-trK
-trK
-trK
+diA
+diA
+diA
 nGf
-trK
-trK
-trK
+diA
+diA
+diA
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-trK
+diA
 sCc
 wuy
 qVP
@@ -83404,15 +83609,15 @@ veP
 esC
 tdg
 dAi
-psT
+xLY
 gPB
 qbh
 qbh
 bHR
-qUM
-wpg
+iGQ
+rBW
 tWq
-gwR
+dFO
 aTa
 weY
 qyr
@@ -83496,8 +83701,8 @@ qVP
 qVP
 qVP
 wuy
-trK
-vkv
+diA
+yhZ
 rQA
 rQA
 rQA
@@ -83517,7 +83722,7 @@ rQA
 rQA
 rQA
 rQA
-trK
+diA
 sCc
 wuy
 qVP
@@ -83566,7 +83771,7 @@ vky
 vky
 vky
 vky
-nUa
+qgR
 lQE
 aII
 iee
@@ -83653,27 +83858,27 @@ qVP
 qVP
 qVP
 wuy
-trK
-vkv
-tAR
+diA
+yhZ
+qHk
 jeU
-nBX
+trK
 jeU
-nBX
-tAR
 trK
-trK
-trK
+qHk
+diA
+diA
+diA
 nGf
-trK
-trK
-trK
-tAR
+diA
+diA
+diA
+qHk
 jeU
-nBX
+trK
 jeU
-nBX
-tAR
+trK
+qHk
 sCc
 sCc
 wuy
@@ -83718,7 +83923,7 @@ psI
 pnG
 bpE
 faw
-xLY
+dJx
 uej
 bNV
 bNV
@@ -83732,11 +83937,11 @@ qyr
 qyr
 uck
 odO
-hDf
-hDf
-hDf
-hDf
-hDf
+uQN
+uQN
+uQN
+uQN
+uQN
 cah
 ioB
 nPD
@@ -83813,10 +84018,10 @@ wuy
 wuy
 qQP
 lhT
-jdI
-jdI
-jdI
-jdI
+iwD
+iwD
+iwD
+iwD
 vTc
 qQP
 qQP
@@ -83826,10 +84031,10 @@ qQP
 qQP
 qQP
 pXJ
-tHs
-tHs
-tHs
-tHs
+wtM
+wtM
+wtM
+wtM
 rgW
 qQP
 wuy
@@ -83880,10 +84085,10 @@ qyr
 qyr
 qyr
 bHR
-qUM
-wpg
+iGQ
+rBW
 tWq
-gwR
+dFO
 fwd
 weY
 qyr
@@ -84144,7 +84349,7 @@ isV
 tXh
 uzD
 bAy
-dAF
+dUe
 ogk
 qVP
 qVP
@@ -84301,7 +84506,7 @@ nzy
 sjI
 bIh
 lyZ
-vDc
+gwR
 rUa
 qVP
 qVP
@@ -84509,7 +84714,7 @@ nGw
 qyr
 nDq
 xLA
-hDf
+uQN
 ejX
 mfG
 cPn
@@ -84519,7 +84724,7 @@ mfG
 pqx
 mfG
 mfG
-ldv
+hkQ
 wmg
 ust
 qyr
@@ -84676,7 +84881,7 @@ bNV
 vrG
 bNV
 bNV
-ctC
+sPO
 bNV
 bNV
 qyr
@@ -84771,8 +84976,8 @@ qMD
 gGE
 sVe
 yim
-yhZ
-wrl
+ldv
+dAF
 dOf
 qVP
 qVP
@@ -85147,7 +85352,7 @@ qVP
 qVP
 wCo
 gvH
-dSu
+bul
 olT
 jdO
 wCo
@@ -85304,7 +85509,7 @@ dTg
 dTg
 dTg
 cmX
-bul
+pQg
 isb
 tsI
 wCo
@@ -85453,7 +85658,7 @@ lJw
 cFv
 syO
 pgS
-xYm
+swY
 joj
 woI
 eZS
@@ -85610,7 +85815,7 @@ dmE
 cFv
 crs
 fLg
-hbF
+xYm
 dYv
 woI
 qZi
@@ -85884,9 +86089,9 @@ uxc
 wCJ
 vVb
 vVb
-sKg
-sKg
-sKg
+bYx
+bYx
+bYx
 mUn
 mUn
 mUn
@@ -86019,11 +86224,11 @@ xth
 xth
 xth
 xth
+hXO
 eIL
-rVJ
-rVJ
-wgV
-idt
+eIL
+mrN
+cYv
 xth
 fdA
 uOG
@@ -86039,12 +86244,12 @@ aNP
 aAq
 aGd
 aGd
-tQQ
+kdT
 kPt
 oyt
 egd
 kNZ
-iol
+eNn
 mUn
 mUn
 mUn
@@ -86179,7 +86384,7 @@ cNx
 aJZ
 llM
 gMP
-scS
+jxf
 tEB
 xth
 rRW
@@ -86196,11 +86401,11 @@ ghX
 ojj
 qAi
 vVb
-bKO
+tQQ
 pWI
-bYx
-bYx
-bYx
+hDf
+hDf
+hDf
 aBf
 mUn
 dpz
@@ -86336,7 +86541,7 @@ bUh
 oRx
 tYl
 hpF
-rUG
+kzw
 iVk
 xth
 nCJ
@@ -86348,7 +86553,7 @@ lSF
 gOY
 mHD
 nPN
-biA
+aHr
 icl
 ojj
 tit
@@ -86671,8 +86876,8 @@ gFX
 gFX
 gFX
 kih
-pcr
-lyQ
+ecu
+rvF
 fsT
 gvY
 qVP
@@ -86961,14 +87166,14 @@ kDP
 kDP
 eCA
 eCA
-ilJ
+slV
 eCA
 eCA
 pAx
 gbr
 pSi
 ukz
-uGU
+quL
 tfP
 hPr
 jgb
@@ -86976,7 +87181,7 @@ fBA
 tfj
 eFj
 mcE
-diA
+nta
 avK
 uiB
 pIx
@@ -87259,7 +87464,7 @@ tuc
 eSR
 rqy
 eSR
-mtQ
+upb
 eSR
 qVP
 qVP
@@ -87267,7 +87472,7 @@ gsG
 jIe
 kxC
 ccb
-koC
+afN
 ccb
 rib
 hmJ
@@ -87416,14 +87621,14 @@ tuc
 rqy
 tuc
 rqy
-mtQ
+upb
 rqy
 qVP
 qVP
 gsG
 gsG
 gsG
-qRY
+hnl
 adK
 ahD
 gsG
@@ -87573,7 +87778,7 @@ rqy
 rqy
 rqy
 rqy
-afp
+dpc
 rqy
 qVP
 qVP
@@ -87747,10 +87952,10 @@ qey
 qey
 fhe
 gsG
-tDb
-tDb
+kda
+kda
 uop
-tDb
+kda
 gsG
 djs
 nhz
@@ -87885,9 +88090,9 @@ qVP
 qVP
 rqy
 rqy
-ocO
-afp
-afp
+tuc
+dSu
+rqy
 srt
 qVP
 qVP
@@ -88040,8 +88245,8 @@ qVP
 rqy
 rqy
 rqy
-afp
-afp
+rqy
+jIA
 ocO
 rqy
 wyu
@@ -88194,10 +88399,10 @@ qVP
 qVP
 rqy
 rqy
-afp
-ocO
-ocO
-afp
+rqy
+gqh
+idt
+nkB
 rqy
 rqy
 rqy
@@ -88232,7 +88437,7 @@ bmS
 qMP
 pIG
 kNf
-upb
+nBX
 lwr
 hPz
 xwH
@@ -88348,10 +88553,10 @@ qVP
 qVP
 rqy
 rqy
-afp
-afp
-afp
-afp
+rqy
+rqy
+rqy
+dSu
 rqy
 qVP
 rqy
@@ -88505,9 +88710,9 @@ qVP
 rqy
 rqy
 rqy
-afp
 rqy
 rqy
+dSu
 rqy
 qVP
 qVP
@@ -88541,10 +88746,10 @@ cMl
 oaV
 vBz
 pee
-pvp
+afd
 jgI
 cAY
-swY
+mHB
 oTl
 sRF
 sRF
@@ -88662,8 +88867,8 @@ qVP
 qVP
 rqy
 rqy
-ocO
-rqy
+tuc
+bxY
 qVP
 qVP
 qVP
@@ -88697,11 +88902,11 @@ vPr
 ebH
 fjl
 hfM
-tZl
-xrd
+ihd
+own
 tKf
 jYX
-olt
+nRT
 qoR
 sRF
 keh
@@ -88819,8 +89024,8 @@ qVP
 qVP
 rqy
 rqy
-ocO
-rqy
+tuc
+dpc
 qVP
 qVP
 qVP
@@ -88976,8 +89181,8 @@ qVP
 qVP
 rqy
 rqy
-ocO
-ocO
+tuc
+tRt
 qVP
 qVP
 qVP
@@ -89007,7 +89212,7 @@ mpT
 eGf
 gkJ
 jZb
-cXc
+ylx
 kEE
 ebH
 kRQ
@@ -89134,7 +89339,7 @@ qVP
 qVP
 qVP
 rqy
-afp
+rqy
 afp
 qVP
 qVP
@@ -89164,8 +89369,8 @@ anZ
 eGf
 eAg
 sxb
-pYn
-wtM
+nDB
+mfY
 gkJ
 eAg
 feG
@@ -89292,8 +89497,8 @@ qVP
 qVP
 qVP
 rqy
-afp
-afp
+dxJ
+rqy
 rqy
 rqy
 rqy
@@ -89321,8 +89526,8 @@ aRD
 exz
 hFC
 gQv
+hLl
 tfU
-omf
 ohb
 ebH
 mbT
@@ -89451,7 +89656,7 @@ qVP
 qVP
 rqy
 afp
-afp
+rqy
 rqy
 rqy
 rHU
@@ -89607,10 +89812,10 @@ rqy
 rqy
 qVP
 qVP
-rqy
-afp
-afp
-rqy
+xKg
+ruE
+ruE
+ieM
 rHU
 rqy
 tuc
@@ -89766,10 +89971,10 @@ rqy
 qVP
 qVP
 rqy
-afp
-afp
-afp
-afp
+rqy
+xKg
+ruE
+ieM
 rqy
 rqy
 rqy
@@ -89926,7 +90131,7 @@ qVP
 qVP
 rqy
 rHU
-afp
+dpc
 rqy
 rqy
 rqy
@@ -90083,7 +90288,7 @@ qVP
 qVP
 qVP
 rHU
-hcc
+dpc
 rqy
 rqy
 rqy
@@ -90240,7 +90445,7 @@ qVP
 qVP
 iHy
 ruE
-pIj
+kZE
 rqy
 rqy
 rqy
@@ -90395,9 +90600,9 @@ rqy
 rqy
 rqy
 rqy
-hcc
+dpc
 rEA
-quR
+wrl
 rEA
 rEA
 sIt
@@ -90424,7 +90629,7 @@ naE
 mCH
 dvF
 hHs
-kkt
+lnN
 dwU
 blf
 blf
@@ -90552,9 +90757,9 @@ rqy
 rqy
 rqy
 rqy
-hcc
+dpc
 rek
-iaa
+npw
 jJJ
 wAN
 sIt
@@ -90709,12 +90914,12 @@ qVP
 rqy
 rqy
 rqy
-kTS
+pfG
 rEA
-oYE
+bZO
 jBo
-qHk
-aNc
+oYE
+quR
 ruE
 ieM
 rqy
@@ -90866,7 +91071,7 @@ qVP
 rqy
 tuc
 tuc
-hcc
+dpc
 rEA
 aQr
 oXp
@@ -111497,7 +111702,7 @@ wuy
 kBk
 dlm
 fLk
-uFg
+bGR
 uFg
 lse
 lse
@@ -111971,9 +112176,9 @@ wuy
 kBk
 tUT
 pOx
-rJc
-iwD
-iwD
+atK
+noU
+noU
 oyK
 kBk
 wuy
@@ -112128,7 +112333,7 @@ wuy
 kBk
 avB
 pOx
-vlp
+oym
 dRt
 bUr
 noU
@@ -112935,7 +113140,7 @@ hwG
 goF
 tgq
 fzN
-xdW
+kpP
 pAc
 bOE
 vvm
@@ -113564,7 +113769,7 @@ wuy
 wuy
 jfa
 vVU
-gqh
+gbS
 wuT
 wuT
 mkD
@@ -115134,10 +115339,10 @@ kRE
 bmz
 bmz
 bmz
-aRb
-jbI
-jbI
-jbI
+iol
+jdI
+jdI
+jdI
 ikZ
 fyZ
 rKj
@@ -115297,7 +115502,7 @@ mpQ
 mpQ
 eJO
 mpQ
-fNw
+eYM
 bCA
 qhL
 qhL
@@ -115453,8 +115658,8 @@ pyh
 ctS
 ctS
 pyh
-bkq
-hWp
+ftX
+rCm
 jfa
 czR
 ggl
@@ -115611,7 +115816,7 @@ qGr
 qQy
 pyh
 mpQ
-fNw
+eYM
 mpQ
 mpQ
 mpQ
@@ -115762,16 +115967,16 @@ aDi
 jlE
 pyh
 hyP
-lTu
+oID
 hch
 hch
 hQX
 pyh
 mpQ
-uQN
+rXK
 xbH
 eWW
-dJx
+rtX
 uUC
 mpQ
 jfa
@@ -116082,7 +116287,7 @@ sxJ
 jXz
 pyh
 mpQ
-eYM
+nmw
 cPJ
 tdy
 hFz
@@ -116242,7 +116447,7 @@ jjd
 xpH
 cPJ
 ncG
-byz
+iLi
 pzN
 cPJ
 wuy
@@ -116399,7 +116604,7 @@ mpQ
 xpH
 cPJ
 vsE
-iLi
+tCo
 bmZ
 cPJ
 wuy
@@ -116547,12 +116752,12 @@ lxS
 lxS
 bvM
 rJS
-dpc
-dpc
-dpc
-dpc
-dpc
-dpc
+jbI
+jbI
+jbI
+jbI
+jbI
+jbI
 ivq
 cPJ
 evB

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -210,10 +210,7 @@
 /area/station/hallway/primary/central)
 "afp" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "144"
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
@@ -423,12 +420,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "alr" = (
@@ -471,9 +462,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "amN" = (
@@ -838,6 +831,14 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
+"avq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "avB" = (
 /turf/open/openspace,
 /area/station/commons/lounge)
@@ -1227,11 +1228,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
-"aGi" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "aGC" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
@@ -1332,11 +1328,9 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
 "aJv" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "aJH" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -1467,6 +1461,15 @@
 	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/toilet/restrooms)
+"aOs" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "aOB" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/light/small/directional/south,
@@ -1520,6 +1523,9 @@
 "aPX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "aQd" = (
@@ -1547,18 +1553,6 @@
 /obj/effect/spawner/random/engineering/material,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"aQJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "aQL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -1885,7 +1879,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
@@ -1973,6 +1967,19 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"aZU" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "aZX" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/light/small/directional/west,
@@ -2053,8 +2060,10 @@
 "bbK" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "bbS" = (
@@ -2080,7 +2089,7 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "3"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
@@ -2271,9 +2280,11 @@
 /area/station/medical/storage)
 "bhd" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "bhD" = (
@@ -2393,19 +2404,6 @@
 /obj/structure/water_source/puddle,
 /turf/open/floor/grass,
 /area/station/service/library)
-"bkG" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "bkR" = (
 /obj/structure/table,
 /obj/effect/spawner/random/deadspace/ammo,
@@ -2479,6 +2477,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
+"bmH" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "bmJ" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -2751,18 +2758,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central/aft)
-"bsJ" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "bsW" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/machinery/computer/atmos_control/plasma_tank{
@@ -2896,6 +2891,16 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"bvS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "bwn" = (
 /obj/structure/rack,
 /obj/item/clothing/under/costume/pirate,
@@ -3016,15 +3021,6 @@
 /obj/structure/railing,
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
-"bzz" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/server)
 "bzD" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/item/bikehorn/airhorn,
@@ -3063,7 +3059,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "bAs" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "bAx" = (
@@ -3106,10 +3104,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"bAY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/commons/dorms/barracks/male)
 "bBh" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/closet/secure_closet/personal,
@@ -3225,6 +3219,8 @@
 "bEf" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "bEj" = (
@@ -3311,12 +3307,25 @@
 /obj/item/bodypart/leg/left/robot,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
+"bGq" = (
+/obj/structure/cable/multiz,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "bGB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 4
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"bGK" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "bGQ" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/yellow{
@@ -3410,14 +3419,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"bJn" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/break_room)
 "bJz" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/central)
@@ -3752,6 +3753,12 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"bSO" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "bSP" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -3770,6 +3777,13 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
+"bTd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/service/janitor)
 "bTh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3801,16 +3815,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
-"bTS" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/male)
 "bTT" = (
 /obj/structure/janitorialcart,
 /obj/effect/turf_decal/box,
@@ -3943,12 +3947,6 @@
 /obj/machinery/light/small/maintenance/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"bWQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "bWY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
@@ -4294,6 +4292,11 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
 "cgw" = (
@@ -4348,28 +4351,10 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
-"chz" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
 "chP" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
-"chW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "ciq" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
@@ -4384,9 +4369,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "ciE" = (
@@ -4449,11 +4436,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/cargo/storage)
-"clx" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "clD" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -5071,7 +5053,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "cBh" = (
@@ -5135,7 +5116,6 @@
 /area/aegis/surface)
 "cCP" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/starboard)
 "cCT" = (
@@ -5399,12 +5379,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
-"cIs" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/checkpoint/customs)
 "cIF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5452,12 +5426,23 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
-"cKw" = (
+"cKm" = (
 /obj/structure/cable/yellow{
-	icon_state = "68"
+	icon_state = "3"
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
+"cKw" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_right{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "cKy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -5550,6 +5535,9 @@
 "cMQ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "cMZ" = (
@@ -5707,14 +5695,6 @@
 /obj/item/clothing/mask/bandana/blue,
 /turf/open/floor/deadspace/hardwood,
 /area/station/maintenance/fore/lesser)
-"cQO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/carpet/red,
-/area/station/security/office)
 "cQY" = (
 /turf/open/floor/deadspace/mono,
 /area/station/security/lockers)
@@ -5804,13 +5784,11 @@
 /turf/open/water,
 /area/station/maintenance/port/lesser)
 "cUc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "12"
 	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "cUs" = (
 /obj/machinery/disposal/bin,
 /obj/effect/floor_decal/ds/spline/fancy/wood{
@@ -5825,7 +5803,10 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
@@ -5839,7 +5820,9 @@
 	},
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "cUQ" = (
@@ -5855,6 +5838,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"cVt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "cVO" = (
 /obj/machinery/flasher{
 	id = "Cell 4";
@@ -6024,12 +6015,6 @@
 	dir = 4
 	},
 /area/station/security/brig)
-"dag" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "daK" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/chief_medical_officer,
@@ -6160,6 +6145,13 @@
 /obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/deadspace/mono,
 /area/station/medical/exam_room)
+"dfR" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "dfY" = (
 /obj/machinery/light/directional/west,
 /obj/structure/railing,
@@ -6210,15 +6202,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "5"
 	},
-/turf/open/floor/iron/white,
-/area/station/service/kitchen)
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -6277,14 +6266,6 @@
 /obj/item/plate_shard/marker_shard,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
-"dkf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "dki" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/norn,
@@ -6507,6 +6488,16 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
+"dqH" = (
+/obj/machinery/light/directional/north,
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "dqU" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/grater,
@@ -6702,6 +6693,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
+"dxJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "dxM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
@@ -6840,8 +6837,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -6933,14 +6933,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
-"dDl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "dDu" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/side{
@@ -7190,10 +7182,10 @@
 /area/station/cargo/drone_bay)
 "dJx" = (
 /obj/structure/cable/yellow{
-	icon_state = "40"
+	icon_state = "3"
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
@@ -7303,6 +7295,12 @@
 "dMI" = (
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/fore/lesser)
+"dMZ" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "dNz" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
@@ -7374,7 +7372,9 @@
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/female)
 "dPG" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "dQh" = (
@@ -7467,13 +7467,10 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "9"
 	},
 /turf/open/floor/iron/dark,
-/area/station/science/breakroom)
+/area/station/medical/break_room)
 "dSB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -7592,11 +7589,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "dUe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "dUl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -7630,25 +7628,6 @@
 	dir = 4
 	},
 /area/mine/production)
-"dUu" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
-"dUL" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "dUU" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -7667,16 +7646,6 @@
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/checkpoint/science)
-"dVu" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "dVv" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/box,
@@ -7700,18 +7669,6 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/dorms/cryo)
-"dWl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "dWo" = (
 /obj/structure/rack{
 	icon = 'icons/obj/stationobjs.dmi';
@@ -7907,6 +7864,14 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"eby" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "ebG" = (
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
@@ -7934,7 +7899,6 @@
 	pixel_x = 20
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "ecy" = (
@@ -8065,11 +8029,17 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "efO" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
+/obj/structure/chair/office{
+	dir = 8
 	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "efQ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -8301,6 +8271,14 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"eme" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "emt" = (
 /obj/structure/railing/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8394,8 +8372,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "epg" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "eph" = (
@@ -8501,6 +8482,18 @@
 	},
 /turf/open/floor/eighties/red,
 /area/aegis/surface)
+"esS" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "etp" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -8961,16 +8954,6 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
-"eEL" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/female)
 "eET" = (
 /obj/machinery/computer/security,
 /obj/machinery/computer/security/telescreen{
@@ -9185,7 +9168,13 @@
 "eIL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/monitoring)
@@ -9699,6 +9688,18 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"eXY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "eYu" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9715,10 +9716,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
@@ -9888,12 +9886,6 @@
 "fdT" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "8"
 	},
 /turf/open/floor/plating,
@@ -9906,15 +9898,19 @@
 	},
 /area/station/hallway/primary/starboard)
 "feD" = (
-/obj/machinery/door/airlock/mining{
-	name = "Cargo Bay";
-	req_one_access_txt = "31;48"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/door/firedoor,
+/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "feG" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Distribution Loop";
@@ -9944,16 +9940,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ffw" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "ffz" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -10102,7 +10093,9 @@
 "fjr" = (
 /obj/structure/table,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "fju" = (
@@ -10159,7 +10152,9 @@
 /area/station/service/hydroponics/upper)
 "fkx" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo)
 "fkE" = (
@@ -10205,14 +10200,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/misc_lab)
 "flr" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "6"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/hallway/secondary/exit/departure_lounge)
 "flJ" = (
 /obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron/dark,
@@ -10269,6 +10264,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/miningoffice)
+"fnB" = (
+/obj/structure/cable/yellow{
+	icon_state = "24"
+	},
+/turf/open/floor/plating,
+/area/aegis/surface)
 "fnQ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/box,
@@ -10295,6 +10296,16 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/maintenance/fore/lesser)
+"foq" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "foz" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -10476,16 +10487,11 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "fsl" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/maint_right{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/checkpoint/customs)
 "fsz" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/conveyor{
@@ -10514,6 +10520,9 @@
 /area/station/engineering/main)
 "fts" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/cargo/qm)
 "ftv" = (
@@ -10594,10 +10603,10 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/customs)
 "fwp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "fwt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10668,7 +10677,6 @@
 /area/station/command/heads_quarters/hos)
 "fzw" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
@@ -10723,17 +10731,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "fBC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "fCw" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -10915,6 +10918,17 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/maintenance/fore/lesser)
+"fIK" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "fIM" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/hydroponics/constructable,
@@ -10923,6 +10937,8 @@
 "fJe" = (
 /obj/structure/frame/computer,
 /obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "fJj" = (
@@ -11127,14 +11143,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"fOK" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/breakroom)
 "fOP" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
@@ -11261,14 +11269,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
-"fRr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "fRC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/firealarm/directional/east,
@@ -11375,6 +11375,8 @@
 "fTI" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "fTX" = (
@@ -11644,6 +11646,7 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "gbS" = (
+/obj/structure/lattice,
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -11879,17 +11882,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"gjU" = (
-/obj/structure/cable/multiz,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "gka" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "gkf" = (
@@ -12036,6 +12034,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
+"gnX" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "goF" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/box,
@@ -12120,15 +12124,13 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/red{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/deadspace/medical,
+/area/station/medical/morgue)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -12158,6 +12160,16 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"gqW" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/female)
 "grv" = (
 /obj/machinery/telephone,
 /turf/open/floor/plating,
@@ -12234,6 +12246,14 @@
 /obj/item/stack/sheet/mineral/plasma/five,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
+"gto" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "guc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood{
@@ -12248,13 +12268,19 @@
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/captain)
 "guQ" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/clothing/costume,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "gva" = (
 /obj/structure/railing,
 /turf/open/floor/deadspace/random/rectangles,
@@ -12304,14 +12330,9 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "gxI" = (
 /obj/structure/cable/yellow{
 	icon_state = "3"
@@ -13021,17 +13042,6 @@
 /obj/machinery/vending/games,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/security/courtroom)
-"gSl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "gSA" = (
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen/double,
@@ -13240,7 +13250,6 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "gXh" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 8
 	},
@@ -13280,6 +13289,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
+"gXW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "gXY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -13399,7 +13419,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
@@ -13732,6 +13752,23 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"hmB" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Cargo Privacy";
+	name = "Cargo Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "hmJ" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
@@ -13884,6 +13921,15 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
+"hqi" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "hqn" = (
 /obj/structure/disposalpipe/junction/flip,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -13994,16 +14040,6 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/deadspace/mono,
 /area/aegis/mining)
-"htm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
 "htp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -14300,12 +14336,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/security/courtroom)
-"hzt" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "hzL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -14417,14 +14447,25 @@
 /area/station/service/chapel)
 "hDf" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/machinery/door/poddoor/preopen{
+	id = "Cargo Privacy";
+	name = "Cargo Shutters"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2"
 	},
 /turf/open/floor/plating,
-/area/station/security/brig)
+/area/station/cargo/qm)
+"hDp" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "hDv" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/customs)
@@ -14759,6 +14800,12 @@
 "hLX" = (
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/starboard)
+"hMw" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "hMz" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/power/floodlight,
@@ -14768,6 +14815,8 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/box,
 /obj/effect/spawner/random/deadspace/ammo,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "hMX" = (
@@ -15265,7 +15314,6 @@
 /area/station/commons/dorms/barracks/male)
 "iae" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "iap" = (
@@ -15349,13 +15397,14 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 4
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/area/station/security/brig)
+/area/aegis/surface)
 "idy" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor{
@@ -15467,6 +15516,17 @@
 "ifl" = (
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/female)
+"ifE" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "ifO" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -15522,9 +15582,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "igF" = (
@@ -15595,12 +15657,16 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lesser)
 "iix" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/security/warden)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "iiK" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -15679,6 +15745,14 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
+"ijA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "ijC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
@@ -15798,7 +15872,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "ilS" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "ilU" = (
@@ -15844,14 +15920,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "imS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "imT" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -15888,10 +15960,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "iol" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/misc/ironsand,
 /area/aegis/surface)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
@@ -16047,12 +16118,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
-"iuc" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "iup" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/cmo)
@@ -16074,6 +16139,19 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/deadspace/cable,
 /area/station/hallway/secondary/exit/departure_lounge)
+"ivi" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "ivk" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/deadspace/mono,
@@ -16087,13 +16165,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
-"ivr" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "ivz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16153,11 +16224,10 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "iwD" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/grille_spare3,
-/area/station/security/checkpoint/customs)
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "iwK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -16375,11 +16445,16 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
 	},
-/turf/open/floor/plating,
-/area/aegis/surface)
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "iCm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate/large/ds/green_horizontal,
@@ -16445,6 +16520,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse/upper)
+"iDC" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/norn,
+/area/station/hallway/primary/starboard)
 "iDL" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/sheet/mineral/diamond,
@@ -16464,6 +16547,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"iEi" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "iEq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
@@ -16718,6 +16810,8 @@
 "iIX" = (
 /obj/machinery/rnd/production/fabricator/department/cargo,
 /obj/structure/window/reinforced/spawner/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "iJe" = (
@@ -16739,9 +16833,18 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "iJI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "iJV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 4
@@ -17268,6 +17371,13 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central/aft)
+"iUB" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "iVk" = (
 /obj/structure/table,
 /obj/machinery/power/data_terminal,
@@ -17429,13 +17539,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
-"iZx" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "iZD" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -17474,7 +17577,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
@@ -17507,10 +17613,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
@@ -17564,16 +17667,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jdI" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "12"
 	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/ce)
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "jdK" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -17598,10 +17696,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "jeU" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
 	},
+/obj/structure/lattice,
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -17705,6 +17803,15 @@
 /obj/structure/railing,
 /turf/open/floor/deadspace/roller,
 /area/aegis/surface)
+"jhA" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/hallway/primary/port)
 "jhB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced/grille,
@@ -17742,7 +17849,6 @@
 /area/mine/storage)
 "jij" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
@@ -18103,9 +18209,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "jpj" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/sorting)
 "jpm" = (
@@ -18137,8 +18245,6 @@
 	c_tag = "Cargo Bay - Aft";
 	pixel_x = 14
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "jpN" = (
@@ -18259,6 +18365,20 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
+"jsg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "jsp" = (
 /obj/effect/spawner/random/trash/garbage{
 	spawn_loot_count = 3
@@ -18384,12 +18504,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"juJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "jvn" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/air_input{
 	dir = 8
@@ -18472,6 +18586,20 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"jxs" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "jxE" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
@@ -18532,12 +18660,6 @@
 	dir = 1
 	},
 /area/aegis/hanger)
-"jzK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/station/commons/lounge)
 "jAf" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8;
@@ -19173,7 +19295,7 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "3"
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
@@ -19252,7 +19374,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
@@ -19274,6 +19396,20 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
+"jUc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/medbay/aft)
 "jUL" = (
 /obj/structure/sign/cec/deck{
 	pixel_y = 34
@@ -19290,6 +19426,14 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/hanger)
+"jVj" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "jVx" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/deadspace/ammo/security,
@@ -19503,6 +19647,15 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"kaD" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "kaO" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/iron/dark,
@@ -19598,6 +19751,13 @@
 /obj/effect/spawner/random/food_or_drink/snack,
 /turf/open/floor/plating,
 /area/aegis/surface)
+"kdT" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "keh" = (
 /obj/machinery/power/smes/engineering{
 	input_level = 60000;
@@ -19880,6 +20040,15 @@
 	},
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
+"kiR" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/grille_spare3,
+/area/station/security/checkpoint/customs)
 "kiW" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/box,
@@ -20003,16 +20172,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
-"knc" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
-	},
-/obj/structure/cable/red{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "knr" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/sunglasses,
@@ -20036,14 +20195,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
-"knH" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
 "knS" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -20082,33 +20233,15 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "kpk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
+/obj/structure/cable/red{
+	icon_state = "1"
 	},
-/turf/open/floor/deadspace/random/maint_center{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
-"kpq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "kpy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -20121,11 +20254,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/clothing/costume,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -20176,9 +20317,13 @@
 	name = "Front Desk";
 	req_one_access_txt = "50"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "krD" = (
@@ -20463,14 +20608,6 @@
 /obj/machinery/pdapainter/research,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"kBA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "kBD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -20485,19 +20622,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
-"kBE" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "kBN" = (
 /obj/effect/landmark/pestspawn,
 /turf/open/floor/deadspace/random/maint_left{
@@ -20512,7 +20636,6 @@
 /area/station/medical/medbay/central)
 "kCt" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "kCF" = (
@@ -20578,7 +20701,6 @@
 /area/station/engineering/storage_shared)
 "kDC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
@@ -20590,11 +20712,14 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
 "kDP" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "144"
+	icon_state = "3"
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "kEv" = (
 /obj/item/megaphone,
 /obj/structure/table/wood,
@@ -20844,9 +20969,11 @@
 	departmentType = 2;
 	name = "Quartermaster's Requests Console"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "kLI" = (
@@ -21412,6 +21539,16 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/command)
+"kZk" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "kZA" = (
 /obj/structure/sink{
 	dir = 8;
@@ -21452,6 +21589,20 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
+"laC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "laL" = (
 /turf/open/floor/deadspace/bathroom,
 /area/station/medical/morgue)
@@ -21583,18 +21734,11 @@
 /area/station/science/breakroom)
 "ldv" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "miningsecprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2"
 	},
 /turf/open/floor/plating,
-/area/station/security/checkpoint/science)
+/area/station/security/brig)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -21699,10 +21843,12 @@
 	name = "Drone Bay";
 	req_access_txt = "31"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "lgw" = (
@@ -21722,6 +21868,9 @@
 	pixel_y = -2
 	},
 /obj/machinery/camera/autoname/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "lgT" = (
@@ -21777,7 +21926,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "lhH" = (
@@ -21891,12 +22039,6 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
-"lkZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "lli" = (
 /obj/machinery/power/floodlight,
 /turf/open/floor/plating,
@@ -22036,6 +22178,20 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
+"loc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "loo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22070,8 +22226,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "lpq" = (
@@ -22196,6 +22354,9 @@
 "lue" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "luo" = (
@@ -22271,20 +22432,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
-"lwU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/medbay/aft)
 "lwW" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -22414,10 +22561,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "9"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -22537,6 +22681,13 @@
 "lDu" = (
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse)
+"lDx" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "lDy" = (
 /obj/structure/rack/shelf,
 /obj/item/storage/book/bible/unitology,
@@ -22587,6 +22738,12 @@
 /obj/structure/table,
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
+"lFI" = (
+/obj/structure/cable/yellow{
+	icon_state = "132"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "lFN" = (
 /obj/structure/closet/jcloset,
 /turf/open/floor/deadspace/random/maint_right,
@@ -22620,14 +22777,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/wood,
 /area/station/service/bar)
-"lGU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/morgue)
 "lHc" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -22953,6 +23102,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/item/folder/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "lOT" = (
@@ -23116,6 +23270,18 @@
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
+"lTl" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "lTt" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/east,
@@ -23452,8 +23618,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
@@ -23582,7 +23746,6 @@
 /area/station/cargo/warehouse/upper)
 "mhg" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
@@ -23661,13 +23824,6 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
-"mka" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/service/janitor)
 "mkp" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/deadspace/grater,
@@ -23689,14 +23845,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
-"mlo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "mlt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -23838,11 +23986,10 @@
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "mou" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "moB" = (
 /obj/machinery/door/airlock/hydroponics/glass{
 	name = "Abandoned Hydroponics";
@@ -24065,7 +24212,7 @@
 /area/station/hallway/primary/fore)
 "mtQ" = (
 /obj/structure/cable/yellow{
-	icon_state = "24"
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/aegis/surface)
@@ -24191,6 +24338,13 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
+"mxq" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "mxv" = (
 /obj/structure/chair,
 /turf/open/floor/deadspace/random/rectangles,
@@ -24297,7 +24451,6 @@
 	name = "Aegis Cargo"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -24309,11 +24462,14 @@
 /turf/open/floor/engine,
 /area/station/command/heads_quarters/rd)
 "mBv" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "mBz" = (
 /obj/machinery/door/airlock/medical{
 	name = "Bioprosthetics Lab";
@@ -24339,17 +24495,11 @@
 	},
 /area/mine/production)
 "mCd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/commons/dorms/cryo)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "mCl" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/east,
@@ -24479,7 +24629,9 @@
 "mEu" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "mEz" = (
@@ -24587,17 +24739,6 @@
 	},
 /turf/open/water,
 /area/station/hallway/primary/aft)
-"mJT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "mJY" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/ten,
@@ -25278,7 +25419,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "nbJ" = (
@@ -25348,7 +25494,7 @@
 /area/station/maintenance/fore/lesser)
 "ncO" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
@@ -25425,9 +25571,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "ngl" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "ngs" = (
@@ -25462,6 +25610,12 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"nhi" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "nhw" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/cee{
 	dir = 8
@@ -25735,8 +25889,12 @@
 "nqi" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/structure/chair/office,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "nqw" = (
@@ -25772,6 +25930,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
+"nrT" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/security/warden)
 "nrV" = (
 /obj/machinery/photocopier,
 /obj/item/toner,
@@ -25820,13 +25985,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"nsG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "nth" = (
 /obj/machinery/light,
 /turf/open/misc/asteroid,
@@ -25870,13 +26028,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"nvs" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "nvH" = (
 /obj/structure/rack,
 /obj/item/plant_analyzer,
@@ -25971,6 +26122,13 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"nyJ" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "nyU" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/qm)
@@ -26095,6 +26253,12 @@
 	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
+"nAO" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "nAP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -26156,13 +26320,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "nBX" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "nCk" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -26481,6 +26646,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
+"nLT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "nLV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -26601,14 +26774,15 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "nOQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/floor_decal/ds/spline/fancy/wood{
+	dir = 8
 	},
-/obj/structure/cable/white{
-	icon_state = "132"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/station/service/chapel/monastery)
+/turf/open/floor/carpet/royalblue,
+/area/station/service/library)
 "nOX" = (
 /obj/machinery/cryopod,
 /obj/effect/landmark/latejoin,
@@ -26643,6 +26817,12 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
+"nPt" = (
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "nPD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -26806,6 +26986,27 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"nTW" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "nTY" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/west,
@@ -26936,9 +27137,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "nYh" = (
@@ -27079,7 +27278,7 @@
 /area/station/command/bridge)
 "ocO" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "129"
 	},
 /turf/open/misc/ironsand,
 /area/aegis/surface)
@@ -27133,9 +27332,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
@@ -27316,6 +27512,13 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
+"oiD" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "oiJ" = (
 /obj/machinery/modular_computer/console/preset/cargochat/security{
 	dir = 8
@@ -27644,19 +27847,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"oqx" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "oqy" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /obj/structure/cable/yellow{
 	icon_state = "2"
 	},
@@ -27736,6 +27931,13 @@
 "osC" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
+"osG" = (
+/obj/effect/turf_decal/box,
+/obj/effect/spawner/random/clothing/wardrobe_closet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "osQ" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
@@ -27834,16 +28036,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
-"ovS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "ovV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -28128,6 +28320,15 @@
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"oDX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "oEw" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 4
@@ -28216,6 +28417,20 @@
 	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
+"oGE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "oGW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -28362,8 +28577,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/disposal)
 "oKC" = (
@@ -28405,7 +28623,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "oMt" = (
@@ -28509,6 +28732,18 @@
 	},
 /turf/open/openspace,
 /area/station/command/bridge)
+"oPG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "oQa" = (
 /obj/structure/chair{
 	dir = 4
@@ -28673,6 +28908,16 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
+"oTz" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/male)
 "oTC" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -28697,9 +28942,14 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/hallway/primary/central)
 "oUk" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "oUu" = (
@@ -28710,6 +28960,20 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"oUz" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "oUN" = (
 /obj/structure/bed/pod{
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
@@ -28813,20 +29077,6 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"oXx" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "oXC" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -28909,6 +29159,10 @@
 "oZq" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "oZw" = (
@@ -29125,14 +29379,16 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "pfG" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/hallway/primary/central)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "pfH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -29202,26 +29458,14 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"phJ" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "P-Sec Brig";
-	req_access_txt = "63";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
+"phE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "5"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
+/turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "piB" = (
 /obj/structure/railing{
@@ -29408,15 +29652,11 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "pmS" = (
-/obj/effect/floor_decal/ds/spline/fancy/wood{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/carpet/royalblue,
-/area/station/service/library)
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "pnj" = (
 /obj/structure/railing{
 	dir = 6
@@ -29511,8 +29751,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "pqx" = (
@@ -29560,9 +29802,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "prT" = (
@@ -29742,6 +29986,13 @@
 /obj/structure/table/wood/fancy/red,
 /turf/open/floor/wood,
 /area/station/service/chapel)
+"pxh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/maintenance/fore/greater)
 "pxs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -29792,9 +30043,11 @@
 /obj/structure/table/reinforced,
 /obj/machinery/telephone/cargo,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "pyD" = (
@@ -29842,13 +30095,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
-"pzM" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "pzN" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical,
@@ -29970,15 +30216,13 @@
 	dir = 1
 	},
 /area/aegis/hanger)
-"pBG" = (
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "pCh" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "pCn" = (
@@ -30126,6 +30370,14 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
+"pFS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/morgue)
 "pGh" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 4
@@ -30133,7 +30385,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
 "pGu" = (
@@ -30141,8 +30395,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "pGC" = (
@@ -30230,6 +30486,13 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
+"pIJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "pIO" = (
 /obj/structure/ladder/invincible,
 /turf/open/floor/deadspace/mono,
@@ -30452,6 +30715,19 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
+"pNZ" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/white,
+/area/station/service/kitchen)
 "pOk" = (
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 1;
@@ -30562,6 +30838,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "pQl" = (
@@ -30596,6 +30874,12 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"pRj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "pRl" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -30679,7 +30963,9 @@
 /obj/machinery/computer/security/qm{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "pVm" = (
@@ -30851,9 +31137,11 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "pZg" = (
@@ -30913,9 +31201,11 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "qbL" = (
@@ -30952,7 +31242,9 @@
 	id = "Cargo Privacy";
 	name = "Cargo Shutters"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/qm)
 "qct" = (
@@ -31046,7 +31338,9 @@
 /obj/structure/table,
 /obj/machinery/telephone/cargo,
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/lobby)
 "qfr" = (
@@ -31162,11 +31456,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
-"qhC" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
 "qhK" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -31377,9 +31666,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/landmark/navigate_destination,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "qnp" = (
@@ -31569,8 +31860,13 @@
 /area/station/science/research)
 "qrQ" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "qrX" = (
@@ -31579,6 +31875,11 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
+"qsb" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "qsq" = (
 /turf/open/floor/deadspace/random/maint_right{
 	dir = 8
@@ -31632,13 +31933,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse/upper)
-"qtx" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "qtB" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -31740,7 +32034,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -31775,6 +32069,12 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/male)
+"qwm" = (
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "qwp" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/right,
@@ -31918,14 +32218,16 @@
 /turf/open/floor/iron/norn,
 /area/station/medical/office)
 "qAY" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/hallway/primary/port)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "qBi" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
@@ -31951,7 +32253,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "qDn" = (
@@ -32046,14 +32350,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
-"qES" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/exam_room)
 "qEV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/pestspawn,
@@ -32092,10 +32388,6 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"qGh" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "qGi" = (
 /obj/structure/sign/cec/deck/security{
 	pixel_y = -32
@@ -32115,19 +32407,22 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qHk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Mining Privacy";
+	name = "Mining Shutters"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "10"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -32160,6 +32455,14 @@
 	dir = 1
 	},
 /area/station/security/brig)
+"qHT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/wood,
+/area/station/cargo/qm)
 "qIi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32200,9 +32503,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "qJb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "qJr" = (
@@ -32214,20 +32519,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"qJF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "qJH" = (
 /obj/structure/chair{
 	dir = 4
@@ -32318,9 +32609,13 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "qMP" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "qMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -32397,12 +32692,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
-"qON" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "qOQ" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/grater,
@@ -32595,7 +32884,6 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
 "qUK" = (
@@ -32609,16 +32897,14 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "qUM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/hallway/primary/central)
 "qVj" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
@@ -32627,6 +32913,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/hanger)
+"qVk" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "qVv" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
@@ -32821,16 +33114,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"raj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/floor/has_bulb,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "ran" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
@@ -32851,15 +33134,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
-"rbA" = (
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/hallway/secondary/exit/departure_lounge)
 "rbD" = (
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
@@ -32997,7 +33271,9 @@
 /turf/open/floor/stone,
 /area/aegis/surface)
 "rfJ" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo)
 "rfR" = (
@@ -33094,7 +33370,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "3"
 	},
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
@@ -33197,6 +33473,14 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/female)
+"rlb" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
+	},
+/area/station/security/brig)
 "rlg" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/tool,
@@ -33249,13 +33533,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "rlW" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+	dir = 8
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
+/turf/open/floor/wood,
+/area/station/cargo/qm)
 "rma" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Cryo - Left"
@@ -33420,13 +33702,6 @@
 "rqy" = (
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"rqC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
 "rqH" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table,
@@ -33449,6 +33724,11 @@
 /area/station/maintenance/fore/lesser)
 "rrw" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/cargo/lobby)
 "rrP" = (
@@ -33537,11 +33817,14 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "rui" = (
@@ -33741,17 +34024,6 @@
 /obj/effect/spawner/random/deadspace/ammo/mining,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
-"rAp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "rAt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/deadspace/mono,
@@ -33889,13 +34161,15 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "rDI" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig/upper)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "rDN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -34003,9 +34277,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/landmark/pestspawn,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "rIo" = (
@@ -34038,9 +34314,8 @@
 	name = "Cargo Privacy Control";
 	id = "Cargo Privacy"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
@@ -34086,7 +34361,9 @@
 	pixel_y = -3
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "rJS" = (
@@ -34361,6 +34638,10 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/secondary/service)
+"rRl" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "rRv" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -34485,7 +34766,15 @@
 	dir = 5
 	},
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "rVz" = (
@@ -34523,9 +34812,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
 /turf/open/floor/deadspace/grille_spare3,
 /area/station/security/checkpoint/customs)
 "rWy" = (
@@ -34554,11 +34840,14 @@
 /turf/open/floor/plating,
 /area/station/medical/surgery/theatre)
 "rXD" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/brig)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/commons/dorms/cryo)
 "rXE" = (
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
@@ -34668,6 +34957,18 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"sdf" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "sdl" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/bot,
@@ -35008,16 +35309,6 @@
 /obj/item/stack/ore/diamond,
 /turf/open/misc/asteroid,
 /area/station/hallway/primary/fore)
-"snm" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "snn" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/medical/medkit_rare,
@@ -35253,6 +35544,20 @@
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
+"sup" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "suq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35282,6 +35587,18 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
+"svh" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "svo" = (
 /obj/structure/rack/shelf,
 /obj/effect/turf_decal/bot_white,
@@ -35341,12 +35658,19 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "swY" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
+/obj/structure/disposalpipe/junction{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -35421,13 +35745,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
-"syh" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "syO" = (
 /obj/structure/table/glass,
 /obj/machinery/light/cold/directional/north,
@@ -35495,12 +35812,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"sAI" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "sAQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
@@ -35536,11 +35847,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "sCc" = (
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
-/area/aegis/surface)
+/turf/open/floor/deadspace/mono,
+/area/station/cargo/sorting)
 "sCd" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/random/maintenance/two,
@@ -35613,12 +35926,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
-"sDR" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "sDZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/flashlight,
@@ -35793,7 +36100,6 @@
 /area/aegis/mining)
 "sJV" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -35865,15 +36171,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
-"sMz" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "sMK" = (
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -35989,16 +36286,19 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sPk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "sPH" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/bot,
@@ -36262,6 +36562,10 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
+"sWd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/commons/dorms/barracks/male)
 "sWE" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/deadspace/heavy,
@@ -36465,9 +36769,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tda" = (
@@ -36511,6 +36812,13 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/kitchen_coldroom,
 /area/station/medical/coldroom)
+"teI" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "teS" = (
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
@@ -36659,6 +36967,13 @@
 "thU" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/warehouse/upper)
+"thV" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "tij" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -36737,6 +37052,12 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
+"tkg" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "tkF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -36755,15 +37076,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
-"tlV" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "tmd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -36817,10 +37129,12 @@
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "tmZ" = (
@@ -36910,14 +37224,13 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "trK" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "9"
 	},
-/turf/open/floor/wood,
-/area/station/medical/psychology)
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "trL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37043,6 +37356,9 @@
 /obj/item/computer_hardware/hard_drive/role/quartermaster,
 /obj/item/computer_hardware/hard_drive/role/quartermaster,
 /obj/item/computer_hardware/hard_drive/role/quartermaster,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "tuG" = (
@@ -37448,14 +37764,15 @@
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/male)
 "tIj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "tIu" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_right,
@@ -37494,9 +37811,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "tKw" = (
@@ -37505,12 +37824,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"tKz" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "tKA" = (
 /obj/item/restraints/legcuffs/beartrap,
 /obj/item/restraints/legcuffs/beartrap,
@@ -37557,6 +37870,20 @@
 /obj/structure/table,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"tLv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "tLZ" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
@@ -37576,6 +37903,17 @@
 	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/maintenance/port/lesser)
+"tMD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "tME" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
@@ -37599,10 +37937,7 @@
 	name = "Aegis Cargo"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -37617,11 +37952,16 @@
 	},
 /area/station/hallway/primary/starboard)
 "tNh" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Mining Privacy";
+	name = "Mining Shutters"
 	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "tNI" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4;
@@ -37697,7 +38037,10 @@
 "tQQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
@@ -37753,9 +38096,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "tSh" = (
@@ -37906,7 +38251,6 @@
 /turf/open/water,
 /area/station/hallway/primary/aft)
 "tVH" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
@@ -37987,6 +38331,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
+"tXY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "tYc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/keycard_auth/directional/east,
@@ -38001,13 +38353,6 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
-"tYh" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "tYl" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -38047,9 +38392,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "tZw" = (
@@ -38076,9 +38423,11 @@
 /area/station/hallway/secondary/exit)
 "uaF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "ubd" = (
@@ -38276,9 +38625,11 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
 "uhr" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "uhA" = (
@@ -38584,16 +38935,16 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
 "upb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "1"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/ce)
 "upl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -38682,10 +39033,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "ure" = (
@@ -38829,10 +39182,10 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "uuS" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "uvc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -38891,6 +39244,16 @@
 	dir = 1
 	},
 /area/aegis/mining)
+"uwL" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "uwQ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -38929,14 +39292,11 @@
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation)
 "uyg" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "uyk" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/vending/hydroseeds,
@@ -38955,6 +39315,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"uyJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "132"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/service/chapel/monastery)
 "uyL" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
@@ -39085,27 +39454,17 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
-"uBu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
-"uBx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
 "uBz" = (
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 2
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo)
 "uBM" = (
@@ -39222,6 +39581,14 @@
 "uFg" = (
 /turf/open/floor/carpet/red,
 /area/station/commons/lounge)
+"uFr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "uFs" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment,
@@ -39283,16 +39650,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "miningsecprivacy";
-	name = "privacy shutter"
-	},
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "12"
 	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/science)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39307,7 +39672,6 @@
 	req_one_access_txt = "31;48"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
@@ -39356,15 +39720,6 @@
 /obj/machinery/light/small/maintenance/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"uJP" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "uKg" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -39418,7 +39773,9 @@
 	id = "Mining Privacy";
 	name = "Mining Shutters"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/qm)
 "uLE" = (
@@ -39522,6 +39879,10 @@
 "uOK" = (
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
+"uOU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "uOY" = (
 /obj/machinery/light/directional/east,
 /turf/open/misc/asteroid,
@@ -39572,12 +39933,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "2"
+	icon_state = "10"
 	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
+/turf/open/floor/deadspace/medical,
+/area/station/medical/exam_room)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -39788,6 +40150,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
 "uWt" = (
@@ -39840,11 +40205,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "uXv" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "uXE" = (
@@ -39865,6 +40233,12 @@
 /obj/structure/curtain,
 /turf/open/floor/deadspace/grille_spare4,
 /area/station/commons/dorms/barracks/male)
+"uXQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/station/commons/lounge)
 "uXT" = (
 /obj/machinery/autolathe,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -40410,12 +40784,13 @@
 /turf/closed/wall/r_wall,
 /area/mine/hydroponics)
 "vmK" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "vmO" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -40463,12 +40838,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/aft)
-"vpn" = (
-/obj/structure/cable/yellow{
-	icon_state = "132"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "vpw" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
@@ -40552,14 +40921,6 @@
 "vri" = (
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
-"vrr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "vrv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40573,15 +40934,6 @@
 /obj/machinery/camera/motion/directional/east,
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/brig)
-"vrH" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "vrN" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -40673,6 +41025,10 @@
 "vtr" = (
 /obj/effect/landmark/navigate_destination/cargo,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "vtX" = (
@@ -40757,10 +41113,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vwz" = (
-/obj/effect/floor_decal/ds/spline/fancy/wood,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/carpet/royalblack,
-/area/station/cargo/lobby)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "vwZ" = (
 /obj/structure/sign/cec/deck/research{
 	pixel_y = -32
@@ -41064,8 +41424,11 @@
 	dir = 9
 	},
 /obj/effect/landmark/navigate_destination/disposals,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "vFk" = (
@@ -41104,16 +41467,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
-"vGe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/computer)
 "vGr" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/prepainted/daedalus,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -41163,17 +41516,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
-"vHR" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
 "vHV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 10
@@ -41202,18 +41546,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
-"vII" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
 "vIJ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -41367,6 +41699,17 @@
 /obj/machinery/light/small/maintenance/directional/north,
 /turf/open/water,
 /area/station/maintenance/fore/lesser)
+"vLN" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "vLT" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/material,
@@ -41951,9 +42294,14 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/pharmacy)
 "wbX" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/sorting)
 "wcc" = (
@@ -42027,11 +42375,11 @@
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "weG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "weI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/mono,
@@ -42223,7 +42571,6 @@
 /area/station/hallway/primary/starboard)
 "wjU" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
@@ -42271,6 +42618,9 @@
 	pixel_y = -2
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "wlw" = (
@@ -42407,12 +42757,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/maintenance/fore/greater)
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "wpl" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
@@ -42497,13 +42846,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "wrl" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
+/turf/open/misc/asteroid,
 /area/aegis/surface)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -42531,8 +42877,12 @@
 /area/station/science/robotics/lab)
 "wrD" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
 "wrV" = (
@@ -42583,13 +42933,10 @@
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "wtM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/morgue)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -42902,6 +43249,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
 "wEm" = (
@@ -43020,6 +43375,9 @@
 	name = "Dud Rocket";
 	pixel_x = -4;
 	pixel_y = -7
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/carpet/red,
 /area/station/cargo/qm)
@@ -43249,8 +43607,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/supply{
 	pixel_y = -32
@@ -43461,6 +43817,15 @@
 "wUC" = (
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
+"wUD" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "wUW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -43789,6 +44154,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/hallway/primary/central/aft)
+"xda" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "xdu" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/deadspace/random/maint_right{
@@ -43842,10 +44213,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/office)
 "xdQ" = (
@@ -44077,6 +44450,18 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/catwalk_floor,
 /area/station/command/bridge)
+"xjn" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "xjr" = (
 /obj/item/cultivator,
 /obj/item/crowbar,
@@ -44266,8 +44651,11 @@
 "xnH" = (
 /obj/machinery/holopad,
 /mob/living/simple_animal/sloth/citrus,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "xoi" = (
@@ -44291,6 +44679,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/mono,
 /area/station/service/kitchen/coldroom)
+"xoY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "xpF" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
@@ -44370,6 +44762,17 @@
 	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/central)
+"xrP" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "xrV" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -44387,19 +44790,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "xsj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "18"
 	},
-/turf/open/floor/deadspace/random/maint_center{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "xsl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -44590,11 +44985,10 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "xwJ" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/yellow{
+	icon_state = "68"
 	},
+/turf/open/misc/asteroid,
 /area/aegis/surface)
 "xwY" = (
 /obj/effect/landmark/pestspawn,
@@ -44703,9 +45097,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "xyM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
@@ -44970,9 +45366,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "xIC" = (
@@ -45103,7 +45501,7 @@
 	name = "privacy shutter"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/science)
@@ -45111,15 +45509,10 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/hanger)
-"xLM" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "xLY" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "4"
 	},
 /turf/open/floor/plating,
 /area/station/security/warden)
@@ -45411,6 +45804,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/aft)
+"xXu" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "xXD" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -45428,6 +45828,15 @@
 /obj/effect/spawner/random/food_or_drink/snack,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"xXS" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "xXW" = (
 /obj/structure/table,
 /obj/effect/spawner/random/deadspace/ammo,
@@ -45439,9 +45848,6 @@
 /area/mine/lobby)
 "xYi" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -45686,12 +46092,12 @@
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "ygs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
+/area/aegis/surface)
 "ygt" = (
 /obj/structure/rack/shelf,
 /obj/item/plate_shard/marker_shard,
@@ -45755,16 +46161,13 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/deadspace/mono,
+/area/station/cargo/sorting)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
@@ -45845,6 +46248,10 @@
 "yjV" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"yka" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "ykc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -54147,7 +54554,7 @@ uoP
 trm
 mNO
 mNO
-nOQ
+uyJ
 trm
 ssE
 jxc
@@ -56720,8 +57127,8 @@ hgU
 qkb
 mNS
 vQc
+gqh
 aXf
-lGU
 qli
 qli
 qli
@@ -56878,7 +57285,7 @@ gpV
 qWI
 buK
 ovu
-jTf
+pFS
 cgY
 qWI
 eoV
@@ -57035,7 +57442,7 @@ bGQ
 qWI
 utT
 cSl
-jTf
+pFS
 cSl
 jpm
 eoV
@@ -57187,12 +57594,12 @@ eAl
 bXp
 yjT
 dAN
-lwU
+jUc
 gGN
 qWI
 utT
 mob
-jTf
+pFS
 mob
 jpm
 eoV
@@ -57349,7 +57756,7 @@ cXW
 qWI
 utT
 hTB
-jTf
+pFS
 mob
 jpm
 eoV
@@ -57496,7 +57903,7 @@ qVP
 lAb
 qgO
 dfD
-qES
+uQN
 ibV
 xDY
 mBz
@@ -57506,7 +57913,7 @@ gGN
 qWI
 ofx
 eoV
-wtM
+jTf
 pbI
 ktX
 aaa
@@ -64408,8 +64815,8 @@ qVP
 erk
 erk
 iVy
-jiS
-jiS
+rRl
+imS
 jiS
 jiS
 gRg
@@ -64723,7 +65130,7 @@ erk
 tmo
 ebG
 tDQ
-tSR
+osG
 wEX
 hBa
 ebG
@@ -64880,8 +65287,8 @@ erk
 erk
 ebG
 ebG
-ebG
-ebG
+uuS
+dxJ
 ebG
 ebG
 erk
@@ -65351,7 +65758,7 @@ erk
 erk
 ebG
 ebG
-ebG
+uuS
 ebG
 ebG
 ebG
@@ -65822,7 +66229,7 @@ erk
 erk
 xUZ
 ebG
-ebG
+uuS
 ebG
 ebG
 uyM
@@ -65978,8 +66385,8 @@ vAm
 erk
 jiS
 ebG
-ebG
-ebG
+aJv
+uuS
 jiS
 jiS
 aIS
@@ -66134,10 +66541,10 @@ etJ
 ulq
 erk
 fkx
+xda
 ilS
-ilS
-ebG
-jiS
+uuS
+ffw
 erk
 erk
 erk
@@ -66293,8 +66700,8 @@ erk
 jiS
 jiS
 rfJ
-ebG
-jiS
+uuS
+yka
 erk
 qVP
 qVP
@@ -66450,7 +66857,7 @@ erk
 eUJ
 erk
 uBz
-jiS
+imS
 jiS
 erk
 qVP
@@ -78832,7 +79239,7 @@ xVM
 xVM
 xVM
 fQc
-qAY
+jhA
 pMt
 gRy
 rwp
@@ -79273,7 +79680,7 @@ rwR
 azW
 hbH
 fXy
-bTS
+oTz
 iYH
 iYH
 iYH
@@ -79605,7 +80012,7 @@ mwV
 eDu
 mwV
 mwV
-bAY
+sWd
 qwb
 alr
 jJc
@@ -80068,7 +80475,7 @@ wbh
 sFi
 dnX
 sNO
-ncO
+jdI
 sNO
 dTJ
 sFi
@@ -80211,7 +80618,7 @@ qVP
 anE
 gRv
 gRv
-cUw
+rXD
 sxL
 cYy
 anE
@@ -80225,7 +80632,7 @@ nFb
 sFi
 hFa
 sNO
-guQ
+alq
 sNO
 sWE
 sFi
@@ -80368,7 +80775,7 @@ qVP
 anE
 sxe
 nAx
-cUw
+rXD
 vqU
 bro
 anE
@@ -80382,7 +80789,7 @@ foz
 sFi
 ykX
 sNO
-guQ
+alq
 sNO
 xsV
 sFi
@@ -80525,7 +80932,7 @@ qVP
 anE
 fDg
 mbe
-mCd
+cUw
 wSD
 aqS
 anE
@@ -80538,8 +80945,8 @@ veo
 veo
 sFi
 nAH
-chz
-alq
+ncO
+kpP
 sNO
 dIR
 sFi
@@ -80682,7 +81089,7 @@ qVP
 anE
 hTF
 tXB
-cUw
+rXD
 vqU
 oJf
 anE
@@ -80696,7 +81103,7 @@ xyR
 sFi
 hiA
 sNO
-guQ
+alq
 sNO
 fpd
 sFi
@@ -81010,7 +81417,7 @@ vxt
 sFi
 xqH
 sNO
-ncO
+jdI
 sNO
 jhD
 sFi
@@ -81785,7 +82192,7 @@ nHL
 azW
 hbH
 dVP
-eEL
+gqW
 jKk
 jKk
 jKk
@@ -82293,8 +82700,8 @@ tyr
 dmW
 hEO
 mui
+pNZ
 vHE
-diA
 eEt
 qYZ
 fXZ
@@ -82745,7 +83152,7 @@ fnR
 sMY
 tQS
 hnk
-mka
+bTd
 msD
 ayh
 npi
@@ -82755,8 +83162,8 @@ bYo
 kBk
 ruP
 bwu
-rAp
 jaQ
+ijA
 nAc
 wVk
 ijf
@@ -83331,11 +83738,11 @@ qVP
 qVP
 wuy
 wuy
-gbS
-gbS
-gbS
-gbS
-gbS
+iol
+iol
+iol
+iol
+iol
 wuy
 wuy
 wuy
@@ -83487,24 +83894,24 @@ wuy
 wuy
 wuy
 wuy
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
+iol
+iol
+iol
+iol
+iol
+iol
+iol
+iol
+iol
+iol
+iol
+iol
+iol
+iol
+iol
+iol
+iol
+iol
 wuy
 wuy
 vRZ
@@ -83547,7 +83954,7 @@ mwp
 yfI
 cZh
 uEm
-cQO
+tXY
 xfD
 vky
 dAe
@@ -83559,7 +83966,7 @@ vky
 vky
 vky
 vky
-mJT
+tMD
 vky
 tCw
 aQM
@@ -83640,29 +84047,29 @@ qVP
 qVP
 qVP
 wuy
-gbS
-gbS
-xwJ
-xwJ
-xwJ
-xwJ
-xwJ
-xwJ
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
-gbS
+iol
+iol
+ygs
+ygs
+ygs
+ygs
+ygs
+ygs
+iol
+iol
+iol
+iol
+iol
+iol
+iol
 qnp
-xwJ
-xwJ
-xwJ
-xwJ
-xwJ
-gbS
-gbS
+ygs
+ygs
+ygs
+ygs
+ygs
+iol
+iol
 wuy
 vRZ
 bzI
@@ -83797,29 +84204,29 @@ qVP
 qVP
 qVP
 wuy
-gbS
-xwJ
+iol
+ygs
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-gbS
-gbS
-gbS
+iol
+iol
+iol
 dsu
-gbS
-gbS
-gbS
+iol
+iol
+iol
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-xwJ
-gbS
+ygs
+iol
 wuy
 vRZ
 uho
@@ -83954,29 +84361,29 @@ qVP
 qVP
 qVP
 wuy
-gbS
-xwJ
+iol
+ygs
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-gbS
-gbS
-gbS
+iol
+iol
+iol
 nGf
-gbS
-gbS
-gbS
+iol
+iol
+iol
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-xwJ
-gbS
+ygs
+iol
 wuy
 vRZ
 ham
@@ -84024,10 +84431,10 @@ qyr
 qyr
 qyr
 bHR
-kpq
-idt
+jsg
+rlb
 tWq
-rXD
+pRj
 cVO
 weY
 qyr
@@ -84111,29 +84518,29 @@ qVP
 qVP
 qVP
 wuy
+iol
+ygs
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 gbS
-xwJ
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-sCc
-sCc
-sCc
+gbS
+gbS
 dsu
-sCc
-sCc
-sCc
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-xwJ
 gbS
+gbS
+gbS
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+ygs
+iol
 wuy
 vRZ
 vRZ
@@ -84268,29 +84675,29 @@ qVP
 qVP
 qVP
 wuy
-gbS
-gbS
+iol
+iol
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-gbS
-gbS
-gbS
+iol
+iol
+iol
 nGf
-gbS
-gbS
-gbS
+iol
+iol
+iol
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-gbS
-gbS
+iol
+iol
 wuy
 qVP
 qVP
@@ -84333,10 +84740,10 @@ bJz
 wqD
 bJz
 bJz
+ldv
 oqy
-hDf
-hDf
-dVu
+oqy
+uwL
 bHR
 mWE
 jYt
@@ -84346,7 +84753,7 @@ qyr
 qyr
 qyr
 tfu
-qHk
+tLv
 igw
 fpu
 fpu
@@ -84425,29 +84832,29 @@ qVP
 qVP
 qVP
 wuy
-gbS
-xwJ
+iol
+ygs
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-gbS
-gbS
-gbS
+iol
+iol
+iol
 nGf
-gbS
-gbS
-gbS
+iol
+iol
+iol
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-xwJ
-gbS
+ygs
+iol
 wuy
 qVP
 qVP
@@ -84483,22 +84890,22 @@ ohU
 wEZ
 wEZ
 lWL
-pfG
-pfG
+qUM
+qUM
 xPJ
-pfG
-pfG
-pfG
-pfG
+qUM
+qUM
+qUM
+qUM
 kVf
 uSt
 kVO
-phJ
+nTW
 sXZ
 bHX
-idt
+rlb
 tWq
-rXD
+pRj
 dHZ
 weY
 qyr
@@ -84582,29 +84989,29 @@ qVP
 qVP
 qVP
 wuy
+iol
+ygs
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 gbS
-xwJ
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-sCc
-sCc
-sCc
+gbS
+gbS
 dsu
-sCc
-sCc
-sCc
+gbS
+gbS
+gbS
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-xwJ
-sCc
+ygs
+gbS
 wuy
 qVP
 qVP
@@ -84739,28 +85146,28 @@ qVP
 qVP
 qVP
 wuy
-gbS
-xwJ
+iol
+ygs
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-gbS
-gbS
-gbS
+iol
+iol
+iol
 nGf
-gbS
-gbS
-gbS
+iol
+iol
+iol
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-xwJ
+ygs
 dsu
 wuy
 qVP
@@ -84800,7 +85207,7 @@ rcl
 wUC
 aTw
 crJ
-iix
+xLY
 svE
 crJ
 crJ
@@ -84817,7 +85224,7 @@ qyr
 qyr
 qyr
 uck
-yhZ
+odO
 xIM
 pfC
 pXF
@@ -84896,29 +85303,29 @@ qVP
 qVP
 qVP
 wuy
-gbS
-gbS
+iol
+iol
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-gbS
-gbS
-gbS
+iol
+iol
+iol
 nGf
+iol
+iol
+iol
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+iol
 gbS
-gbS
-gbS
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-gbS
-sCc
 wuy
 qVP
 qVP
@@ -84961,15 +85368,15 @@ veP
 esC
 tdg
 dAi
-iix
+xLY
 gPB
 qbh
 qbh
 bHR
-qHk
-idt
+tLv
+rlb
 tWq
-rXD
+pRj
 aTa
 weY
 qyr
@@ -85053,29 +85460,29 @@ qVP
 qVP
 qVP
 wuy
+iol
+bSO
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 gbS
-qON
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-sCc
-sCc
-sCc
+gbS
+gbS
 dsu
-sCc
-sCc
-sCc
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
 gbS
-sCc
+gbS
+gbS
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+iol
+gbS
 wuy
 qVP
 kZJ
@@ -85123,7 +85530,7 @@ vky
 vky
 vky
 vky
-qJF
+loc
 lQE
 aII
 iee
@@ -85210,29 +85617,29 @@ qVP
 qVP
 qVP
 wuy
-gbS
-qON
-wrl
+iol
+bSO
 jeU
-sMz
+vwz
+idt
+vwz
+idt
 jeU
-sMz
-wrl
-gbS
-gbS
-gbS
+iol
+iol
+iol
 nGf
-gbS
-gbS
-gbS
-wrl
+iol
+iol
+iol
 jeU
-sMz
+vwz
+idt
+vwz
+idt
 jeU
-sMz
-wrl
-sCc
-sCc
+gbS
+gbS
 wuy
 qVP
 kZJ
@@ -85275,7 +85682,7 @@ psI
 pnG
 bpE
 faw
-xLY
+nrT
 uej
 bNV
 bNV
@@ -85288,12 +85695,12 @@ qyr
 qyr
 qyr
 uck
-odO
-upb
-upb
-upb
-upb
-upb
+swY
+pfG
+pfG
+pfG
+pfG
+pfG
 cah
 ioB
 nPD
@@ -85370,10 +85777,10 @@ wuy
 wuy
 qQP
 lhT
-knc
-knc
-knc
-knc
+foq
+foq
+foq
+foq
 vTc
 qQP
 qQP
@@ -85383,10 +85790,10 @@ qQP
 qQP
 qQP
 pXJ
-gqh
-gqh
-gqh
-gqh
+kpk
+kpk
+kpk
+kpk
 rgW
 qQP
 wuy
@@ -85437,10 +85844,10 @@ qyr
 qyr
 qyr
 bHR
-qHk
-idt
+tLv
+rlb
 tWq
-rXD
+pRj
 fwd
 weY
 qyr
@@ -85527,7 +85934,7 @@ qVP
 qVP
 qQP
 hBo
-weG
+gXh
 aIL
 aIL
 aIL
@@ -85540,10 +85947,10 @@ fnm
 geM
 bwR
 gFk
-weG
 gXh
-weG
-weG
+lDx
+gXh
+gXh
 nJu
 qQP
 qVP
@@ -85701,7 +86108,7 @@ isV
 tXh
 uzD
 bAy
-ovS
+bvS
 ogk
 qVP
 qVP
@@ -85858,7 +86265,7 @@ nzy
 sjI
 bIh
 lyZ
-dAF
+oDX
 rUa
 qVP
 qVP
@@ -85876,8 +86283,8 @@ eRR
 dyb
 aUy
 vQq
-pmS
 riy
+nOQ
 ayu
 dUo
 bPG
@@ -85900,7 +86307,7 @@ cPX
 wce
 bbh
 hTw
-trK
+iEi
 tml
 rCl
 ifc
@@ -86016,7 +86423,7 @@ eIK
 kit
 edO
 hCO
-dUe
+pmS
 qVP
 qVP
 qVP
@@ -86066,7 +86473,7 @@ nGw
 qyr
 nDq
 xLA
-upb
+pfG
 ejX
 mfG
 cPn
@@ -86076,7 +86483,7 @@ mfG
 pqx
 mfG
 mfG
-uBu
+phE
 wmg
 ust
 qyr
@@ -86173,7 +86580,7 @@ jiK
 iMZ
 blO
 cTo
-dUe
+pmS
 qVP
 qVP
 qVP
@@ -86233,7 +86640,7 @@ bNV
 vrG
 bNV
 bNV
-fRr
+cVt
 bNV
 bNV
 qyr
@@ -86328,8 +86735,8 @@ qMD
 gGE
 sVe
 yim
-uBx
-chW
+kaD
+dAF
 dOf
 qVP
 qVP
@@ -86861,7 +87268,7 @@ dTg
 dTg
 dTg
 cmX
-htm
+kZk
 isb
 tsI
 wCo
@@ -87167,7 +87574,7 @@ dmE
 cFv
 crs
 fLg
-vrr
+uFr
 dYv
 woI
 qZi
@@ -87441,9 +87848,9 @@ uxc
 wCJ
 vVb
 vVb
-swY
-swY
-swY
+thV
+thV
+thV
 mUn
 mUn
 mUn
@@ -87576,11 +87983,11 @@ xth
 xth
 xth
 xth
-qtx
-snm
-snm
-kBE
+oiD
+tIj
+tIj
 eIL
+xXu
 xth
 fdA
 uOG
@@ -87596,12 +88003,12 @@ aNP
 aAq
 aGd
 aGd
-vGe
+tQQ
 kPt
 oyt
 egd
 kNZ
-pBG
+gnX
 mUn
 mUn
 mUn
@@ -87736,7 +88143,7 @@ cNx
 aJZ
 llM
 gMP
-tlV
+nBX
 tEB
 xth
 rRW
@@ -87753,12 +88160,12 @@ ghX
 ojj
 qAi
 vVb
-tQQ
+dUe
 pWI
 bYx
 bYx
 bYx
-lkZ
+wpg
 mUn
 dpz
 mUn
@@ -87775,29 +88182,29 @@ oIb
 jcd
 bPG
 bSP
-fsl
+cKw
 gRf
 mLj
 uME
 nLC
 qyR
 lzq
-oXx
+sPk
 cBm
 xki
-flr
-flr
-flr
-raj
+tcX
+tcX
+tcX
+hDp
 cOX
-flr
-flr
+tcX
+tcX
 tcQ
 dLA
-flr
 tcX
-flr
-flr
+lTl
+tcX
+tcX
 vwt
 tup
 vmf
@@ -87893,7 +88300,7 @@ bUh
 oRx
 tYl
 hpF
-bsJ
+efO
 iVk
 xth
 nCJ
@@ -87905,7 +88312,7 @@ lSF
 gOY
 mHD
 nPN
-dUu
+svh
 icl
 ojj
 tit
@@ -87915,7 +88322,7 @@ iqB
 gvY
 pkg
 cqi
-lkZ
+wpg
 jDd
 dxU
 tsG
@@ -87940,7 +88347,7 @@ ngP
 oYw
 rPR
 kCq
-ffw
+iix
 kCq
 jpQ
 kCq
@@ -88072,7 +88479,7 @@ smA
 gvY
 mUn
 mUn
-lkZ
+wpg
 lch
 gvY
 gvY
@@ -88228,7 +88635,7 @@ gFX
 gFX
 gFX
 kih
-kpP
+weG
 aBf
 fsT
 gvY
@@ -88245,7 +88652,7 @@ pLY
 ccd
 jML
 cwa
-xsj
+feD
 jlM
 uwQ
 gqi
@@ -88284,8 +88691,8 @@ qtY
 eet
 vEb
 val
-bJn
 jRe
+dSu
 bfm
 xKp
 qVP
@@ -88509,21 +88916,21 @@ qVP
 gsG
 kud
 nQh
-gwR
-gwR
-gwR
-gwR
-gwR
-gwR
-gwR
-imS
-imS
+kDP
+kDP
+kDP
+kDP
+kDP
+kDP
+kDP
+hqi
+hqi
 eCA
-imS
-imS
+hqi
+hqi
 pAx
 gbr
-vII
+esS
 ukz
 pSi
 tfP
@@ -88533,7 +88940,7 @@ fBA
 tfj
 eFj
 mcE
-gSl
+iCe
 avK
 uiB
 pIx
@@ -88742,18 +89149,18 @@ xCy
 wbK
 oEA
 vmh
-flr
+tcX
 qcz
 nOt
-flr
+tcX
 aur
-flr
-flr
-flr
-flr
-flr
-flr
-flr
+tcX
+tcX
+tcX
+tcX
+tcX
+tcX
+tcX
 kCT
 pWM
 cON
@@ -88816,7 +89223,7 @@ tuc
 eSR
 rqy
 eSR
-iCe
+mtQ
 eSR
 qVP
 qVP
@@ -88824,7 +89231,7 @@ gsG
 jIe
 kxC
 ccb
-dkf
+aPX
 ccb
 rib
 hmJ
@@ -88903,7 +89310,7 @@ izF
 sPc
 kCq
 kCq
-ffw
+iix
 kCq
 fqY
 kCq
@@ -88973,16 +89380,16 @@ tuc
 rqy
 tuc
 rqy
-iCe
+mtQ
 rqy
 qVP
 qVP
 gsG
 gsG
 gsG
-iZx
+iUB
 adK
-tYh
+mxq
 gsG
 gsG
 pMH
@@ -88993,15 +89400,15 @@ gsG
 rPz
 oDt
 hqb
-gwR
-gwR
+kDP
+kDP
 nau
 iqf
 sSt
 pmf
 jto
 xtH
-jdI
+upb
 fRQ
 xbE
 wmL
@@ -89130,7 +89537,7 @@ rqy
 rqy
 rqy
 rqy
-aJv
+wrl
 rqy
 qVP
 qVP
@@ -89149,7 +89556,7 @@ gsG
 gsG
 oBx
 ccb
-aPX
+wtM
 ccb
 ubN
 xnC
@@ -89158,7 +89565,7 @@ nJs
 jSE
 kPV
 mXQ
-jdI
+upb
 ktu
 xbE
 wmL
@@ -89287,7 +89694,7 @@ qVP
 rqy
 eSR
 rqy
-mtQ
+fnB
 jnM
 qVP
 qVP
@@ -89443,7 +89850,7 @@ qVP
 rqy
 rqy
 tuc
-kDP
+afp
 rqy
 srt
 qVP
@@ -89598,8 +90005,8 @@ rqy
 rqy
 rqy
 rqy
-iuc
-bWQ
+xsj
+ocO
 rqy
 wyu
 qVP
@@ -89629,7 +90036,7 @@ huG
 aYV
 mrm
 upl
-jdI
+upb
 mKE
 jqC
 dEQ
@@ -89752,9 +90159,9 @@ qVP
 rqy
 rqy
 rqy
-iol
-dag
-hzt
+hMw
+mCd
+nAO
 rqy
 rqy
 rqy
@@ -89786,10 +90193,10 @@ rDV
 iAC
 fRC
 bmS
-jdI
+upb
 pIG
 kNf
-juJ
+bGK
 lwr
 hPz
 xwH
@@ -89908,7 +90315,7 @@ rqy
 rqy
 rqy
 rqy
-kDP
+afp
 rqy
 qVP
 rqy
@@ -90064,7 +90471,7 @@ rqy
 rqy
 rqy
 rqy
-kDP
+afp
 rqy
 qVP
 qVP
@@ -90098,10 +90505,10 @@ cMl
 oaV
 vBz
 pee
-qGh
+gwR
 jgI
 cAY
-qMP
+xoY
 oTl
 sRF
 sRF
@@ -90220,7 +90627,7 @@ qVP
 rqy
 rqy
 tuc
-vpn
+lFI
 qVP
 qVP
 qVP
@@ -90254,11 +90661,11 @@ vPr
 ebH
 fjl
 hfM
-nsG
-qhC
+pIJ
+fwp
 tKf
 jYX
-iJI
+uOU
 qoR
 sRF
 keh
@@ -90287,17 +90694,17 @@ sxj
 sxj
 bPG
 djt
-fsl
+cKw
 xnE
 qgi
 uMo
 epq
 djC
-tIj
-tIj
-tIj
-tIj
-tIj
+mBv
+mBv
+mBv
+mBv
+mBv
 djC
 maK
 fpH
@@ -90310,7 +90717,7 @@ lrx
 xxC
 xxC
 rlA
-tIj
+mBv
 xxC
 uKh
 lhm
@@ -90377,7 +90784,7 @@ qVP
 rqy
 rqy
 tuc
-aJv
+wrl
 qVP
 qVP
 qVP
@@ -90426,7 +90833,7 @@ wDy
 rkU
 vQi
 rkU
-mlo
+eby
 pZv
 sxj
 wDV
@@ -90534,7 +90941,7 @@ qVP
 rqy
 rqy
 tuc
-efO
+nPt
 qVP
 qVP
 qVP
@@ -90564,7 +90971,7 @@ mpT
 eGf
 gkJ
 jZb
-ivr
+teI
 kEE
 ebH
 kRQ
@@ -90583,7 +90990,7 @@ fDt
 rbK
 rbK
 rbK
-dWl
+oPG
 pZv
 sxj
 eLJ
@@ -90692,7 +91099,7 @@ qVP
 qVP
 rqy
 rqy
-cKw
+xwJ
 qVP
 qVP
 qVP
@@ -90721,8 +91128,8 @@ anZ
 eGf
 eAg
 sxb
-xLM
-clx
+mou
+qsb
 gkJ
 eAg
 feG
@@ -90849,7 +91256,7 @@ qVP
 qVP
 qVP
 rqy
-dJx
+qwm
 rqy
 rqy
 rqy
@@ -90879,7 +91286,7 @@ exz
 hFC
 gQv
 tfU
-tKz
+dMZ
 ohb
 ebH
 mbT
@@ -91007,7 +91414,7 @@ rqy
 qVP
 qVP
 rqy
-cKw
+xwJ
 rqy
 rqy
 rqy
@@ -91483,7 +91890,7 @@ qVP
 qVP
 rqy
 rHU
-aJv
+wrl
 rqy
 rqy
 rqy
@@ -91640,7 +92047,7 @@ qVP
 qVP
 qVP
 rHU
-aJv
+wrl
 rqy
 rqy
 rqy
@@ -91797,7 +92204,7 @@ qVP
 qVP
 iHy
 ruE
-afp
+xXS
 rqy
 rqy
 rqy
@@ -91839,7 +92246,7 @@ rkX
 bkg
 ieE
 ijk
-fBC
+eXY
 rkU
 sxj
 puN
@@ -91952,9 +92359,9 @@ rqy
 rqy
 rqy
 rqy
-aJv
+wrl
 rEA
-oqx
+quR
 rEA
 rEA
 sIt
@@ -91981,7 +92388,7 @@ naE
 mCH
 dvF
 hHs
-pzM
+kdT
 dwU
 blf
 blf
@@ -91990,7 +92397,7 @@ woN
 bDj
 bnW
 vwd
-haR
+jVj
 eDU
 rkX
 wzw
@@ -92109,9 +92516,9 @@ rqy
 rqy
 rqy
 rqy
-aJv
+wrl
 rek
-sDR
+nhi
 jJJ
 wAN
 sIt
@@ -92148,12 +92555,12 @@ mbT
 jpS
 vwd
 jaR
-knH
+haR
 eYu
 eYu
 qXg
 cAk
-fBC
+eXY
 bvP
 sxj
 eaH
@@ -92196,7 +92603,7 @@ jhV
 bid
 bUP
 nLV
-bzz
+wUD
 sAH
 edX
 xRl
@@ -92266,12 +92673,12 @@ qVP
 rqy
 rqy
 rqy
-ocO
+cUc
 rEA
-uJP
+bmH
 jBo
 oYE
-quR
+fIK
 ruE
 ieM
 rqy
@@ -92337,11 +92744,11 @@ dHN
 dHN
 kXb
 sTl
-fOK
-dSu
-fOK
-fOK
 bcm
+qAY
+bcm
+bcm
+trK
 cMP
 cMP
 mhi
@@ -92423,7 +92830,7 @@ qVP
 rqy
 tuc
 tuc
-aJv
+wrl
 rEA
 aQr
 oXp
@@ -92789,7 +93196,7 @@ yio
 yio
 yio
 yio
-aQJ
+xjn
 rDZ
 fEk
 vDP
@@ -92955,7 +93362,7 @@ fVs
 sBp
 soj
 juy
-kpk
+laC
 iGp
 wZK
 snn
@@ -93403,13 +93810,13 @@ cJM
 hHi
 hHi
 rTI
-iwD
 rWq
-iwD
+kiR
+rWq
 fwj
 qIi
-cIs
-cIs
+fsl
+fsl
 cFk
 faY
 qVP
@@ -93716,14 +94123,14 @@ xJv
 hqp
 xTj
 qwA
-dUL
+qVk
 xNF
 eBq
 aKq
 faY
 pDD
 wgO
-cIs
+fsl
 pYw
 faY
 fPT
@@ -93873,7 +94280,7 @@ uaC
 hqp
 rSF
 kAv
-bkG
+iJI
 hgV
 rlP
 mHv
@@ -93899,7 +94306,7 @@ kyw
 gNo
 rAl
 uXc
-xLC
+vLN
 fDQ
 riO
 pkp
@@ -94030,7 +94437,7 @@ uaC
 hqp
 xgO
 kAv
-syh
+fdT
 wcV
 jSw
 rQc
@@ -94042,7 +94449,7 @@ olg
 faY
 otF
 rkU
-uyg
+aOs
 rkU
 rkU
 gmN
@@ -94188,9 +94595,9 @@ hqp
 kAg
 pug
 akZ
-uQN
-fdT
-nvs
+dfR
+ivi
+nyJ
 faY
 ktR
 bbF
@@ -94213,7 +94620,7 @@ kxK
 kgC
 iTo
 uXc
-ldv
+oUz
 pcA
 bVG
 qhu
@@ -94370,7 +94777,7 @@ kxK
 lcv
 rAl
 ayx
-uGU
+xLC
 tiS
 dVm
 rIm
@@ -94670,7 +95077,7 @@ iel
 iel
 iel
 iel
-mBv
+uyg
 eCC
 njj
 wYA
@@ -94694,7 +95101,7 @@ qDb
 iae
 kDC
 iae
-rlW
+iae
 uHI
 jij
 vFj
@@ -94827,7 +95234,7 @@ odc
 odc
 odc
 odc
-nBX
+vmK
 tXH
 njj
 ncl
@@ -94848,18 +95255,18 @@ ayy
 liT
 vlR
 mdg
-fwp
-fwp
-fwp
-fwp
-feD
-qcv
+emH
+emH
+emH
+emH
+jCn
+swv
 szo
-qcv
-qcv
-qcv
-qcv
-qcv
+swv
+swv
+swv
+swv
+swv
 prQ
 qcv
 qcv
@@ -95141,7 +95548,7 @@ uxN
 uxN
 uxN
 uxN
-mBv
+uyg
 eCC
 njj
 tNe
@@ -95168,7 +95575,7 @@ xhi
 mdX
 trT
 bNt
-swv
+szo
 cxD
 swv
 swv
@@ -95298,7 +95705,7 @@ iJv
 iJv
 iJv
 iJv
-nBX
+vmK
 aWW
 jfn
 bev
@@ -95316,8 +95723,8 @@ sAo
 xQK
 xYi
 tMU
-vmK
-vmK
+iae
+iae
 nXM
 qnk
 oys
@@ -95455,7 +95862,7 @@ iXU
 ivg
 iXU
 ueC
-rbA
+flr
 hfD
 wHF
 cvC
@@ -95471,11 +95878,11 @@ dZO
 sAo
 sAo
 oZq
-sAo
+iDC
 rrw
-emH
+xrP
 vtr
-emH
+qMP
 lOB
 cgv
 wEk
@@ -95488,7 +95895,7 @@ xnH
 epg
 ngl
 ngl
-tZt
+guQ
 swv
 tij
 pvL
@@ -95612,7 +96019,7 @@ iel
 iel
 iel
 iel
-mBv
+uyg
 eCC
 jfn
 bev
@@ -95630,13 +96037,13 @@ sAo
 kYq
 cCP
 mBt
-iae
+fBC
 fzw
 xew
 eGW
 wMP
 uWl
-vwz
+ikq
 trT
 bBh
 wXZ
@@ -95769,7 +96176,7 @@ odc
 odc
 odc
 odc
-nBX
+vmK
 aWW
 njj
 tNe
@@ -95944,7 +96351,7 @@ sej
 lmF
 aLW
 ayy
-pWp
+dqH
 tVH
 tMP
 vrC
@@ -96083,7 +96490,7 @@ uxN
 uxN
 uxN
 uxN
-mBv
+uyg
 xdQ
 njj
 ncl
@@ -96103,7 +96510,7 @@ krF
 ayy
 wlv
 tVH
-ygs
+rpp
 emH
 emH
 emH
@@ -96240,7 +96647,7 @@ iJv
 iJv
 iJv
 iJv
-nBX
+vmK
 aWW
 njj
 fjW
@@ -96266,21 +96673,21 @@ mhg
 iae
 iae
 uHI
-uuS
-uuS
-uuS
-uuS
-uuS
-uuS
-uuS
-tKq
-szo
-szo
-szo
-szo
-szo
-szo
-szo
+icC
+icC
+icC
+icC
+icC
+icC
+icC
+sup
+ngl
+ngl
+ngl
+ngl
+ngl
+ngl
+avq
 jpF
 shR
 oQR
@@ -96425,8 +96832,8 @@ lLU
 nyU
 nyU
 nyU
-qcm
-qcm
+hDf
+hmB
 qcm
 nyU
 eFY
@@ -96437,8 +96844,8 @@ evb
 swv
 xFe
 ghq
-evb
-szo
+uGU
+swv
 shR
 lXt
 wRX
@@ -96550,16 +96957,16 @@ jfn
 iel
 hKR
 cpt
-tNh
+dJx
 qgU
-tNh
-tNh
-vHR
+dJx
+dJx
+tkg
 dtP
 njj
 qwK
 kyb
-sAI
+cKm
 pmL
 vNP
 rsD
@@ -96594,7 +97001,7 @@ xFe
 swv
 xFe
 swv
-xFe
+aZU
 ngl
 qno
 qbt
@@ -96741,18 +97148,18 @@ brk
 syb
 pCw
 oUk
-oUk
+qHT
 tmW
 ngl
-tZt
+oGE
 xFe
 swv
 evb
 swv
 evb
 swv
-xFe
-mou
+rDI
+swv
 shR
 qIY
 wjU
@@ -96902,14 +97309,14 @@ fXF
 nyU
 swv
 pYT
-uuS
-uuS
-uuS
+icC
+icC
+icC
 sJV
-uuS
-uuS
+icC
+icC
 ciy
-mou
+swv
 shR
 eIw
 llB
@@ -97207,7 +97614,7 @@ dsg
 imT
 xzt
 sIH
-uLy
+qHk
 wGC
 fts
 lue
@@ -97364,10 +97771,10 @@ iaO
 iaO
 xzt
 sIH
-uLy
+tNh
 sUB
 xMe
-dym
+rlW
 rIL
 kLy
 nyU
@@ -98006,7 +98413,7 @@ qBi
 ijm
 txt
 jpj
-jpj
+sCc
 piB
 piB
 txt
@@ -98162,7 +98569,7 @@ hvt
 owQ
 nZZ
 txt
-jpj
+yhZ
 sQY
 gYJ
 gYJ
@@ -113054,7 +113461,7 @@ wuy
 kBk
 dlm
 fLk
-jzK
+uXQ
 uFg
 lse
 lse
@@ -113685,7 +114092,7 @@ wuy
 kBk
 avB
 pOx
-aGi
+iwD
 dRt
 bUr
 noU
@@ -114492,7 +114899,7 @@ hwG
 goF
 tgq
 fzN
-rqC
+diA
 pAc
 bOE
 vvm
@@ -115121,7 +115528,7 @@ wuy
 wuy
 jfa
 vVU
-rDI
+eme
 wuT
 wuT
 mkD
@@ -116691,10 +117098,10 @@ kRE
 bmz
 bmz
 bmz
+sdf
 jbI
-vrH
-vrH
-vrH
+jbI
+jbI
 ikZ
 fyZ
 rKj
@@ -116854,7 +117261,7 @@ mpQ
 mpQ
 eJO
 mpQ
-qUM
+gXW
 bCA
 qhL
 qhL
@@ -117010,8 +117417,8 @@ pyh
 ctS
 ctS
 pyh
-gjU
-eYM
+bGq
+jxs
 jfa
 czR
 ggl
@@ -117162,13 +117569,13 @@ prI
 pVm
 pyh
 oer
-lAk
+ifE
 uuA
 qGr
 qQy
 pyh
 mpQ
-qUM
+gXW
 mpQ
 mpQ
 mpQ
@@ -117319,16 +117726,16 @@ aDi
 jlE
 pyh
 hyP
-cUc
+lAk
 hch
 hch
 hQX
 pyh
 mpQ
-sPk
+eYM
 xbH
 eWW
-kBA
+nLT
 uUC
 mpQ
 jfa
@@ -117639,7 +118046,7 @@ sxJ
 jXz
 pyh
 mpQ
-dDl
+gto
 cPJ
 tdy
 hFz
@@ -117799,7 +118206,7 @@ jjd
 xpH
 cPJ
 ncG
-wpg
+pxh
 pzN
 cPJ
 wuy

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -32,12 +32,13 @@
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "abd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "abi" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment{
@@ -68,8 +69,10 @@
 /area/station/engineering/engine_smes)
 "abY" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningdock/oresilo)
 "acb" = (
@@ -280,7 +283,9 @@
 /area/station/security/checkpoint/customs)
 "aiw" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "aiX" = (
@@ -454,6 +459,23 @@
 	},
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/commons/dorms/barracks/male)
+"amf" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Mining Privacy";
+	name = "Mining Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "ami" = (
 /obj/machinery/light/directional/west,
 /turf/open/misc/beach/sand/coastline_t,
@@ -622,7 +644,9 @@
 /area/station/science/lab)
 "aqr" = (
 /obj/machinery/door/airlock/mining,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "aqD" = (
@@ -831,14 +855,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
-"avq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
 "avB" = (
 /turf/open/openspace,
 /area/station/commons/lounge)
@@ -881,6 +897,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"awP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo/warehouse)
 "awR" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -986,6 +1006,16 @@
 /obj/structure/holohoop,
 /turf/open/floor/deadspace/hardwood,
 /area/station/maintenance/port/lesser)
+"azf" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "azp" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_center,
@@ -1058,7 +1088,7 @@
 /area/station/hallway/primary/port)
 "aBf" = (
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "12"
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
@@ -1191,6 +1221,13 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
+"aEF" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "aEG" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Monitoring";
@@ -1328,9 +1365,26 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
 "aJv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
+"aJA" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "aJH" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -1408,6 +1462,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
+"aMR" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "aMT" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/deadspace/random/maint_left{
@@ -1461,15 +1521,6 @@
 	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/toilet/restrooms)
-"aOs" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "aOB" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/light/small/directional/south,
@@ -1879,7 +1930,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
@@ -1934,6 +1985,14 @@
 	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
+"aYP" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "aYU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -1967,19 +2026,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"aZU" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
 "aZX" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/light/small/directional/west,
@@ -2089,7 +2135,7 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "9"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
@@ -2112,6 +2158,16 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"bcN" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock/cafeteria)
 "bcW" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock/pile,
@@ -2190,6 +2246,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/fore)
+"bfq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/service/janitor)
 "bfv" = (
 /obj/structure/railing{
 	dir = 1
@@ -2261,6 +2324,17 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
+"bgl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "bgx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -2312,6 +2386,10 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
+"bhY" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "bid" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/door/airlock/command/glass{
@@ -2477,15 +2555,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
-"bmH" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "bmJ" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -2612,7 +2681,7 @@
 "bqd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
@@ -2644,7 +2713,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "bqC" = (
@@ -2810,6 +2878,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"but" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "buu" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/tile/bar{
@@ -2891,16 +2965,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"bvS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "bwn" = (
 /obj/structure/rack,
 /obj/item/clothing/under/costume/pirate,
@@ -3154,7 +3218,9 @@
 /area/station/security/brig/upper)
 "bCR" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -3267,6 +3333,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"bFI" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse/upper)
 "bFP" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 1
@@ -3307,25 +3384,12 @@
 /obj/item/bodypart/leg/left/robot,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
-"bGq" = (
-/obj/structure/cable/multiz,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "bGB" = (
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 4
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"bGK" = (
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "bGQ" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/yellow{
@@ -3409,9 +3473,11 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
 "bID" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
 "bII" = (
@@ -3603,6 +3669,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
+"bPf" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "bPk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3622,7 +3694,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
 "bPy" = (
@@ -3753,12 +3827,6 @@
 /obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"bSO" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "bSP" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -3777,13 +3845,6 @@
 /obj/structure/sign/warning/nosmoking,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos)
-"bTd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/service/janitor)
 "bTh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -3915,6 +3976,16 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
+"bVH" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/male)
 "bWf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
@@ -4013,7 +4084,7 @@
 "bYx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "4"
 	},
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
@@ -4352,9 +4423,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "chP" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/mine/lobby)
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock/cafeteria)
 "ciq" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
@@ -4476,8 +4550,10 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
 "cmw" = (
@@ -4922,9 +4998,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -5123,7 +5201,9 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "cCU" = (
@@ -5379,6 +5459,16 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
+"cIz" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "cIF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5426,23 +5516,15 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
-"cKm" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "cKw" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/maint_right{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/hallway/primary/port)
 "cKy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -5512,8 +5594,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "cMn" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
 "cMt" = (
@@ -5574,6 +5658,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"cOO" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "cOP" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron/dark/side{
@@ -5595,9 +5694,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -5731,7 +5827,9 @@
 /turf/open/floor/deadspace/grater,
 /area/station/medical/morgue)
 "cSt" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "cSE" = (
@@ -5784,11 +5882,10 @@
 /turf/open/water,
 /area/station/maintenance/port/lesser)
 "cUc" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "cUs" = (
 /obj/machinery/disposal/bin,
 /obj/effect/floor_decal/ds/spline/fancy/wood{
@@ -5803,10 +5900,7 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
@@ -5838,14 +5932,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
-"cVt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "cVO" = (
 /obj/machinery/flasher{
 	id = "Cell 4";
@@ -6145,13 +6231,6 @@
 /obj/item/reagent_containers/glass/beaker/synthflesh,
 /turf/open/floor/deadspace/mono,
 /area/station/medical/exam_room)
-"dfR" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "dfY" = (
 /obj/machinery/light/directional/west,
 /obj/structure/railing,
@@ -6180,6 +6259,11 @@
 "dhr" = (
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
+"dhS" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "dhT" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -6202,12 +6286,11 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -6266,6 +6349,20 @@
 /obj/item/plate_shard/marker_shard,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
+"dka" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "dki" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/norn,
@@ -6488,16 +6585,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
-"dqH" = (
-/obj/machinery/light/directional/north,
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
 "dqU" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/grater,
@@ -6514,6 +6601,16 @@
 /obj/structure/rack,
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
+"drk" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "dru" = (
 /obj/item/clothing/head/collectable/paper{
 	desc = "What looks like an ordinary paper hat is actually a rare and valuable collector's edition paper hat. Keep away from fire, Curators, and ocean waves."
@@ -6638,6 +6735,20 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
+"dvw" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "dvD" = (
 /obj/structure/beebox/premade/random,
 /turf/open/floor/plating,
@@ -6693,12 +6804,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
-"dxJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
 "dxM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
@@ -6759,6 +6864,13 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
+"dzg" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "dzm" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
@@ -6773,6 +6885,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/psychology)
+"dzp" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "dzw" = (
 /obj/structure/ladder/invincible,
 /obj/structure/disposalpipe/trunk/multiz{
@@ -6837,11 +6953,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
+	dir = 8
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -6907,6 +7020,19 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
+"dCz" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "dCD" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/tool,
@@ -7181,15 +7307,29 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "dJx" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/carpet/red,
+/area/station/commons/lounge)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
+"dJM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "dJY" = (
 /turf/open/floor/eighties/red,
 /area/aegis/surface)
@@ -7239,6 +7379,9 @@
 "dLg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/eva)
 "dLj" = (
@@ -7261,6 +7404,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"dLH" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "dLK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -7295,12 +7447,6 @@
 "dMI" = (
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/fore/lesser)
-"dMZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "dNz" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
@@ -7464,13 +7610,10 @@
 	},
 /area/aegis/mining)
 "dSu" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/break_room)
+/area/aegis/surface)
 "dSB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -7589,12 +7732,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "dUe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/computer)
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "dUl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -7607,6 +7749,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"dUm" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "dUn" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -7621,9 +7770,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -7779,6 +7930,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/mine/eva)
 "dZu" = (
@@ -7858,20 +8012,18 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"ebu" = (
+/obj/structure/cable/yellow{
+	icon_state = "68"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "ebw" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 8
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"eby" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "ebG" = (
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
@@ -8029,17 +8181,12 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "efO" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
+/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "2"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "efQ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -8271,14 +8418,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"eme" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig/upper)
 "emt" = (
 /obj/structure/railing/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8409,6 +8548,17 @@
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
+"epK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/medbay/aft)
 "epU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8482,18 +8632,6 @@
 	},
 /turf/open/floor/eighties/red,
 /area/aegis/surface)
-"esS" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
 "etp" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
@@ -8599,9 +8737,14 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
 "ewa" = (
+/obj/effect/turf_decal/bot_white,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/miningoffice)
+/area/station/cargo/storage)
 "ewj" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/disposal/bin,
@@ -8748,6 +8891,12 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
+"ezg" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "ezM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
@@ -9119,7 +9268,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "eHW" = (
@@ -9168,13 +9319,10 @@
 "eIL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "2"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "3"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/monitoring)
@@ -9358,6 +9506,13 @@
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
+"eOp" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "eON" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -9528,6 +9683,20 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
+"eTF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "eTK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9623,6 +9792,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"eWy" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "eWE" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -9688,18 +9864,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
-"eXY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "eYu" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -9750,7 +9914,9 @@
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
 "eZs" = (
@@ -9883,10 +10049,16 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
+"fdE" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "fdT" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "1"
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
@@ -9898,19 +10070,11 @@
 	},
 /area/station/hallway/primary/starboard)
 "feD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/maint_center{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse/upper)
 "feG" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Distribution Loop";
@@ -9940,11 +10104,16 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ffw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
 	},
-/turf/open/floor/deadspace/mono,
-/area/station/cargo)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "ffz" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -10200,14 +10369,21 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/misc_lab)
 "flr" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"flF" = (
+/obj/machinery/light/directional/west,
 /obj/structure/cable/yellow{
 	icon_state = "6"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/stone,
+/area/aegis/surface)
 "flJ" = (
 /obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron/dark,
@@ -10258,18 +10434,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/miningoffice)
-"fnB" = (
-/obj/structure/cable/yellow{
-	icon_state = "24"
-	},
-/turf/open/floor/plating,
-/area/aegis/surface)
 "fnQ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/box,
@@ -10296,16 +10468,6 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/maintenance/fore/lesser)
-"foq" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
-	},
-/obj/structure/cable/red{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "foz" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -10487,11 +10649,16 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "fsl" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/checkpoint/customs)
+/turf/open/floor/deadspace/random/maint_right{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "fsz" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/conveyor{
@@ -10568,6 +10735,12 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
+"fvx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "fvJ" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/table,
@@ -10603,17 +10776,23 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/customs)
 "fwp" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "fwt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "fwv" = (
@@ -10694,6 +10873,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/port)
+"fzJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "fzN" = (
 /obj/item/paper_bin,
 /obj/structure/table/wood,
@@ -10731,12 +10918,23 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "fBC" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
+/turf/open/floor/stone,
+/area/aegis/surface)
+"fBE" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "fCw" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -10765,6 +10963,13 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
+"fCB" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "fDg" = (
 /obj/structure/ladder/invincible,
 /obj/structure/lattice,
@@ -10918,17 +11123,6 @@
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/maintenance/fore/lesser)
-"fIK" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "fIM" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/hydroponics/constructable,
@@ -11046,6 +11240,17 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/station/service/library)
+"fMx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "fML" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/hanger)
@@ -11065,9 +11270,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/mine/production)
 "fNt" = (
@@ -11562,8 +11769,10 @@
 "fZe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
 "fZC" = (
@@ -11659,10 +11868,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/miningoffice)
 "gcA" = (
@@ -12034,12 +12245,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
-"gnX" = (
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "goF" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/box,
@@ -12094,7 +12299,9 @@
 /turf/open/floor/deadspace/mono,
 /area/aegis/mining)
 "gpv" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse)
 "gpy" = (
@@ -12124,13 +12331,9 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/morgue)
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -12146,6 +12349,20 @@
 /obj/machinery/light/small/maintenance/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"gqG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "gqO" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/deepfryer,
@@ -12160,16 +12377,6 @@
 /obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"gqW" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/female)
 "grv" = (
 /obj/machinery/telephone,
 /turf/open/floor/plating,
@@ -12246,14 +12453,6 @@
 /obj/item/stack/sheet/mineral/plasma/five,
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
-"gto" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "guc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood{
@@ -12268,19 +12467,12 @@
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/captain)
 "guQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/box,
+/obj/effect/spawner/random/clothing/wardrobe_closet,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "gva" = (
 /obj/structure/railing,
 /turf/open/floor/deadspace/random/rectangles,
@@ -12330,9 +12522,13 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
+	},
+/area/station/security/brig)
 "gxI" = (
 /obj/structure/cable/yellow{
 	icon_state = "3"
@@ -12449,6 +12645,16 @@
 /obj/structure/lattice,
 /turf/open/openspace,
 /area/station/maintenance/starboard/central)
+"gAR" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "gAV" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_center,
@@ -12484,6 +12690,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/hallway/primary/central)
+"gBn" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "gBt" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/griddle,
@@ -12636,6 +12849,14 @@
 "gFX" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/aft)
+"gGD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "gGE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12936,6 +13157,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central/aft)
+"gQj" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "gQq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -13108,6 +13335,14 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"gTX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "gUk" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/openspace,
@@ -13185,9 +13420,11 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
 "gVD" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningdock/oresilo)
 "gVS" = (
@@ -13250,6 +13487,7 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "gXh" = (
+/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 8
 	},
@@ -13289,17 +13527,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
-"gXW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "gXY" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -13419,7 +13646,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
@@ -13472,7 +13699,6 @@
 	},
 /area/station/hallway/primary/fore)
 "hdz" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/eva)
@@ -13581,6 +13807,13 @@
 	},
 /turf/open/floor/plating,
 /area/aegis/surface)
+"hgB" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/security/warden)
 "hgC" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -13752,23 +13985,6 @@
 /obj/structure/railing,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
-"hmB" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Cargo Privacy";
-	name = "Cargo Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/qm)
 "hmJ" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
@@ -13921,20 +14137,14 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
-"hqi" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "hqn" = (
 /obj/structure/disposalpipe/junction/flip,
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "hqp" = (
@@ -14316,6 +14526,16 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
+"hyS" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "hzd" = (
 /obj/machinery/light/small/maintenance/directional/east,
 /obj/item/clothing/suit/apron/chef,
@@ -14350,9 +14570,11 @@
 /area/station/command/heads_quarters/rd)
 "hzT" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "hAa" = (
@@ -14446,26 +14668,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "hDf" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Cargo Privacy";
-	name = "Cargo Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/qm)
-"hDp" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "hDv" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/customs)
@@ -14588,7 +14794,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
@@ -14730,9 +14935,11 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
 "hJT" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
 "hKc" = (
@@ -14800,17 +15007,17 @@
 "hLX" = (
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/starboard)
-"hMw" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "hMz" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/power/floodlight,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
+"hMH" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/checkpoint/customs)
 "hMJ" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/box,
@@ -15366,7 +15573,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
@@ -15397,14 +15604,26 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
 	},
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
 	},
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "idy" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor{
@@ -15462,12 +15681,17 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "iet" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "ieE" = (
@@ -15516,17 +15740,12 @@
 "ifl" = (
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/female)
-"ifE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+"ifH" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/lobby)
 "ifO" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -15652,25 +15871,40 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
+"ihP" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/hallway/secondary/exit/departure_lounge)
 "iib" = (
 /obj/machinery/light/small/maintenance/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lesser)
 "iix" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "iiK" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"ija" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "ijd" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/two,
@@ -15745,14 +15979,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
-"ijA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "ijC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/showroomfloor,
@@ -15878,12 +16104,14 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "ilU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/mine/production)
 "imw" = (
@@ -15920,10 +16148,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "imS" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/mono,
-/area/station/cargo)
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/break_room)
 "imT" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -15960,10 +16191,16 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "iol" = (
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15988,7 +16225,6 @@
 /area/station/security/brig)
 "ioE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/eva)
 "ipf" = (
@@ -16103,9 +16339,11 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "itM" = (
@@ -16139,19 +16377,6 @@
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/deadspace/cable,
 /area/station/hallway/secondary/exit/departure_lounge)
-"ivi" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "ivk" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/deadspace/mono,
@@ -16169,9 +16394,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "ivB" = (
@@ -16224,10 +16451,11 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "iwD" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "iwK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -16239,9 +16467,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "ixe" = (
@@ -16290,6 +16520,13 @@
 /obj/effect/spawner/random/deadspace/rig,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
+"izE" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "izF" = (
 /obj/effect/landmark/pestspawn,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -16413,9 +16650,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "iAV" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
 "iBJ" = (
@@ -16446,15 +16685,10 @@
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/area/station/cargo/warehouse)
 "iCm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate/large/ds/green_horizontal,
@@ -16515,19 +16749,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "iDB" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse/upper)
-"iDC" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/norn,
-/area/station/hallway/primary/starboard)
 "iDL" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/sheet/mineral/diamond,
@@ -16547,15 +16775,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"iEi" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/wood,
-/area/station/medical/psychology)
 "iEq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light/small/directional/east,
@@ -16616,9 +16835,11 @@
 /area/station/service/chapel)
 "iFH" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/miningoffice)
 "iFK" = (
@@ -16635,6 +16856,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"iFY" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "iGf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -16833,18 +17058,16 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "iJI" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "2"
+	icon_state = "3"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "10"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "iJV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 4
@@ -17371,13 +17594,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central/aft)
-"iUB" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "iVk" = (
 /obj/structure/table,
 /obj/machinery/power/data_terminal,
@@ -17577,10 +17793,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "3"
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
@@ -17613,7 +17826,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
@@ -17667,11 +17883,16 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jdI" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
 	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/ce)
 "jdK" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -17696,10 +17917,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "jeU" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -17803,15 +18024,6 @@
 /obj/structure/railing,
 /turf/open/floor/deadspace/roller,
 /area/aegis/surface)
-"jhA" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/hallway/primary/port)
 "jhB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced/grille,
@@ -18022,8 +18234,10 @@
 	},
 /area/station/hallway/primary/fore)
 "jlP" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
 "jlY" = (
@@ -18285,9 +18499,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "jpV" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/stone,
-/area/aegis/surface)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "jpX" = (
 /obj/structure/rack,
 /obj/item/storage/lunchbox/cec,
@@ -18365,20 +18582,17 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
-"jsg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"jrY" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "jsp" = (
 /obj/effect/spawner/random/trash/garbage{
 	spawn_loot_count = 3
@@ -18428,6 +18642,23 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"jtr" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Cargo Privacy";
+	name = "Cargo Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "jtu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
@@ -18568,9 +18799,11 @@
 /turf/open/floor/carpet/red,
 /area/station/security/warden)
 "jwI" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/mine/production)
 "jwX" = (
@@ -18586,20 +18819,6 @@
 /obj/machinery/autolathe,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"jxs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "jxE" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
@@ -18640,9 +18859,11 @@
 /area/station/service/chapel)
 "jyy" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
@@ -18760,6 +18981,15 @@
 /obj/structure/table/wood/fancy/blue,
 /turf/open/floor/iron/ported/lino,
 /area/station/service/library)
+"jCN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "jDd" = (
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
@@ -18944,6 +19174,12 @@
 /obj/structure/flora/rock,
 /turf/open/misc/asteroid,
 /area/station/cargo/miningdock/oresilo)
+"jIq" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "jIr" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/medical/minor_healing,
@@ -19199,6 +19435,12 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"jOG" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jON" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -19396,20 +19638,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
-"jUc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/medbay/aft)
 "jUL" = (
 /obj/structure/sign/cec/deck{
 	pixel_y = 34
@@ -19426,14 +19654,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/hanger)
-"jVj" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
 "jVx" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/deadspace/ammo/security,
@@ -19647,15 +19867,6 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"kaD" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
 "kaO" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/iron/dark,
@@ -19751,13 +19962,6 @@
 /obj/effect/spawner/random/food_or_drink/snack,
 /turf/open/floor/plating,
 /area/aegis/surface)
-"kdT" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "keh" = (
 /obj/machinery/power/smes/engineering{
 	input_level = 60000;
@@ -20040,15 +20244,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
-"kiR" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/deadspace/grille_spare3,
-/area/station/security/checkpoint/customs)
 "kiW" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/box,
@@ -20059,6 +20254,14 @@
 /obj/structure/closet/secure_closet/ds/chief_medical,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
+"kjn" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "kjv" = (
 /turf/closed/wall/r_wall,
 /area/station/security/range)
@@ -20227,21 +20430,31 @@
 /obj/machinery/light/directional/north,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"koP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "kpe" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album/library,
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "kpk" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/red{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "kpy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -20254,19 +20467,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/clothing/costume,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -20414,6 +20622,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"ktN" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/norn,
+/area/station/hallway/primary/starboard)
 "ktR" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
@@ -21255,7 +21471,6 @@
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/mono,
 /area/mine/eva)
 "kSy" = (
@@ -21364,6 +21579,9 @@
 "kVd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "kVf" = (
@@ -21539,16 +21757,6 @@
 	dir = 8
 	},
 /area/station/hallway/secondary/command)
-"kZk" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
 "kZA" = (
 /obj/structure/sink{
 	dir = 8;
@@ -21589,20 +21797,6 @@
 /obj/item/stack/sheet/iron/fifty,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
-"laC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/maint_center{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
 "laL" = (
 /turf/open/floor/deadspace/bathroom,
 /area/station/medical/morgue)
@@ -21707,6 +21901,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
+"lcL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "lcV" = (
 /obj/machinery/newscaster/directional/east,
 /obj/structure/cable/yellow{
@@ -21735,10 +21937,10 @@
 "ldv" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "2"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
-/area/station/security/brig)
+/area/station/tcommsat/server)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -21747,9 +21949,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "ldI" = (
@@ -22178,20 +22385,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
-"loc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "loo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -22489,9 +22682,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "lyW" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -22535,6 +22730,16 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"lzz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "lzS" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -22645,6 +22850,12 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/bar)
+"lCi" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "lCt" = (
 /obj/structure/destructible/cult/item_dispenser/archives/library,
 /obj/item/book/codex_gigas,
@@ -22681,13 +22892,6 @@
 "lDu" = (
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse)
-"lDx" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
 "lDy" = (
 /obj/structure/rack/shelf,
 /obj/item/storage/book/bible/unitology,
@@ -22738,12 +22942,6 @@
 /obj/structure/table,
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
-"lFI" = (
-/obj/structure/cable/yellow{
-	icon_state = "132"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "lFN" = (
 /obj/structure/closet/jcloset,
 /turf/open/floor/deadspace/random/maint_right,
@@ -23270,18 +23468,6 @@
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
-"lTl" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "lTt" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/east,
@@ -23375,6 +23561,12 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
+"lWk" = (
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "lWw" = (
 /obj/structure/railing,
 /turf/open/water,
@@ -23681,11 +23873,11 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
 "mfG" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "5"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
@@ -23986,10 +24178,11 @@
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "mou" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "moB" = (
 /obj/machinery/door/airlock/hydroponics/glass{
 	name = "Abandoned Hydroponics";
@@ -24338,13 +24531,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
-"mxq" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "mxv" = (
 /obj/structure/chair,
 /turf/open/floor/deadspace/random/rectangles,
@@ -24462,14 +24648,11 @@
 /turf/open/floor/engine,
 /area/station/command/heads_quarters/rd)
 "mBv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "mBz" = (
 /obj/machinery/door/airlock/medical{
 	name = "Bioprosthetics Lab";
@@ -24496,9 +24679,9 @@
 /area/mine/production)
 "mCd" = (
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "6"
 	},
-/turf/open/misc/ironsand,
+/turf/open/floor/stone,
 /area/aegis/surface)
 "mCl" = (
 /obj/structure/window/reinforced/spawner/west,
@@ -24975,12 +25158,20 @@
 /turf/closed/wall/r_wall,
 /area/station/science/breakroom)
 "mQm" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/mine/production)
 "mQn" = (
@@ -25097,13 +25288,32 @@
 "mUd" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "mUn" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"mUx" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "mUC" = (
 /obj/machinery/door/poddoor,
 /obj/machinery/conveyor{
@@ -25126,6 +25336,13 @@
 	dir = 5
 	},
 /area/station/hallway/primary/starboard)
+"mVx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/cargo/warehouse)
 "mVI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -25207,6 +25424,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "mXc" = (
@@ -25246,9 +25466,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "mYf" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse/upper)
 "mYj" = (
@@ -25275,6 +25497,14 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
+"mYN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "mYP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/south,
@@ -25494,7 +25724,7 @@
 /area/station/maintenance/fore/lesser)
 "ncO" = (
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
@@ -25610,12 +25840,6 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"nhi" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "nhw" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/cee{
 	dir = 8
@@ -25672,8 +25896,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "nin" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
 "niw" = (
@@ -25761,6 +25987,10 @@
 /obj/item/clothing/head/cone,
 /turf/open/floor/stone,
 /area/aegis/surface)
+"nll" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides,
+/area/station/cargo/warehouse)
 "nlK" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/toy,
@@ -25782,6 +26012,14 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
+"nmy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "nmA" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/mono,
@@ -25930,13 +26168,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
-"nrT" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/security/warden)
 "nrV" = (
 /obj/machinery/photocopier,
 /obj/item/toner,
@@ -25996,7 +26227,6 @@
 /turf/open/misc/beach/sand/coastline_t,
 /area/station/hallway/primary/port)
 "nuf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
@@ -26122,13 +26352,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
-"nyJ" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "nyU" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/qm)
@@ -26253,12 +26476,6 @@
 	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
-"nAO" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "nAP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -26320,14 +26537,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "nBX" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
+/area/aegis/surface)
 "nCk" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -26398,6 +26613,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"nDn" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "nDq" = (
 /obj/machinery/camera/motion/directional/north,
 /turf/open/floor/deadspace/random/slides{
@@ -26441,6 +26662,15 @@
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
+"nGv" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "nGw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -26522,7 +26752,9 @@
 "nHM" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "nIf" = (
@@ -26646,14 +26878,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
-"nLT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "nLV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -26680,9 +26904,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse)
 "nMG" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "nMM" = (
 /obj/machinery/air_sensor/plasma_tank,
 /obj/machinery/camera/directional/east{
@@ -26690,6 +26916,14 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
+"nMR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "nMS" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -26774,15 +27008,16 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "nOQ" = (
-/obj/effect/floor_decal/ds/spline/fancy/wood{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
-/turf/open/floor/carpet/royalblue,
-/area/station/service/library)
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "nOX" = (
 /obj/machinery/cryopod,
 /obj/effect/landmark/latejoin,
@@ -26817,12 +27052,6 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
-"nPt" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "nPD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -26938,6 +27167,13 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/female)
+"nSo" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "nSr" = (
 /obj/machinery/light/small/maintenance/directional/west,
 /obj/structure/table/wood,
@@ -26986,27 +27222,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"nTW" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "P-Sec Brig";
-	req_access_txt = "63";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig)
 "nTY" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/west,
@@ -27091,9 +27306,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
 "nWN" = (
@@ -27193,6 +27410,16 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
+"oab" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "oam" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/deadspace/mono,
@@ -27231,6 +27458,19 @@
 /obj/machinery/meter/monitored/distro_loop,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"obj" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/white,
+/area/station/service/kitchen)
 "obr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/deadspace/random/rectangles,
@@ -27238,6 +27478,9 @@
 "obv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/eva)
 "oby" = (
@@ -27278,7 +27521,7 @@
 /area/station/command/bridge)
 "ocO" = (
 /obj/structure/cable/yellow{
-	icon_state = "129"
+	icon_state = "40"
 	},
 /turf/open/misc/ironsand,
 /area/aegis/surface)
@@ -27512,13 +27755,6 @@
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
-"oiD" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "oiJ" = (
 /obj/machinery/modular_computer/console/preset/cargochat/security{
 	dir = 8
@@ -27531,10 +27767,12 @@
 	name = "Mining Locker Room";
 	req_access_txt = "48"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/mine/living_quarters)
 "ojj" = (
@@ -27836,6 +28074,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/security/range)
+"oqg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "oqn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -27868,9 +28111,17 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/miningoffice)
 "oqU" = (
@@ -27931,13 +28182,6 @@
 "osC" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
-"osG" = (
-/obj/effect/turf_decal/box,
-/obj/effect/spawner/random/clothing/wardrobe_closet,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
 "osQ" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
@@ -27949,6 +28193,13 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
+"otp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "otu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -27989,6 +28240,11 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
+"ouq" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "ouE" = (
 /obj/effect/landmark/navigate_destination{
 	location = "Mining"
@@ -28274,7 +28530,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "oCi" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse/upper)
 "oCw" = (
@@ -28321,14 +28581,16 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "oDX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "oEw" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 4
@@ -28348,6 +28610,10 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"oEC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "oET" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Ports"
@@ -28417,20 +28683,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
-"oGE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
 "oGW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -28732,18 +28984,6 @@
 	},
 /turf/open/openspace,
 /area/station/command/bridge)
-"oPG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "oQa" = (
 /obj/structure/chair{
 	dir = 4
@@ -28797,9 +29037,11 @@
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain)
 "oQX" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
 "oQZ" = (
@@ -28908,16 +29150,6 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
-"oTz" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/male)
 "oTC" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -28960,20 +29192,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
-"oUz" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "miningsecprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/science)
 "oUN" = (
 /obj/structure/bed/pod{
 	desc = "An old medical bed, just waiting for replacement with something up to date.";
@@ -29379,16 +29597,14 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "pfG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/hallway/primary/central)
 "pfH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -29458,15 +29674,16 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"phE" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "5"
+"phP" = (
+/obj/machinery/light/directional/north,
+/obj/structure/chair{
+	pixel_y = -2
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "piB" = (
 /obj/structure/railing{
 	dir = 8
@@ -29652,11 +29869,15 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "pmS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/station/service/library)
 "pnj" = (
 /obj/structure/railing{
 	dir = 6
@@ -29885,6 +30106,12 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/maintenance/fore/lesser)
+"ptq" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/warehouse)
 "ptu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -29905,9 +30132,11 @@
 	},
 /area/station/hallway/primary/central)
 "pud" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
 "pug" = (
@@ -29948,6 +30177,17 @@
 /obj/structure/railing/corner,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
+"pvC" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Mining Privacy";
+	name = "Mining Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "pvH" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/button/door/directional/north{
@@ -29977,22 +30217,37 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
+"pwG" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/clothing/costume,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "pwR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/bathroom,
 /area/station/medical/morgue)
+"pwU" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "pwW" = (
 /obj/structure/railing,
 /obj/structure/table/wood/fancy/red,
 /turf/open/floor/wood,
 /area/station/service/chapel)
-"pxh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/maintenance/fore/greater)
 "pxs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -30327,9 +30582,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/miningoffice)
 "pFf" = (
@@ -30370,14 +30627,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
-"pFS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/morgue)
 "pGh" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 4
@@ -30486,13 +30735,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
-"pIJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "pIO" = (
 /obj/structure/ladder/invincible,
 /turf/open/floor/deadspace/mono,
@@ -30534,6 +30776,14 @@
 	},
 /turf/open/floor/eighties/red,
 /area/aegis/surface)
+"pKq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "pKA" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -30715,19 +30965,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
-"pNZ" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/white,
-/area/station/service/kitchen)
 "pOk" = (
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 1;
@@ -30811,6 +31048,17 @@
 	dir = 4
 	},
 /area/station/hallway/primary/fore)
+"pPq" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Cargo Privacy";
+	name = "Cargo Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "pPG" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -30874,12 +31122,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"pRj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/brig)
 "pRl" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -30911,9 +31153,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
@@ -30973,6 +31212,11 @@
 /obj/item/clothing/head/cseco,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hos)
+"pVu" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "pVI" = (
 /obj/item/storage/box/gloves,
 /obj/structure/table,
@@ -31102,9 +31346,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "pYv" = (
@@ -31361,7 +31607,7 @@
 "qfF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "5"
 	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
@@ -31472,9 +31718,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "qhR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/deadspace/bathroom,
-/area/mine/production)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "qhZ" = (
 /obj/structure/rack,
 /obj/item/clothing/under/rank/medical/scrubs/purple,
@@ -31597,9 +31845,12 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "qly" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/eva)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "qlA" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plating,
@@ -31875,11 +32126,6 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
-"qsb" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "qsq" = (
 /turf/open/floor/deadspace/random/maint_right{
 	dir = 8
@@ -32034,7 +32280,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -32069,12 +32315,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/male)
-"qwm" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "qwp" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/right,
@@ -32217,17 +32457,30 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/norn,
 /area/station/medical/office)
-"qAY" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
+"qAC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/morgue)
+"qAU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
+/turf/open/floor/wood,
+/area/station/cargo/qm)
+"qAY" = (
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/breakroom)
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "qBi" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
@@ -32406,23 +32659,22 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
+"qHf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "qHk" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Mining Privacy";
-	name = "Mining Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/qm)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo/warehouse)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -32455,14 +32707,6 @@
 	dir = 1
 	},
 /area/station/security/brig)
-"qHT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/wood,
-/area/station/cargo/qm)
 "qIi" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -32560,6 +32804,17 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"qLI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "qLV" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -32591,6 +32846,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
+"qME" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "qMH" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/structure/crate,
@@ -32609,13 +32872,13 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "qMP" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "qMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -32666,10 +32929,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "qOa" = (
@@ -32818,6 +33083,15 @@
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
+"qSC" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/grille_spare3,
+/area/station/security/checkpoint/customs)
 "qSL" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/slides{
@@ -32897,14 +33171,13 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "qUM" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/hallway/primary/central)
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "qVj" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
@@ -32913,13 +33186,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/hanger)
-"qVk" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "qVv" = (
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
@@ -33280,6 +33546,11 @@
 /obj/structure/filingcabinet,
 /turf/open/water,
 /area/station/maintenance/fore/lesser)
+"rfU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "rfV" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -33360,6 +33631,13 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"rir" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/maintenance/fore/greater)
 "rit" = (
 /obj/structure/ore_box,
 /turf/open/misc/asteroid,
@@ -33421,6 +33699,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
+"rjR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/cargo/miningoffice)
 "rkf" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33473,14 +33761,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/female)
-"rlb" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 4
-	},
-/area/station/security/brig)
 "rlg" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/tool,
@@ -33533,11 +33813,10 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "rlW" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/cargo/qm)
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "rma" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Cryo - Left"
@@ -33602,11 +33881,35 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
+"rnQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "rop" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock/pile/icy,
 /turf/open/misc/asteroid/snow,
 /area/station/science/breakroom)
+"ror" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/commons/dorms/cryo)
 "roG" = (
 /turf/open/floor/iron/dark/side{
 	dir = 6
@@ -33776,10 +34079,12 @@
 /obj/machinery/door/airlock/mining{
 	name = "Mining Refining Room"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningdock/oresilo)
 "rtC" = (
@@ -34000,9 +34305,11 @@
 	},
 /area/station/hallway/primary/fore)
 "rAb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "rAl" = (
@@ -34161,15 +34468,14 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "rDI" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "rDN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -34212,6 +34518,14 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
+"rFk" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "rFp" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -34473,6 +34787,12 @@
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/station/maintenance/fore/lesser)
+"rMh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "rMK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/binary/pump/on,
@@ -34565,6 +34885,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"rOW" = (
+/obj/structure/cable/multiz,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "rOY" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34617,14 +34944,10 @@
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
 "rQA" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "rQK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/tool,
@@ -34638,10 +34961,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/secondary/service)
-"rRl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/deadspace/mono,
-/area/station/cargo)
 "rRv" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -34714,9 +35033,13 @@
 /turf/open/floor/deadspace/grater,
 /area/station/command/bridge)
 "rTT" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/mine/eva)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/morgue)
 "rTW" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -34840,14 +35163,18 @@
 /turf/open/floor/plating,
 /area/station/medical/surgery/theatre)
 "rXD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/plating,
-/area/station/commons/dorms/cryo)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "rXE" = (
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
@@ -34957,18 +35284,6 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"sdf" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "sdl" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/bot,
@@ -34987,6 +35302,10 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"sdz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "sdK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/maintenance,
@@ -35051,10 +35370,12 @@
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "sfP" = (
@@ -35346,6 +35667,15 @@
 	},
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
+"snt" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "snw" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -35358,9 +35688,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/mine/production)
 "soj" = (
@@ -35531,6 +35866,19 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"stk" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "sua" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -35544,20 +35892,6 @@
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
-"sup" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
 "suq" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -35587,18 +35921,6 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
-"svh" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "svo" = (
 /obj/structure/rack/shelf,
 /obj/effect/turf_decal/bot_white,
@@ -35658,19 +35980,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "swY" = (
-/obj/structure/disposalpipe/junction{
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/area/aegis/surface)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -35847,13 +36164,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "sCc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/mono,
-/area/station/cargo/sorting)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "sCd" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/random/maintenance/two,
@@ -35908,6 +36221,10 @@
 /obj/machinery/light/small/red,
 /turf/open/floor/deadspace/grille_spare3,
 /area/station/cargo/warehouse)
+"sDh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "sDl" = (
 /obj/effect/landmark/navigate_destination/hydro,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -35926,6 +36243,14 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
+"sDX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "sDZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/flashlight,
@@ -35981,6 +36306,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "sEW" = (
@@ -35989,6 +36317,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/fore)
+"sEX" = (
+/obj/structure/cable/yellow{
+	icon_state = "24"
+	},
+/turf/open/floor/plating,
+/area/aegis/surface)
 "sFc" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/maint_right,
@@ -36053,7 +36387,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
@@ -36214,9 +36547,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
 "sNc" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -36235,9 +36570,11 @@
 	req_access_txt = "48"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/miningoffice)
 "sNO" = (
@@ -36286,19 +36623,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sPk" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "2"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "sPH" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/bot,
@@ -36562,10 +36896,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
-"sWd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/commons/dorms/barracks/male)
 "sWE" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/deadspace/heavy,
@@ -36652,7 +36982,15 @@
 /area/station/command/heads_quarters/cmo)
 "sYk" = (
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "sYm" = (
@@ -36769,6 +37107,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tda" = (
@@ -36812,13 +37153,6 @@
 /obj/machinery/iv_drip,
 /turf/open/floor/iron/kitchen_coldroom,
 /area/station/medical/coldroom)
-"teI" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "teS" = (
 /obj/machinery/recharger,
 /obj/structure/table/reinforced,
@@ -36967,13 +37301,6 @@
 "thU" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/warehouse/upper)
-"thV" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
 "tij" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37052,12 +37379,15 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
-"tkg" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
+"tkh" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
 	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "tkF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -37118,6 +37448,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
+"tmB" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "tmQ" = (
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark/side{
@@ -37224,13 +37560,9 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "trK" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/breakroom)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "trL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37656,7 +37988,15 @@
 /area/aegis/surface)
 "tCy" = (
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 2
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "tCR" = (
@@ -37764,19 +38104,26 @@
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/male)
 "tIj" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "tIu" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/female)
+"tIJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/exam_room)
 "tIM" = (
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
@@ -37807,6 +38154,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
+"tKm" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/female)
 "tKq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -37870,20 +38227,6 @@
 /obj/structure/table,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
-"tLv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "tLZ" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
@@ -37903,17 +38246,6 @@
 	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/maintenance/port/lesser)
-"tMD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "tME" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
@@ -37952,16 +38284,17 @@
 	},
 /area/station/hallway/primary/starboard)
 "tNh" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Mining Privacy";
-	name = "Mining Shutters"
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "5"
 	},
-/turf/open/floor/plating,
-/area/station/cargo/qm)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "tNI" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4;
@@ -38238,9 +38571,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "tVl" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -38331,14 +38666,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/circuit/telecomms/server,
 /area/station/science/server)
-"tXY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/carpet/red,
-/area/station/security/office)
 "tYc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/keycard_auth/directional/east,
@@ -38395,7 +38722,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
@@ -38809,6 +39139,15 @@
 /obj/item/toy/plush/beeplushie,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"unh" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "unk" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
@@ -38935,16 +39274,18 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
 "upb" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
 /turf/open/floor/plating,
-/area/station/command/heads_quarters/ce)
+/area/station/engineering/monitoring)
 "upl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -39073,6 +39414,10 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/customs)
+"urW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "ust" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -39112,6 +39457,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"utg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "utw" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/deadspace/random/maint_center,
@@ -39182,10 +39534,14 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "uuS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock/cafeteria)
 "uvc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39244,16 +39600,6 @@
 	dir = 1
 	},
 /area/aegis/mining)
-"uwL" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "uwQ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -39292,11 +39638,16 @@
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation)
 "uyg" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "uyk" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/vending/hydroseeds,
@@ -39315,15 +39666,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"uyJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "132"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/station/service/chapel/monastery)
 "uyL" = (
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
@@ -39536,7 +39878,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
@@ -39555,6 +39900,12 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
+"uDI" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "uDQ" = (
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
@@ -39575,20 +39926,14 @@
 "uFb" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/table,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
 "uFg" = (
 /turf/open/floor/carpet/red,
 /area/station/commons/lounge)
-"uFr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "uFs" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment,
@@ -39650,14 +39995,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "4"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39820,7 +40163,9 @@
 /area/station/medical/medbay/lobby)
 "uMH" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse)
 "uNp" = (
@@ -39842,6 +40187,12 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plating,
 /area/misc/testroom)
+"uNE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/cargo/qm)
 "uNG" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plating,
@@ -39879,10 +40230,6 @@
 "uOK" = (
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
-"uOU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "uOY" = (
 /obj/machinery/light/directional/east,
 /turf/open/misc/asteroid,
@@ -39933,13 +40280,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
+/obj/machinery/conveyor{
+	id = "Lower Marker Conveyor"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/exam_room)
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -39981,6 +40328,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/mine/eva)
 "uSd" = (
@@ -40022,6 +40372,12 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
+"uSu" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/bathroom,
+/area/mine/production)
 "uSY" = (
 /obj/structure/table,
 /obj/item/clothing/head/cone{
@@ -40054,6 +40410,11 @@
 	dir = 8
 	},
 /area/station/security/lockers)
+"uSZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo/warehouse)
 "uTc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40094,7 +40455,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
@@ -40233,12 +40593,6 @@
 /obj/structure/curtain,
 /turf/open/floor/deadspace/grille_spare4,
 /area/station/commons/dorms/barracks/male)
-"uXQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/station/commons/lounge)
 "uXT" = (
 /obj/machinery/autolathe,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -40784,13 +41138,19 @@
 /turf/closed/wall/r_wall,
 /area/mine/hydroponics)
 "vmK" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
+	},
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "6"
 	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "2"
 	},
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "vmO" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -40921,6 +41281,12 @@
 "vri" = (
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
+"vrp" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "vrv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40994,7 +41360,9 @@
 /area/station/engineering/main)
 "vsC" = (
 /obj/machinery/light/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse)
 "vsE" = (
@@ -41090,9 +41458,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "vwd" = (
@@ -41113,14 +41483,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vwz" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "vwZ" = (
 /obj/structure/sign/cec/deck/research{
 	pixel_y = -32
@@ -41274,6 +41644,12 @@
 /obj/machinery/autolathe,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/port/lesser)
+"vAC" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "vAI" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
@@ -41699,17 +42075,6 @@
 /obj/machinery/light/small/maintenance/directional/north,
 /turf/open/water,
 /area/station/maintenance/fore/lesser)
-"vLN" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "miningsecprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/science)
 "vLT" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/material,
@@ -41735,6 +42100,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"vMn" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "vMp" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -41764,7 +42135,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "vMK" = (
@@ -41800,6 +42173,18 @@
 "vNo" = (
 /turf/open/floor/deadspace/grater,
 /area/mine/hydroponics)
+"vNq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "vNC" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/light/small/directional/north,
@@ -41808,6 +42193,18 @@
 "vNP" = (
 /turf/closed/wall/r_wall,
 /area/mine/lobby)
+"vOt" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "vOD" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Cold Storage";
@@ -42001,8 +42398,10 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table/reinforced,
 /obj/machinery/telephone/cargo,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "vTv" = (
@@ -42110,6 +42509,10 @@
 	dir = 6
 	},
 /area/station/hallway/primary/central)
+"vUH" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/slides,
+/area/station/cargo/warehouse)
 "vUL" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -42185,9 +42588,11 @@
 /area/station/hallway/primary/central/aft)
 "vYd" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
 "vYt" = (
@@ -42293,6 +42698,12 @@
 "wbK" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/pharmacy)
+"wbT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/cargo/warehouse)
 "wbX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42307,6 +42718,9 @@
 "wcc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/eva)
 "wce" = (
@@ -42375,11 +42789,11 @@
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "weG" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
 	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "weI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/mono,
@@ -42515,6 +42929,12 @@
 /obj/effect/spawner/random/clothing/gloves,
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
+"whZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "wie" = (
 /obj/structure/closet{
 	name = "Evidence Closet 2"
@@ -42665,9 +43085,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
 "wnm" = (
@@ -42757,11 +43179,19 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpg" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "wpl" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
@@ -42847,7 +43277,7 @@
 /area/station/cargo/drone_bay)
 "wrl" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "132"
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
@@ -42933,10 +43363,11 @@
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "wtM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -42959,6 +43390,14 @@
 	dir = 4
 	},
 /area/aegis/mining)
+"wur" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/mono,
+/area/station/cargo/sorting)
 "wuy" = (
 /turf/closed/indestructible/rock,
 /area/aegis/surface)
@@ -43055,9 +43494,11 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
 "wxK" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "wyu" = (
@@ -43352,6 +43793,11 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
+"wFV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides,
+/area/station/cargo/warehouse)
 "wFX" = (
 /obj/machinery/jukebox,
 /turf/open/floor/wood,
@@ -43456,6 +43902,20 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
+"wHt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "wHC" = (
 /obj/structure/rack/shelf,
 /obj/effect/turf_decal/bot_white,
@@ -43765,9 +44225,11 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "wSU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/stone,
 /area/aegis/surface)
 "wTm" = (
@@ -43817,15 +44279,6 @@
 "wUC" = (
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
-"wUD" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/server)
 "wUW" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -43931,9 +44384,11 @@
 "wXB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
@@ -43998,6 +44453,12 @@
 	dir = 10
 	},
 /turf/open/floor/deadspace/grater,
+/area/aegis/surface)
+"wYn" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/ironsand,
 /area/aegis/surface)
 "wYs" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
@@ -44154,12 +44615,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/hallway/primary/central/aft)
-"xda" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
 "xdu" = (
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/deadspace/random/maint_right{
@@ -44251,6 +44706,14 @@
 /obj/effect/spawner/random/deadspace/ammo,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
+"xeG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "xeQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -44414,9 +44877,11 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse/upper)
 "xiy" = (
@@ -44450,18 +44915,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/catwalk_floor,
 /area/station/command/bridge)
-"xjn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "xjr" = (
 /obj/item/cultivator,
 /obj/item/crowbar,
@@ -44495,12 +44948,14 @@
 /turf/open/floor/deadspace/mono,
 /area/aegis/mining)
 "xkN" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/conveyor{
 	id = "Storage Upper"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "xkP" = (
@@ -44527,18 +44982,22 @@
 	name = "Mining Tool Storage";
 	req_access_txt = "48"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/mine/storage)
 "xlo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
@@ -44679,10 +45138,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/mono,
 /area/station/service/kitchen/coldroom)
-"xoY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "xpF" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
@@ -44762,17 +45217,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/central)
-"xrP" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
 "xrV" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -44790,11 +45234,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "xsj" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "18"
+	icon_state = "3"
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "xsl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -44821,7 +45267,9 @@
 /area/station/hallway/primary/central/aft)
 "xsQ" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "xsU" = (
@@ -44931,7 +45379,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "xvI" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "xvN" = (
@@ -44985,11 +45437,16 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "xwJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "68"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/lobby)
 "xwY" = (
 /obj/effect/landmark/pestspawn,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -45200,6 +45657,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
+"xDb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/commons/dorms/barracks/male)
 "xDc" = (
 /obj/machinery/light/small/maintenance/directional/east,
 /obj/structure/table/wood,
@@ -45324,6 +45785,9 @@
 /area/station/security/courtroom)
 "xHF" = (
 /obj/machinery/light/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/stone,
 /area/aegis/surface)
 "xHG" = (
@@ -45380,6 +45844,13 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
+"xIL" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "xIM" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/deadspace/random/slides{
@@ -45473,6 +45944,12 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"xLd" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "xLh" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/surface)
@@ -45674,6 +46151,9 @@
 "xRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "xRl" = (
@@ -45804,13 +46284,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/aft)
-"xXu" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "xXD" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -45828,15 +46301,6 @@
 /obj/effect/spawner/random/food_or_drink/snack,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"xXS" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "xXW" = (
 /obj/structure/table,
 /obj/effect/spawner/random/deadspace/ammo,
@@ -45853,8 +46317,8 @@
 	},
 /area/station/hallway/primary/starboard)
 "xYm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
@@ -46001,6 +46465,14 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
+"ycY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/mono,
+/area/station/cargo/sorting)
 "ycZ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -46092,12 +46564,12 @@
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "ygs" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
-/area/aegis/surface)
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "ygt" = (
 /obj/structure/rack/shelf,
 /obj/item/plate_shard/marker_shard,
@@ -46161,13 +46633,14 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/deadspace/mono,
-/area/station/cargo/sorting)
+/obj/structure/cable/white{
+	icon_state = "132"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/service/chapel/monastery)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
@@ -46192,6 +46665,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/aft)
+"yit" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "yiz" = (
 /obj/item/clothing/suit/xenos,
 /obj/item/clothing/head/xenos,
@@ -46248,10 +46730,12 @@
 "yjV" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"yka" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/deadspace/mono,
-/area/station/cargo)
+"yjX" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "ykc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -54554,7 +55038,7 @@ uoP
 trm
 mNO
 mNO
-uyJ
+yhZ
 trm
 ssE
 jxc
@@ -57127,8 +57611,8 @@ hgU
 qkb
 mNS
 vQc
-gqh
 aXf
+qAC
 qli
 qli
 qli
@@ -57280,12 +57764,12 @@ qAj
 boH
 lAb
 gGN
-uCR
+epK
 gpV
 qWI
 buK
 ovu
-pFS
+rTT
 cgY
 qWI
 eoV
@@ -57442,7 +57926,7 @@ bGQ
 qWI
 utT
 cSl
-pFS
+rTT
 cSl
 jpm
 eoV
@@ -57594,12 +58078,12 @@ eAl
 bXp
 yjT
 dAN
-jUc
+uCR
 gGN
 qWI
 utT
 mob
-pFS
+rTT
 mob
 jpm
 eoV
@@ -57751,12 +58235,12 @@ tik
 bXp
 yjT
 gGN
-uCR
+epK
 cXW
 qWI
 utT
 hTB
-pFS
+rTT
 mob
 jpm
 eoV
@@ -57903,8 +58387,8 @@ qVP
 lAb
 qgO
 dfD
-uQN
 ibV
+tIJ
 xDY
 mBz
 isc
@@ -64815,8 +65299,8 @@ qVP
 erk
 erk
 iVy
-rRl
-imS
+iFY
+rfU
 jiS
 jiS
 gRg
@@ -65130,7 +65614,7 @@ erk
 tmo
 ebG
 tDQ
-osG
+guQ
 wEX
 hBa
 ebG
@@ -65287,8 +65771,8 @@ erk
 erk
 ebG
 ebG
-uuS
-dxJ
+cUc
+iwD
 ebG
 ebG
 erk
@@ -65758,7 +66242,7 @@ erk
 erk
 ebG
 ebG
-uuS
+cUc
 ebG
 ebG
 ebG
@@ -66229,7 +66713,7 @@ erk
 erk
 xUZ
 ebG
-uuS
+cUc
 ebG
 ebG
 uyM
@@ -66385,8 +66869,8 @@ vAm
 erk
 jiS
 ebG
-aJv
-uuS
+sdz
+cUc
 jiS
 jiS
 aIS
@@ -66541,10 +67025,10 @@ etJ
 ulq
 erk
 fkx
-xda
+vAC
 ilS
-uuS
-ffw
+cUc
+rMh
 erk
 erk
 erk
@@ -66700,8 +67184,8 @@ erk
 jiS
 jiS
 rfJ
-uuS
-yka
+cUc
+dzp
 erk
 qVP
 qVP
@@ -66857,7 +67341,7 @@ erk
 eUJ
 erk
 uBz
-imS
+rfU
 jiS
 erk
 qVP
@@ -74675,7 +75159,7 @@ sCv
 epE
 sCv
 lVh
-sCv
+nDn
 sCv
 kWK
 sCv
@@ -74825,29 +75309,29 @@ qVP
 qVP
 kWK
 sCv
+whZ
 sCv
 sCv
 sCv
 sCv
 sCv
 sCv
-sCv
-sCv
+trK
 sCv
 kWK
 sCv
 sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
+sCc
+gqh
+gqh
+gqh
+gqh
+rQA
+trK
+trK
+trK
+trK
+fvx
 gHW
 tbB
 gHW
@@ -74982,14 +75466,14 @@ qVP
 qVP
 kWK
 goN
+iCe
 goN
 goN
 goN
 goN
 goN
 goN
-goN
-goN
+wbT
 goN
 kWK
 mgm
@@ -74999,7 +75483,7 @@ goN
 goN
 goN
 goN
-goN
+mVx
 goN
 goN
 goN
@@ -75139,14 +75623,14 @@ qVP
 qVP
 kWK
 lDu
-lDu
-lDu
-nOn
-lDu
+qHk
 lDu
 nOn
 lDu
 lDu
+nOn
+lDu
+awP
 lDu
 lTv
 lDu
@@ -75156,7 +75640,7 @@ lDu
 lDu
 lDu
 nOn
-lDu
+uSZ
 lDu
 nOn
 lDu
@@ -75296,14 +75780,14 @@ qVP
 qVP
 uYj
 mPy
-mPy
-mPy
-uYj
-mPy
+vUH
 mPy
 uYj
 mPy
 mPy
+uYj
+mPy
+nll
 mPy
 uYj
 mPy
@@ -75313,7 +75797,7 @@ mPy
 mPy
 mPy
 uYj
-mPy
+wFV
 mPy
 uYj
 mPy
@@ -75453,24 +75937,24 @@ rqy
 qVP
 lxi
 mvU
-wwS
-wwS
-wwS
-sCv
-sCv
-wwS
-wwS
-wwS
-wwS
-wwS
-wwS
-wwS
-wwS
-wwS
-wwS
+fCB
 wwS
 wwS
 sCv
+sCv
+wwS
+wwS
+gBn
+wwS
+wwS
+wwS
+wwS
+wwS
+wwS
+wwS
+wwS
+wwS
+rQA
 sCv
 wwS
 wwS
@@ -75610,24 +76094,24 @@ ozq
 pFl
 mUC
 wnU
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
+uQN
 bmx
 bmx
 bmx
@@ -75767,24 +76251,24 @@ rqy
 qVP
 lxi
 wUu
-gvZ
-gvZ
-gvZ
-sCv
-sCv
-gvZ
-gvZ
-gvZ
-gvZ
-gvZ
-gvZ
-gvZ
-gvZ
-gvZ
-gvZ
+nSo
 gvZ
 gvZ
 sCv
+sCv
+gvZ
+gvZ
+dUm
+gvZ
+gvZ
+gvZ
+gvZ
+gvZ
+gvZ
+gvZ
+gvZ
+gvZ
+rQA
 sCv
 gvZ
 gvZ
@@ -75924,14 +76408,14 @@ qVP
 qVP
 uYj
 goN
-goN
-goN
-uYj
-goN
+wbT
 goN
 uYj
 goN
 goN
+uYj
+goN
+iCe
 goN
 uYj
 goN
@@ -75941,7 +76425,7 @@ goN
 goN
 goN
 uYj
-goN
+mVx
 goN
 uYj
 goN
@@ -76081,14 +76565,14 @@ qVP
 qVP
 kWK
 lDu
-lDu
-lDu
-asE
-lDu
+awP
 lDu
 asE
 lDu
 lDu
+asE
+lDu
+qHk
 lDu
 lTv
 lDu
@@ -76098,7 +76582,7 @@ lDu
 lDu
 lDu
 asE
-lDu
+uSZ
 lDu
 asE
 lDu
@@ -76238,14 +76722,14 @@ qVP
 qVP
 kWK
 mPy
+nll
 mPy
 mPy
 mPy
 mPy
 mPy
 mPy
-mPy
-mPy
+vUH
 mPy
 kWK
 aPO
@@ -76255,7 +76739,7 @@ mPy
 mPy
 mPy
 mPy
-mPy
+wFV
 mPy
 mPy
 mPy
@@ -76395,30 +76879,30 @@ qVP
 qVP
 kWK
 sCv
+trK
 sCv
 sCv
 sCv
 sCv
 sCv
 sCv
-sCv
-sCv
+gqh
 sCv
 kWK
 sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
+oEC
+trK
+trK
+trK
+trK
+trK
+rQA
+gqh
+gqh
+gqh
+gqh
+gqh
+tmB
 sCv
 sCv
 kWK
@@ -76552,14 +77036,14 @@ qVP
 qVP
 kWK
 sCv
+but
 sCv
 sCv
 sCv
 sCv
 sCv
 sCv
-sCv
-sCv
+mBv
 sCv
 kWK
 sCv
@@ -76569,7 +77053,7 @@ cQh
 cQh
 cQh
 sCv
-sCv
+rQA
 sCv
 sCv
 sCv
@@ -76725,8 +77209,8 @@ sCv
 sCv
 dqU
 tCy
-cSt
-cSt
+fzJ
+fzJ
 cSt
 cSt
 cSt
@@ -76736,7 +77220,7 @@ cSt
 cSt
 cSt
 aqr
-gpv
+ptq
 sCv
 mHX
 ljF
@@ -79239,7 +79723,7 @@ xVM
 xVM
 xVM
 fQc
-jhA
+cKw
 pMt
 gRy
 rwp
@@ -79680,7 +80164,7 @@ rwR
 azW
 hbH
 fXy
-oTz
+bVH
 iYH
 iYH
 iYH
@@ -80012,7 +80496,7 @@ mwV
 eDu
 mwV
 mwV
-sWd
+xDb
 qwb
 alr
 jJc
@@ -80475,7 +80959,7 @@ wbh
 sFi
 dnX
 sNO
-jdI
+ncO
 sNO
 dTJ
 sFi
@@ -80618,7 +81102,7 @@ qVP
 anE
 gRv
 gRv
-rXD
+cUw
 sxL
 cYy
 anE
@@ -80775,7 +81259,7 @@ qVP
 anE
 sxe
 nAx
-rXD
+cUw
 vqU
 bro
 anE
@@ -80932,7 +81416,7 @@ qVP
 anE
 fDg
 mbe
-cUw
+ror
 wSD
 aqS
 anE
@@ -80945,8 +81429,8 @@ veo
 veo
 sFi
 nAH
-ncO
-kpP
+uDI
+pwG
 sNO
 dIR
 sFi
@@ -81089,7 +81573,7 @@ qVP
 anE
 hTF
 tXB
-rXD
+cUw
 vqU
 oJf
 anE
@@ -81417,7 +81901,7 @@ vxt
 sFi
 xqH
 sNO
-jdI
+ncO
 sNO
 jhD
 sFi
@@ -82192,7 +82676,7 @@ nHL
 azW
 hbH
 dVP
-gqW
+tKm
 jKk
 jKk
 jKk
@@ -82700,7 +83184,7 @@ tyr
 dmW
 hEO
 mui
-pNZ
+obj
 vHE
 eEt
 qYZ
@@ -83152,7 +83636,7 @@ fnR
 sMY
 tQS
 hnk
-bTd
+bqd
 msD
 ayh
 npi
@@ -83162,8 +83646,8 @@ bYo
 kBk
 ruP
 bwu
+bgl
 jaQ
-ijA
 nAc
 wVk
 ijf
@@ -83309,7 +83793,7 @@ fnR
 jfz
 hnk
 tQS
-bqd
+bfq
 lqv
 rCd
 npi
@@ -83738,11 +84222,11 @@ qVP
 qVP
 wuy
 wuy
-iol
-iol
-iol
-iol
-iol
+dSu
+dSu
+dSu
+dSu
+dSu
 wuy
 wuy
 wuy
@@ -83814,7 +84298,7 @@ reE
 khL
 qbh
 qbh
-mWE
+uyg
 akB
 qyr
 qVP
@@ -83894,24 +84378,24 @@ wuy
 wuy
 wuy
 wuy
-iol
-iol
-iol
-iol
-iol
-iol
-iol
-iol
-iol
-iol
-iol
-iol
-iol
-iol
-iol
-iol
-iol
-iol
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
 wuy
 wuy
 vRZ
@@ -83954,7 +84438,7 @@ mwp
 yfI
 cZh
 uEm
-tXY
+xRk
 xfD
 vky
 dAe
@@ -83966,11 +84450,11 @@ vky
 vky
 vky
 vky
-tMD
+fMx
 vky
 tCw
 aQM
-mfG
+kpP
 nqY
 daa
 qyr
@@ -84047,29 +84531,29 @@ qVP
 qVP
 qVP
 wuy
-iol
-iol
-ygs
-ygs
-ygs
-ygs
-ygs
-ygs
-iol
-iol
-iol
-iol
-iol
-iol
-iol
+dSu
+dSu
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
 qnp
-ygs
-ygs
-ygs
-ygs
-ygs
-iol
-iol
+nBX
+nBX
+nBX
+nBX
+nBX
+dSu
+dSu
 wuy
 vRZ
 bzI
@@ -84110,14 +84594,14 @@ elo
 mwp
 tTg
 blQ
-xRk
-xRk
+hDf
+hDf
 mwp
 uej
 bNV
 bNV
 bNV
-mWE
+uyg
 bNV
 bNV
 bNV
@@ -84125,7 +84609,7 @@ bNV
 bNV
 bNV
 bNV
-mWE
+uyg
 bNV
 bNV
 bNV
@@ -84204,29 +84688,29 @@ qVP
 qVP
 qVP
 wuy
-iol
-ygs
+dSu
+nBX
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-iol
-iol
-iol
+dSu
+dSu
+dSu
 dsu
-iol
-iol
-iol
+dSu
+dSu
+dSu
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-ygs
-iol
+nBX
+dSu
 wuy
 vRZ
 uho
@@ -84274,7 +84758,7 @@ vHk
 mct
 vmQ
 bHR
-mWE
+uyg
 qWQ
 qyr
 qyr
@@ -84282,7 +84766,7 @@ qyr
 qyr
 qyr
 uck
-mWE
+uyg
 daa
 qyr
 qyr
@@ -84361,29 +84845,29 @@ qVP
 qVP
 qVP
 wuy
-iol
-ygs
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-iol
-iol
-iol
+dSu
+nBX
+swY
+swY
+swY
+swY
+swY
+swY
+dSu
+dSu
+dSu
 nGf
-iol
-iol
-iol
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-ygs
-iol
+dSu
+dSu
+dSu
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
+dSu
 wuy
 vRZ
 ham
@@ -84431,15 +84915,15 @@ qyr
 qyr
 qyr
 bHR
-jsg
-rlb
+eTF
+gwR
 tWq
-pRj
+diA
 cVO
 weY
 qyr
 bHR
-mWE
+uyg
 daa
 qSo
 qSo
@@ -84518,14 +85002,14 @@ qVP
 qVP
 qVP
 wuy
-iol
-ygs
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
+dSu
+nBX
+swY
+swY
+swY
+swY
+swY
+swY
 gbS
 gbS
 gbS
@@ -84533,14 +85017,14 @@ dsu
 gbS
 gbS
 gbS
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-ygs
-iol
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
+dSu
 wuy
 vRZ
 vRZ
@@ -84588,7 +85072,7 @@ kGp
 dSB
 aSO
 bHR
-mWE
+uyg
 qpF
 trI
 iee
@@ -84596,7 +85080,7 @@ qam
 fGV
 qyr
 bHR
-mWE
+uyg
 daa
 qKU
 qKU
@@ -84675,29 +85159,29 @@ qVP
 qVP
 qVP
 wuy
-iol
-iol
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-iol
-iol
-iol
+dSu
+dSu
+swY
+swY
+swY
+swY
+swY
+swY
+dSu
+dSu
+dSu
 nGf
-iol
-iol
-iol
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-iol
-iol
+dSu
+dSu
+dSu
+swY
+swY
+swY
+swY
+swY
+swY
+dSu
+dSu
 wuy
 qVP
 qVP
@@ -84740,12 +85224,12 @@ bJz
 wqD
 bJz
 bJz
-ldv
+eOp
 oqy
 oqy
-uwL
+oab
 bHR
-mWE
+uyg
 jYt
 qyr
 qyr
@@ -84753,7 +85237,7 @@ qyr
 qyr
 qyr
 tfu
-tLv
+mWE
 igw
 fpu
 fpu
@@ -84832,29 +85316,29 @@ qVP
 qVP
 qVP
 wuy
-iol
-ygs
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-iol
-iol
-iol
+dSu
+nBX
+swY
+swY
+swY
+swY
+swY
+swY
+dSu
+dSu
+dSu
 nGf
-iol
-iol
-iol
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-ygs
-iol
+dSu
+dSu
+dSu
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
+dSu
 wuy
 qVP
 qVP
@@ -84890,27 +85374,27 @@ ohU
 wEZ
 wEZ
 lWL
-qUM
-qUM
+pfG
+pfG
 xPJ
-qUM
-qUM
-qUM
-qUM
+pfG
+pfG
+pfG
+pfG
 kVf
 uSt
 kVO
-nTW
+idt
 sXZ
 bHX
-rlb
+gwR
 tWq
-pRj
+diA
 dHZ
 weY
 qyr
 bHR
-mWE
+uyg
 daa
 qKU
 qKU
@@ -84989,14 +85473,14 @@ qVP
 qVP
 qVP
 wuy
-iol
-ygs
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
+dSu
+nBX
+swY
+swY
+swY
+swY
+swY
+swY
 gbS
 gbS
 gbS
@@ -85004,13 +85488,13 @@ dsu
 gbS
 gbS
 gbS
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-ygs
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
 gbS
 wuy
 qVP
@@ -85059,7 +85543,7 @@ qyr
 qyr
 qyr
 bHR
-mWE
+uyg
 lQE
 bqe
 iee
@@ -85067,7 +85551,7 @@ qam
 wYH
 qyr
 bHR
-mWE
+uyg
 daa
 jNW
 jNW
@@ -85146,28 +85630,28 @@ qVP
 qVP
 qVP
 wuy
-iol
-ygs
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-iol
-iol
-iol
+dSu
+nBX
+swY
+swY
+swY
+swY
+swY
+swY
+dSu
+dSu
+dSu
 nGf
-iol
-iol
-iol
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-ygs
+dSu
+dSu
+dSu
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
 dsu
 wuy
 qVP
@@ -85303,28 +85787,28 @@ qVP
 qVP
 qVP
 wuy
-iol
-iol
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-iol
-iol
-iol
+dSu
+dSu
+swY
+swY
+swY
+swY
+swY
+swY
+dSu
+dSu
+dSu
 nGf
-iol
-iol
-iol
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-iol
+dSu
+dSu
+dSu
+swY
+swY
+swY
+swY
+swY
+swY
+dSu
 gbS
 wuy
 qVP
@@ -85373,15 +85857,15 @@ gPB
 qbh
 qbh
 bHR
-tLv
-rlb
+mWE
+gwR
 tWq
-pRj
+diA
 aTa
 weY
 qyr
 bHR
-mWE
+uyg
 daa
 qyr
 qyr
@@ -85460,14 +85944,14 @@ qVP
 qVP
 qVP
 wuy
-iol
-bSO
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
+dSu
+lCi
+swY
+swY
+swY
+swY
+swY
+swY
 gbS
 gbS
 gbS
@@ -85475,13 +85959,13 @@ dsu
 gbS
 gbS
 gbS
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-iol
+swY
+swY
+swY
+swY
+swY
+swY
+dSu
 gbS
 wuy
 qVP
@@ -85530,7 +86014,7 @@ vky
 vky
 vky
 vky
-loc
+dJM
 lQE
 aII
 iee
@@ -85538,7 +86022,7 @@ qam
 hHl
 qyr
 bHR
-mWE
+uyg
 daa
 qbh
 qbh
@@ -85617,27 +86101,27 @@ qVP
 qVP
 qVP
 wuy
-iol
-bSO
+dSu
+lCi
+fwp
 jeU
-vwz
-idt
-vwz
-idt
+unh
 jeU
-iol
-iol
-iol
+unh
+fwp
+dSu
+dSu
+dSu
 nGf
-iol
-iol
-iol
+dSu
+dSu
+dSu
+fwp
 jeU
-vwz
-idt
-vwz
-idt
+unh
 jeU
+unh
+fwp
 gbS
 gbS
 wuy
@@ -85682,12 +86166,12 @@ psI
 pnG
 bpE
 faw
-nrT
+hgB
 uej
 bNV
 bNV
 bHR
-mWE
+uyg
 hor
 qyr
 qyr
@@ -85695,12 +86179,12 @@ qyr
 qyr
 qyr
 uck
-swY
-pfG
-pfG
-pfG
-pfG
-pfG
+dvw
+iix
+iix
+iix
+iix
+iix
 cah
 ioB
 nPD
@@ -85777,10 +86261,10 @@ wuy
 wuy
 qQP
 lhT
-foq
-foq
-foq
-foq
+cIz
+cIz
+cIz
+cIz
 vTc
 qQP
 qQP
@@ -85790,10 +86274,10 @@ qQP
 qQP
 qQP
 pXJ
-kpk
-kpk
-kpk
-kpk
+drk
+drk
+drk
+drk
 rgW
 qQP
 wuy
@@ -85844,15 +86328,15 @@ qyr
 qyr
 qyr
 bHR
-tLv
-rlb
+mWE
+gwR
 tWq
-pRj
+diA
 fwd
 weY
 qyr
 bHR
-mWE
+uyg
 daa
 qnh
 qyr
@@ -85934,7 +86418,7 @@ qVP
 qVP
 qQP
 hBo
-gXh
+weG
 aIL
 aIL
 aIL
@@ -85947,10 +86431,10 @@ fnm
 geM
 bwR
 gFk
+weG
 gXh
-lDx
-gXh
-gXh
+weG
+weG
 nJu
 qQP
 qVP
@@ -86001,7 +86485,7 @@ vMZ
 gmr
 cPb
 oYf
-mWE
+uyg
 lQE
 tmp
 iee
@@ -86009,7 +86493,7 @@ qam
 kIo
 qyr
 bHR
-mWE
+uyg
 daa
 wAU
 sBj
@@ -86108,7 +86592,7 @@ isV
 tXh
 uzD
 bAy
-bvS
+lzz
 ogk
 qVP
 qVP
@@ -86158,7 +86642,7 @@ wie
 mny
 qyr
 bHR
-mWE
+uyg
 ebi
 qyr
 qyr
@@ -86166,7 +86650,7 @@ qyr
 qyr
 qyr
 uck
-mWE
+uyg
 daa
 mdl
 qyr
@@ -86265,7 +86749,7 @@ nzy
 sjI
 bIh
 lyZ
-oDX
+dAF
 rUa
 qVP
 qVP
@@ -86284,7 +86768,7 @@ dyb
 aUy
 vQq
 riy
-nOQ
+pmS
 ayu
 dUo
 bPG
@@ -86307,7 +86791,7 @@ cPX
 wce
 bbh
 hTw
-iEi
+dLH
 tml
 rCl
 ifc
@@ -86315,7 +86799,7 @@ efK
 bwU
 qyr
 bHR
-mWE
+uyg
 qbh
 gPB
 qbh
@@ -86323,7 +86807,7 @@ qbh
 qbh
 qbh
 qbh
-mWE
+uyg
 qbh
 qbh
 kFF
@@ -86423,7 +86907,7 @@ eIK
 kit
 edO
 hCO
-pmS
+dUe
 qVP
 qVP
 qVP
@@ -86473,17 +86957,17 @@ nGw
 qyr
 nDq
 xLA
-pfG
+iix
 ejX
-mfG
+kpP
 cPn
-mfG
-mfG
-mfG
+kpP
+kpP
+kpP
 pqx
+kpP
+kpP
 mfG
-mfG
-phE
 wmg
 ust
 qyr
@@ -86580,7 +87064,7 @@ jiK
 iMZ
 blO
 cTo
-pmS
+dUe
 qVP
 qVP
 qVP
@@ -86640,7 +87124,7 @@ bNV
 vrG
 bNV
 bNV
-cVt
+gTX
 bNV
 bNV
 qyr
@@ -86735,8 +87219,8 @@ qMD
 gGE
 sVe
 yim
-kaD
-dAF
+jCN
+rnQ
 dOf
 qVP
 qVP
@@ -87268,7 +87752,7 @@ dTg
 dTg
 dTg
 cmX
-kZk
+azf
 isb
 tsI
 wCo
@@ -87417,7 +87901,7 @@ lJw
 cFv
 syO
 pgS
-xYm
+abd
 joj
 woI
 eZS
@@ -87574,7 +88058,7 @@ dmE
 cFv
 crs
 fLg
-uFr
+xYm
 dYv
 woI
 qZi
@@ -87848,9 +88332,9 @@ uxc
 wCJ
 vVb
 vVb
-thV
-thV
-thV
+bYx
+bYx
+bYx
 mUn
 mUn
 mUn
@@ -87983,11 +88467,11 @@ xth
 xth
 xth
 xth
-oiD
-tIj
-tIj
+xIL
 eIL
-xXu
+eIL
+upb
+ygs
 xth
 fdA
 uOG
@@ -88008,7 +88492,7 @@ kPt
 oyt
 egd
 kNZ
-gnX
+yjX
 mUn
 mUn
 mUn
@@ -88143,7 +88627,7 @@ cNx
 aJZ
 llM
 gMP
-nBX
+tkh
 tEB
 xth
 rRW
@@ -88160,12 +88644,12 @@ ghX
 ojj
 qAi
 vVb
-dUe
+qly
 pWI
-bYx
-bYx
-bYx
-wpg
+ldv
+ldv
+ldv
+aBf
 mUn
 dpz
 mUn
@@ -88182,29 +88666,29 @@ oIb
 jcd
 bPG
 bSP
-cKw
+fsl
 gRf
 mLj
 uME
 nLC
 qyR
 lzq
-sPk
+cOX
 cBm
 xki
-tcX
-tcX
-tcX
-hDp
-cOX
-tcX
-tcX
+flr
+flr
+flr
+hyS
+mUx
+flr
+flr
 tcQ
 dLA
+flr
 tcX
-lTl
-tcX
-tcX
+flr
+flr
 vwt
 tup
 vmf
@@ -88300,7 +88784,7 @@ bUh
 oRx
 tYl
 hpF
-efO
+vOt
 iVk
 xth
 nCJ
@@ -88312,7 +88796,7 @@ lSF
 gOY
 mHD
 nPN
-svh
+tNh
 icl
 ojj
 tit
@@ -88322,7 +88806,7 @@ iqB
 gvY
 pkg
 cqi
-wpg
+aBf
 jDd
 dxU
 tsG
@@ -88347,7 +88831,7 @@ ngP
 oYw
 rPR
 kCq
-iix
+ffw
 kCq
 jpQ
 kCq
@@ -88479,7 +88963,7 @@ smA
 gvY
 mUn
 mUn
-wpg
+aBf
 lch
 gvY
 gvY
@@ -88635,8 +89119,8 @@ gFX
 gFX
 gFX
 kih
-weG
-aBf
+ija
+bPf
 fsT
 gvY
 qVP
@@ -88652,7 +89136,7 @@ pLY
 ccd
 jML
 cwa
-feD
+wHt
 jlM
 uwQ
 gqi
@@ -88692,7 +89176,7 @@ eet
 vEb
 val
 jRe
-dSu
+imS
 bfm
 xKp
 qVP
@@ -88923,16 +89407,16 @@ kDP
 kDP
 kDP
 kDP
-hqi
-hqi
+kpk
+kpk
 eCA
-hqi
-hqi
+kpk
+kpk
 pAx
 gbr
-esS
-ukz
 pSi
+ukz
+cOO
 tfP
 hPr
 jgb
@@ -88940,7 +89424,7 @@ fBA
 tfj
 eFj
 mcE
-iCe
+koP
 avK
 uiB
 pIx
@@ -89149,18 +89633,18 @@ xCy
 wbK
 oEA
 vmh
-tcX
+flr
 qcz
 nOt
-tcX
+flr
 aur
-tcX
-tcX
-tcX
-tcX
-tcX
-tcX
-tcX
+flr
+flr
+flr
+flr
+flr
+flr
+flr
 kCT
 pWM
 cON
@@ -89310,7 +89794,7 @@ izF
 sPc
 kCq
 kCq
-iix
+ffw
 kCq
 fqY
 kCq
@@ -89387,9 +89871,9 @@ qVP
 gsG
 gsG
 gsG
-iUB
+efO
 adK
-mxq
+izE
 gsG
 gsG
 pMH
@@ -89408,7 +89892,7 @@ sSt
 pmf
 jto
 xtH
-upb
+jdI
 fRQ
 xbE
 wmL
@@ -89537,7 +90021,7 @@ rqy
 rqy
 rqy
 rqy
-wrl
+qhR
 rqy
 qVP
 qVP
@@ -89556,7 +90040,7 @@ gsG
 gsG
 oBx
 ccb
-wtM
+oqg
 ccb
 ubN
 xnC
@@ -89565,7 +90049,7 @@ nJs
 jSE
 kPV
 mXQ
-upb
+jdI
 ktu
 xbE
 wmL
@@ -89694,7 +90178,7 @@ qVP
 rqy
 eSR
 rqy
-fnB
+sEX
 jnM
 qVP
 qVP
@@ -90005,8 +90489,8 @@ rqy
 rqy
 rqy
 rqy
-xsj
-ocO
+jIq
+wYn
 rqy
 wyu
 qVP
@@ -90036,7 +90520,7 @@ huG
 aYV
 mrm
 upl
-upb
+jdI
 mKE
 jqC
 dEQ
@@ -90159,9 +90643,9 @@ qVP
 rqy
 rqy
 rqy
-hMw
-mCd
-nAO
+gQj
+nMG
+xLd
 rqy
 rqy
 rqy
@@ -90193,10 +90677,10 @@ rDV
 iAC
 fRC
 bmS
-upb
+jdI
 pIG
 kNf
-bGK
+ezg
 lwr
 hPz
 xwH
@@ -90505,10 +90989,10 @@ cMl
 oaV
 vBz
 pee
-gwR
+bhY
 jgI
 cAY
-xoY
+sDh
 oTl
 sRF
 sRF
@@ -90627,7 +91111,7 @@ qVP
 rqy
 rqy
 tuc
-lFI
+wrl
 qVP
 qVP
 qVP
@@ -90661,11 +91145,11 @@ vPr
 ebH
 fjl
 hfM
-pIJ
-fwp
+utg
+dhS
 tKf
 jYX
-uOU
+urW
 qoR
 sRF
 keh
@@ -90694,17 +91178,17 @@ sxj
 sxj
 bPG
 djt
-cKw
+fsl
 xnE
 qgi
 uMo
 epq
 djC
-mBv
-mBv
-mBv
-mBv
-mBv
+tIj
+tIj
+tIj
+tIj
+tIj
 djC
 maK
 fpH
@@ -90717,7 +91201,7 @@ lrx
 xxC
 xxC
 rlA
-mBv
+tIj
 xxC
 uKh
 lhm
@@ -90784,7 +91268,7 @@ qVP
 rqy
 rqy
 tuc
-wrl
+qhR
 qVP
 qVP
 qVP
@@ -90833,7 +91317,7 @@ wDy
 rkU
 vQi
 rkU
-eby
+gGD
 pZv
 sxj
 wDV
@@ -90941,7 +91425,7 @@ qVP
 rqy
 rqy
 tuc
-nPt
+ocO
 qVP
 qVP
 qVP
@@ -90971,7 +91455,7 @@ mpT
 eGf
 gkJ
 jZb
-teI
+aJA
 kEE
 ebH
 kRQ
@@ -90990,7 +91474,7 @@ fDt
 rbK
 rbK
 rbK
-oPG
+vNq
 pZv
 sxj
 eLJ
@@ -91099,7 +91583,7 @@ qVP
 qVP
 rqy
 rqy
-xwJ
+ebu
 qVP
 qVP
 qVP
@@ -91128,8 +91612,8 @@ anZ
 eGf
 eAg
 sxb
-mou
-qsb
+ouq
+rlW
 gkJ
 eAg
 feG
@@ -91256,7 +91740,7 @@ qVP
 qVP
 qVP
 rqy
-qwm
+lWk
 rqy
 rqy
 rqy
@@ -91286,7 +91770,7 @@ exz
 hFC
 gQv
 tfU
-dMZ
+vrp
 ohb
 ebH
 mbT
@@ -91414,7 +91898,7 @@ rqy
 qVP
 qVP
 rqy
-xwJ
+ebu
 rqy
 rqy
 rqy
@@ -91890,7 +92374,7 @@ qVP
 qVP
 rqy
 rHU
-wrl
+qhR
 rqy
 rqy
 rqy
@@ -92047,7 +92531,7 @@ qVP
 qVP
 qVP
 rHU
-wrl
+qhR
 rqy
 rqy
 rqy
@@ -92204,7 +92688,7 @@ qVP
 qVP
 iHy
 ruE
-xXS
+yit
 rqy
 rqy
 rqy
@@ -92246,7 +92730,7 @@ rkX
 bkg
 ieE
 ijk
-eXY
+qHf
 rkU
 sxj
 puN
@@ -92359,9 +92843,9 @@ rqy
 rqy
 rqy
 rqy
-wrl
+qhR
 rEA
-quR
+jrY
 rEA
 rEA
 sIt
@@ -92388,7 +92872,7 @@ naE
 mCH
 dvF
 hHs
-kdT
+aEF
 dwU
 blf
 blf
@@ -92397,7 +92881,7 @@ woN
 bDj
 bnW
 vwd
-jVj
+haR
 eDU
 rkX
 wzw
@@ -92516,9 +93000,9 @@ rqy
 rqy
 rqy
 rqy
-wrl
+qhR
 rek
-nhi
+vMn
 jJJ
 wAN
 sIt
@@ -92555,12 +93039,12 @@ mbT
 jpS
 vwd
 jaR
-haR
+aYP
 eYu
 eYu
 qXg
 cAk
-eXY
+qHf
 bvP
 sxj
 eaH
@@ -92603,7 +93087,7 @@ jhV
 bid
 bUP
 nLV
-wUD
+snt
 sAH
 edX
 xRl
@@ -92673,12 +93157,12 @@ qVP
 rqy
 rqy
 rqy
-cUc
+aMR
 rEA
-bmH
+nGv
 jBo
 oYE
-fIK
+quR
 ruE
 ieM
 rqy
@@ -92744,11 +93228,11 @@ dHN
 dHN
 kXb
 sTl
+xsj
+iJI
+xsj
+xsj
 bcm
-qAY
-bcm
-bcm
-trK
 cMP
 cMP
 mhi
@@ -92830,7 +93314,7 @@ qVP
 rqy
 tuc
 tuc
-wrl
+qhR
 rEA
 aQr
 oXp
@@ -93196,7 +93680,7 @@ yio
 yio
 yio
 yio
-xjn
+fBE
 rDZ
 fEk
 vDP
@@ -93362,7 +93846,7 @@ fVs
 sBp
 soj
 juy
-laC
+dka
 iGp
 wZK
 snn
@@ -93811,12 +94295,12 @@ hHi
 hHi
 rTI
 rWq
-kiR
+qSC
 rWq
 fwj
 qIi
-fsl
-fsl
+hMH
+hMH
 cFk
 faY
 qVP
@@ -94123,14 +94607,14 @@ xJv
 hqp
 xTj
 qwA
-qVk
+uGU
 xNF
 eBq
 aKq
 faY
 pDD
 wgO
-fsl
+hMH
 pYw
 faY
 fPT
@@ -94280,7 +94764,7 @@ uaC
 hqp
 rSF
 kAv
-iJI
+stk
 hgV
 rlP
 mHv
@@ -94306,7 +94790,7 @@ kyw
 gNo
 rAl
 uXc
-vLN
+sPk
 fDQ
 riO
 pkp
@@ -94437,7 +94921,7 @@ uaC
 hqp
 xgO
 kAv
-fdT
+dzg
 wcV
 jSw
 rQc
@@ -94449,7 +94933,7 @@ olg
 faY
 otF
 rkU
-aOs
+rDI
 rkU
 rkU
 gmN
@@ -94595,9 +95079,9 @@ hqp
 kAg
 pug
 akZ
-dfR
-ivi
-nyJ
+eWy
+dCz
+fdT
 faY
 ktR
 bbF
@@ -94620,7 +95104,7 @@ kxK
 kgC
 iTo
 uXc
-oUz
+vmK
 pcA
 bVG
 qhu
@@ -95077,7 +95561,7 @@ iel
 iel
 iel
 iel
-uyg
+mou
 eCC
 njj
 wYA
@@ -95234,7 +95718,7 @@ odc
 odc
 odc
 odc
-vmK
+qAY
 tXH
 njj
 ncl
@@ -95424,7 +95908,7 @@ fCw
 fUt
 trT
 aes
-tZt
+iol
 swv
 qUq
 sCq
@@ -95548,7 +96032,7 @@ uxN
 uxN
 uxN
 uxN
-uyg
+mou
 eCC
 njj
 tNe
@@ -95581,7 +96065,7 @@ swv
 swv
 iUp
 swv
-tZt
+iol
 swv
 tij
 pvL
@@ -95705,7 +96189,7 @@ iJv
 iJv
 iJv
 iJv
-vmK
+qAY
 aWW
 jfn
 bev
@@ -95862,7 +96346,7 @@ iXU
 ivg
 iXU
 ueC
-flr
+ihP
 hfD
 wHF
 cvC
@@ -95878,11 +96362,11 @@ dZO
 sAo
 sAo
 oZq
-iDC
+ktN
 rrw
-xrP
+oDX
 vtr
-qMP
+pwU
 lOB
 cgv
 wEk
@@ -95895,7 +96379,7 @@ xnH
 epg
 ngl
 ngl
-guQ
+tZt
 swv
 tij
 pvL
@@ -96019,7 +96503,7 @@ iel
 iel
 iel
 iel
-uyg
+mou
 eCC
 jfn
 bev
@@ -96037,7 +96521,7 @@ sAo
 kYq
 cCP
 mBt
-fBC
+jpV
 fzw
 xew
 eGW
@@ -96052,7 +96536,7 @@ swv
 swv
 swv
 swv
-tZt
+iol
 swv
 tij
 pvL
@@ -96176,7 +96660,7 @@ odc
 odc
 odc
 odc
-vmK
+qAY
 aWW
 njj
 tNe
@@ -96209,7 +96693,7 @@ lHv
 swv
 lty
 swv
-tZt
+iol
 swv
 tij
 pvL
@@ -96351,7 +96835,7 @@ sej
 lmF
 aLW
 ayy
-dqH
+phP
 tVH
 tMP
 vrC
@@ -96366,7 +96850,7 @@ juz
 xNd
 trT
 aes
-tZt
+iol
 swv
 gbi
 oFO
@@ -96490,7 +96974,7 @@ uxN
 uxN
 uxN
 uxN
-uyg
+mou
 xdQ
 njj
 ncl
@@ -96523,7 +97007,7 @@ swv
 swv
 swv
 swv
-tZt
+iol
 swv
 swv
 swv
@@ -96647,7 +97131,7 @@ iJv
 iJv
 iJv
 iJv
-vmK
+qAY
 aWW
 njj
 fjW
@@ -96680,14 +97164,14 @@ icC
 icC
 icC
 icC
-sup
+wpg
 ngl
 ngl
 ngl
 ngl
 ngl
 ngl
-avq
+mYN
 jpF
 shR
 oQR
@@ -96832,19 +97316,19 @@ lLU
 nyU
 nyU
 nyU
-hDf
-hmB
+pPq
+jtr
 qcm
 nyU
 eFY
-tZt
+iol
 xFe
 ilB
 evb
 swv
 xFe
 ghq
-uGU
+ewa
 swv
 shR
 lXt
@@ -96957,23 +97441,23 @@ jfn
 iel
 hKR
 cpt
-dJx
+wtM
 qgU
-dJx
-dJx
-tkg
+wtM
+wtM
+jOG
 dtP
 njj
 qwK
 kyb
-cKm
+fdE
 pmL
 vNP
 rsD
 eHS
 cCT
-chP
-chP
+ifH
+ifH
 ldF
 rKt
 hSX
@@ -96994,14 +97478,14 @@ tuB
 peY
 nyU
 swv
-tZt
+iol
 evb
 swv
 xFe
 swv
 xFe
 swv
-aZU
+rXD
 ngl
 qno
 qbt
@@ -97131,34 +97615,34 @@ rKt
 rKt
 rKt
 rKt
-ldF
+xwJ
 mNP
 mNP
 rUg
 cml
-cMn
+rjR
 lkQ
 lVO
 nHM
 xsQ
-xsQ
+bcN
 jyy
 nyU
 brk
 syb
 pCw
 oUk
-qHT
+qAU
 tmW
 ngl
-oGE
+aJv
 xFe
 swv
 evb
 swv
 evb
 swv
-rDI
+gAR
 swv
 shR
 qIY
@@ -97298,7 +97782,7 @@ vkm
 lVO
 kiq
 jjG
-xzt
+chP
 uTS
 cHJ
 hpz
@@ -97455,7 +97939,7 @@ igF
 lVO
 vpw
 sVG
-xzt
+chP
 sIH
 uLy
 mCX
@@ -97612,9 +98096,9 @@ tXl
 lVO
 dsg
 imT
-xzt
+chP
 sIH
-qHk
+amf
 wGC
 fts
 lue
@@ -97769,12 +98253,12 @@ lVO
 lVO
 iaO
 iaO
-xzt
+chP
 sIH
-tNh
+pvC
 sUB
 xMe
-rlW
+uNE
 rIL
 kLy
 nyU
@@ -97926,7 +98410,7 @@ pzZ
 lVO
 fLK
 xzt
-xzt
+chP
 sIH
 nyU
 nyU
@@ -98072,7 +98556,7 @@ qVP
 qVP
 lVO
 hvQ
-hvQ
+ode
 xlo
 fZe
 fZe
@@ -98082,7 +98566,7 @@ oqG
 vYd
 sfB
 vvK
-mUd
+uuS
 mUd
 hGw
 lLU
@@ -98228,9 +98712,9 @@ qVP
 qVP
 qVP
 lVO
-ode
+hvQ
 nuf
-ewa
+hvQ
 hvQ
 hvQ
 mCU
@@ -98413,7 +98897,7 @@ qBi
 ijm
 txt
 jpj
-sCc
+wur
 piB
 piB
 txt
@@ -98549,7 +99033,7 @@ ney
 mRg
 cxq
 rAb
-wxK
+lcL
 xUf
 xOZ
 qpB
@@ -98569,7 +99053,7 @@ hvt
 owQ
 nZZ
 txt
-yhZ
+ycY
 sQY
 gYJ
 gYJ
@@ -98862,7 +99346,7 @@ lRA
 xTy
 vUf
 eph
-mQm
+fNb
 eph
 xUf
 lsI
@@ -99019,7 +99503,7 @@ hRA
 xTy
 vUf
 eph
-mQm
+fNb
 eph
 xUf
 lsI
@@ -99176,7 +99660,7 @@ hRA
 ney
 ghr
 eph
-mQm
+fNb
 eph
 eRc
 xOZ
@@ -99333,7 +99817,7 @@ hRA
 ucK
 vUf
 eph
-mQm
+fNb
 eph
 xUf
 iYK
@@ -99491,7 +99975,7 @@ xkY
 lyW
 wxK
 mQm
-rAb
+qUM
 sNc
 oje
 bID
@@ -100588,9 +101072,9 @@ oYm
 dZR
 xlt
 tAk
-abd
+fDi
 ixd
-pAS
+qMP
 xUf
 cpf
 bLY
@@ -101368,9 +101852,9 @@ qVP
 qVP
 xlt
 bum
-qhR
-qYJ
 uhl
+qYJ
+uSu
 xlt
 rcd
 uQt
@@ -101530,9 +102014,9 @@ wTQ
 drM
 xlt
 cxa
-nMG
-wxK
-pAS
+eph
+xeG
+kjn
 sxh
 cpf
 gTq
@@ -101844,7 +102328,7 @@ qVP
 qVP
 cEn
 xEP
-rTT
+dOB
 dOB
 wcc
 dOB
@@ -102158,7 +102642,7 @@ qVP
 qVP
 cEn
 eSF
-qly
+bBT
 bBT
 dLg
 lSI
@@ -102315,7 +102799,7 @@ qVP
 qVP
 cEn
 ioE
-rTT
+dOB
 dOB
 wcc
 dOB
@@ -102472,7 +102956,7 @@ qVP
 qVP
 cEn
 vGG
-qly
+bBT
 bBT
 dLg
 dOB
@@ -102629,7 +103113,7 @@ qVP
 qVP
 cEn
 mdf
-qly
+bBT
 bBT
 dLg
 uie
@@ -102786,7 +103270,7 @@ qVP
 qVP
 cEn
 xEP
-rTT
+dOB
 dOB
 obv
 dOB
@@ -103100,9 +103584,9 @@ qVP
 rqy
 rqy
 muO
-jpV
 rfo
-aQP
+mCd
+rFk
 muO
 rqy
 rfo
@@ -103257,8 +103741,8 @@ qVP
 rqy
 rqy
 rqy
-jpV
 rfo
+fBC
 aQP
 rqy
 rqy
@@ -103414,8 +103898,8 @@ qVP
 rqy
 rqy
 rqy
-jpV
 rfo
+fBC
 aQP
 rqy
 rqy
@@ -103571,8 +104055,8 @@ qVP
 qVP
 rqy
 rqy
-jpV
 rfo
+fBC
 aQP
 rqy
 rqy
@@ -103728,8 +104212,8 @@ qVP
 qVP
 qVP
 rqy
-jpV
 rfo
+fBC
 aQP
 rqy
 rqy
@@ -103885,8 +104369,8 @@ qVP
 qVP
 rqy
 rqy
-jpV
 rfo
+fBC
 aQP
 rqy
 rqy
@@ -104042,8 +104526,8 @@ qVP
 qVP
 rqy
 rqy
-jpV
 rfo
+fBC
 aQP
 rqy
 rqy
@@ -104199,8 +104683,8 @@ qVP
 qVP
 qVP
 rqy
-jpV
 rfo
+fBC
 aQP
 bbq
 rqy
@@ -104356,8 +104840,8 @@ qVP
 qVP
 rqy
 rqy
-jpV
 rfo
+fBC
 aQP
 bbq
 rqy
@@ -104513,8 +104997,8 @@ qVP
 rqy
 jKh
 rqy
-jpV
 rfo
+fBC
 aQP
 bbq
 rqy
@@ -104670,8 +105154,8 @@ rqy
 rqy
 rqy
 rqy
-jpV
 rfo
+fBC
 aQP
 rqy
 rqy
@@ -104827,9 +105311,9 @@ bbq
 bbq
 rqy
 rqy
-jpV
+rfo
 xHF
-aQP
+qME
 rqy
 rqy
 rqy
@@ -104984,9 +105468,9 @@ rfo
 rfo
 rfo
 rfo
-jpV
+rfo
 bPH
-aQP
+nMR
 rfo
 rfo
 rfo
@@ -105141,9 +105625,9 @@ rfo
 rfo
 rfo
 rfo
-jpV
+rfo
 bPH
-aQP
+nMR
 rfo
 rfo
 rfo
@@ -105298,9 +105782,9 @@ bbq
 bbq
 rqy
 rqy
-jpV
-iRK
-aQP
+rfo
+flF
+rFk
 rqy
 rqy
 rqy
@@ -105455,8 +105939,8 @@ rqy
 rqy
 rqy
 rqy
-jpV
 rfo
+fBC
 aQP
 rqy
 rqy
@@ -105612,7 +106096,7 @@ rqy
 rqy
 rqy
 rqy
-jpV
+rfo
 wSU
 aQP
 bbq
@@ -107804,14 +108288,14 @@ lxu
 iAy
 thU
 aiw
-xvI
-xvI
-xvI
-xvI
-xvI
-xvI
-xvI
-xvI
+feD
+feD
+feD
+feD
+feD
+feD
+feD
+bFI
 lxu
 lxu
 lxu
@@ -113461,7 +113945,7 @@ wuy
 kBk
 dlm
 fLk
-uXQ
+dJx
 uFg
 lse
 lse
@@ -114092,7 +114576,7 @@ wuy
 kBk
 avB
 pOx
-iwD
+pVu
 dRt
 bUr
 noU
@@ -114899,7 +115383,7 @@ hwG
 goF
 tgq
 fzN
-diA
+qfF
 pAc
 bOE
 vvm
@@ -115056,7 +115540,7 @@ pyk
 pvH
 pYv
 aLQ
-qfF
+otp
 pAc
 bOE
 nRK
@@ -115528,7 +116012,7 @@ wuy
 wuy
 jfa
 vVU
-eme
+pKq
 wuT
 wuT
 mkD
@@ -117098,10 +117582,10 @@ kRE
 bmz
 bmz
 bmz
-sdf
 jbI
-jbI
-jbI
+vwz
+vwz
+vwz
 ikZ
 fyZ
 rKj
@@ -117261,7 +117745,7 @@ mpQ
 mpQ
 eJO
 mpQ
-gXW
+nOQ
 bCA
 qhL
 qhL
@@ -117417,8 +117901,8 @@ pyh
 ctS
 ctS
 pyh
-bGq
-jxs
+rOW
+gqG
 jfa
 czR
 ggl
@@ -117569,13 +118053,13 @@ prI
 pVm
 pyh
 oer
-ifE
+qLI
 uuA
 qGr
 qQy
 pyh
 mpQ
-gXW
+nOQ
 mpQ
 mpQ
 mpQ
@@ -117735,7 +118219,7 @@ mpQ
 eYM
 xbH
 eWW
-nLT
+nmy
 uUC
 mpQ
 jfa
@@ -118046,7 +118530,7 @@ sxJ
 jXz
 pyh
 mpQ
-gto
+sDX
 cPJ
 tdy
 hFz
@@ -118206,7 +118690,7 @@ jjd
 xpH
 cPJ
 ncG
-pxh
+rir
 pzN
 cPJ
 wuy

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -19,10 +19,12 @@
 	req_access_txt = "22;27";
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
 "aaE" = (
@@ -209,7 +211,7 @@
 /area/station/hallway/primary/central)
 "afp" = (
 /obj/structure/cable/yellow{
-	icon_state = "40"
+	icon_state = "144"
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
@@ -264,9 +266,6 @@
 /area/station/engineering/break_room)
 "ahD" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "ahQ" = (
@@ -422,12 +421,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "alr" = (
@@ -484,6 +477,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"anC" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "anE" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/dorms/cryo)
@@ -512,13 +511,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
-"aoo" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/security/warden)
 "aot" = (
 /turf/open/floor/deadspace/mono,
 /area/station/security/courtroom)
@@ -994,12 +986,13 @@
 /area/station/medical/treatment_center)
 "azW" = (
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
-/area/station/security/brig)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "aAj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -1055,6 +1048,9 @@
 "aBg" = (
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/telephone/service,
+/obj/structure/cable/white{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
 "aBD" = (
@@ -1072,18 +1068,6 @@
 /obj/structure/lattice,
 /turf/open/openspace,
 /area/station/commons/storage/primary)
-"aCj" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "aCy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -1246,6 +1230,13 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse/upper)
+"aHo" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "aHO" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
@@ -1625,9 +1616,11 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "aSJ" = (
@@ -1666,6 +1659,17 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
+"aSP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "aSR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1687,9 +1691,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/commons/dorms/laundry)
 "aTa" = (
@@ -1840,7 +1846,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -2006,7 +2011,6 @@
 "bbF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/window/brigdoor/left/directional/west{
 	req_access_txt = "63"
 	},
@@ -2213,6 +2217,8 @@
 "bgx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "bgI" = (
@@ -2247,12 +2253,14 @@
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
 "bhT" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
 /obj/structure/closet/toolcloset,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "bid" = (
@@ -2301,8 +2309,10 @@
 /obj/item/stock_parts/subspace/crystal,
 /obj/item/stock_parts/subspace/crystal,
 /obj/item/stock_parts/subspace/crystal,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "bjI" = (
@@ -2354,7 +2364,7 @@
 "blf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
@@ -2508,6 +2518,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/central)
 "boB" = (
@@ -2598,15 +2611,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
-"bqY" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "bre" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -2631,6 +2635,16 @@
 /obj/item/gun/ballistic/automatic/pistol/rivet,
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
+"brs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "brD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 5
@@ -2727,7 +2741,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "10"
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -2851,6 +2865,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"bxn" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "bxp" = (
 /obj/machinery/power/floodlight,
 /obj/effect/turf_decal/box,
@@ -2912,9 +2933,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -3194,6 +3217,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "bFS" = (
@@ -3350,6 +3376,13 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
+"bLq" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "bLS" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -3449,6 +3482,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "bOc" = (
@@ -3570,10 +3606,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/service/chapel)
 "bRr" = (
@@ -3786,19 +3824,15 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
 "bWf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
-"bWn" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "bWt" = (
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
@@ -3837,9 +3871,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "bXp" = (
@@ -4043,7 +4079,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "ccd" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/toilet/restrooms)
 "cch" = (
@@ -4121,12 +4159,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
-"cfc" = (
-/obj/structure/cable/yellow{
-	icon_state = "68"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "cfk" = (
 /mob/living/simple_animal/slug,
 /turf/open/floor/wood,
@@ -4157,8 +4189,10 @@
 /obj/item/storage/lunchbox/unitology,
 /obj/item/storage/lunchbox/unitology,
 /obj/item/storage/lunchbox/unitology,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/service/library)
 "cgv" = (
@@ -4251,20 +4285,6 @@
 /obj/item/clothing/head/welding/demon,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
-"ciM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "cja" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark/side{
@@ -4449,7 +4469,9 @@
 /area/station/cargo/miningdock/oresilo)
 "cpt" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cpC" = (
@@ -4568,10 +4590,12 @@
 	name = "Church of Unitology"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/central)
 "crZ" = (
@@ -4704,11 +4728,27 @@
 /area/station/hallway/secondary/command)
 "cvC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
 /area/station/hallway/primary/starboard)
+"cvG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "cvS" = (
 /turf/open/floor/deadspace/cable{
 	dir = 8
@@ -4721,7 +4761,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/hanger)
 "cwa" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
 	},
@@ -4745,6 +4787,12 @@
 	dir = 8
 	},
 /area/mine/production)
+"cxh" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "cxq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -4803,7 +4851,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/deadspace/random/slides{
@@ -4838,9 +4885,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
 "czP" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
 "czR" = (
@@ -4854,9 +4903,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "cAk" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cAo" = (
@@ -4987,6 +5038,7 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "cCU" = (
@@ -5054,6 +5106,9 @@
 "cFk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
@@ -5263,7 +5318,9 @@
 /area/station/service/chapel)
 "cJM" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "cJO" = (
@@ -5400,9 +5457,17 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/monitoring)
+"cNY" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "cOf" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
 "cON" = (
@@ -5611,13 +5676,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"cTT" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "cTU" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/water,
@@ -5643,10 +5701,7 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
@@ -5826,12 +5881,6 @@
 "cZt" = (
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
-"cZH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "cZS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5860,10 +5909,12 @@
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
 "daT" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "dbi" = (
@@ -6025,25 +6076,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "P-Sec Brig";
-	req_access_txt = "63";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
 	},
-/turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
@@ -6254,11 +6292,11 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/fore)
 "dpc" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "dpo" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/right{
@@ -6377,6 +6415,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
+"dsr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/commons/dorms/cryo)
 "dsu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
@@ -6645,8 +6695,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
-	dir = 8
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -6677,7 +6728,6 @@
 /area/station/hallway/primary/central)
 "dBf" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/checkpoint/customs)
@@ -6876,6 +6926,17 @@
 /obj/structure/chair/sofa/corp/right,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"dHB" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "dHH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6977,15 +7038,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "dJx" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
-	},
-/obj/structure/cable/red{
-	icon_state = "2"
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/area/station/maintenance/starboard/greater)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
@@ -7154,6 +7211,20 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
+"dQc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "dQh" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -7239,14 +7310,10 @@
 	},
 /area/aegis/mining)
 "dSu" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
+/area/aegis/surface)
 "dSB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -7323,9 +7390,11 @@
 /area/station/engineering/supermatter/room)
 "dTs" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/cable,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dTw" = (
@@ -7361,11 +7430,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "dUe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/iron/white,
+/area/station/service/kitchen)
 "dUl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -7704,9 +7777,11 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "edO" = (
@@ -7788,9 +7863,11 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "efO" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/service/chapel/monastery)
+/obj/structure/cable/yellow{
+	icon_state = "68"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "efQ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -8106,15 +8183,6 @@
 "eoM" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/central)
-"eoT" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "eoV" = (
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
@@ -8206,6 +8274,24 @@
 "erk" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo)
+"ern" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
+"erN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "esc" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/machinery/light/small/maintenance/directional/north,
@@ -8227,10 +8313,26 @@
 	},
 /turf/open/floor/eighties/red,
 /area/aegis/surface)
+"esY" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "etp" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"etu" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "etC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -8424,7 +8526,9 @@
 	},
 /obj/item/storage/photo_album/chapel,
 /obj/machinery/light_switch/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/service/chapel/office)
 "eyr" = (
@@ -8526,7 +8630,9 @@
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/secondary/exit/departure_lounge)
 "eBq" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -8546,12 +8652,6 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/carpet/red,
 /area/aegis/hanger)
-"eCc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/station/commons/lounge)
 "eCf" = (
 /obj/structure/chair{
 	dir = 4
@@ -8579,7 +8679,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit/departure_lounge)
 "eCJ" = (
@@ -8913,17 +9012,6 @@
 "eIZ" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/office)
-"eJm" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "eJA" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8985,10 +9073,12 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "eKJ" = (
@@ -9004,7 +9094,9 @@
 "eLF" = (
 /obj/machinery/light/small/maintenance/directional/west,
 /obj/machinery/power/terminal,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/service/chapel/monastery)
 "eLI" = (
@@ -9052,9 +9144,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -9373,7 +9467,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "5"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
@@ -9412,16 +9506,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "eYu" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "eYM" = (
@@ -9430,13 +9528,21 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "eYU" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "eZc" = (
@@ -9595,6 +9701,15 @@
 /area/station/engineering/storage_shared)
 "fdT" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
 "fdX" = (
@@ -9604,6 +9719,15 @@
 	dir = 1
 	},
 /area/station/hallway/primary/starboard)
+"fex" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "feD" = (
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
@@ -9751,6 +9875,17 @@
 /obj/item/toy/figure/scientist,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
+"fir" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "fiB" = (
 /obj/structure/closet/crate/large/ds/green_horizontal,
 /obj/effect/spawner/random/medical/minor_healing,
@@ -9783,7 +9918,9 @@
 /area/station/engineering/atmos)
 "fjn" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -10262,8 +10399,10 @@
 	name = "Shuttle Bay";
 	req_access_txt = "63"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/customs)
 "fwp" = (
@@ -10311,6 +10450,13 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lesser)
+"fxU" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "fxZ" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/plating,
@@ -10471,7 +10617,9 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -10530,15 +10678,6 @@
 /obj/item/food/soup/blood,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"fGx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "fGV" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet/secure_closet/brig{
@@ -10732,9 +10871,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
@@ -11081,9 +11222,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "fVs" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "fVt" = (
@@ -11362,19 +11505,6 @@
 /obj/effect/spawner/random/deadspace/ammo/mining,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
-"gdZ" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "geq" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/deadspace/grater,
@@ -11768,10 +11898,20 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -11858,16 +11998,6 @@
 /obj/item/storage/medkit/toxin,
 /turf/open/floor/deadspace/grater,
 /area/station/medical/medbay/aft)
-"gsA" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/male)
 "gsG" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
@@ -11901,13 +12031,14 @@
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/captain)
 "guQ" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/clothing/costume,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "gva" = (
 /obj/structure/railing,
 /turf/open/floor/deadspace/random/rectangles,
@@ -11945,7 +12076,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "gwI" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/white{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/storage)
 "gwJ" = (
@@ -11955,16 +12088,17 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/area/station/security/brig)
 "gxI" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
 "gxK" = (
@@ -11989,6 +12123,14 @@
 	dir = 4
 	},
 /area/station/hallway/primary/aft)
+"gyh" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "gyv" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
@@ -12644,6 +12786,12 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/checkpoint/customs)
 "gRY" = (
@@ -12722,9 +12870,11 @@
 /area/aegis/surface)
 "gUl" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
 "gUo" = (
@@ -12919,9 +13069,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "gYJ" = (
@@ -12929,12 +13081,14 @@
 /area/station/cargo/sorting)
 "gYS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
@@ -12961,9 +13115,14 @@
 "gZQ" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/corner,
 /obj/structure/disposalpipe/junction/yjunction,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "hal" = (
@@ -12981,6 +13140,24 @@
 	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/service/chapel/office)
+"hat" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "hay" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/scientist,
@@ -13000,8 +13177,10 @@
 /area/station/maintenance/fore/lesser)
 "haR" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "haZ" = (
@@ -13040,6 +13219,16 @@
 /obj/structure/bed/roller,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"hbZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/male)
 "hch" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -13097,7 +13286,9 @@
 	},
 /area/station/medical/medbay/central)
 "heH" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/secondary/exit/departure_lounge)
 "heI" = (
@@ -13140,7 +13331,9 @@
 /area/station/science/lobby)
 "hfD" = (
 /obj/structure/disposalpipe/junction/yjunction,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hfM" = (
@@ -13189,6 +13382,9 @@
 /area/station/medical/medbay/aft)
 "hgV" = (
 /obj/machinery/computer/station_alert,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -13458,6 +13654,12 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/cable/white{
+	icon_state = "9"
+	},
+/obj/structure/cable/white{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
 "hqb" = (
@@ -13690,6 +13892,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/maint_center{
 	dir = 8
 	},
@@ -13729,7 +13934,9 @@
 /turf/open/floor/wood,
 /area/aegis/mining)
 "hwp" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/chapel)
 "hwE" = (
@@ -13993,9 +14200,14 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "hEM" = (
@@ -14139,7 +14351,9 @@
 /turf/open/floor/deadspace/random/golf_gray,
 /area/aegis/surface)
 "hHi" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "hHl" = (
@@ -14209,6 +14423,17 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"hJF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "hJJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -14568,8 +14793,10 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "hSA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "hSX" = (
@@ -14624,6 +14851,13 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"hUd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/commons/dorms/barracks/male)
 "hUi" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -14712,12 +14946,6 @@
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/deadspace/hardwood,
 /area/aegis/telecomms/high)
-"hXb" = (
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "hXv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14777,6 +15005,15 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"hYP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "hYZ" = (
 /turf/open/floor/engine/airless,
 /area/station/engineering/supermatter/room)
@@ -14832,7 +15069,9 @@
 "iaV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "iba" = (
@@ -14843,12 +15082,6 @@
 /obj/machinery/light/small/maintenance/directional/north,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
-"ibh" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "ibp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output{
 	dir = 8
@@ -14893,14 +15126,16 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "idy" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor{
@@ -14909,12 +15144,14 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "idA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "idL" = (
@@ -15171,7 +15408,9 @@
 /area/station/commons/lounge)
 "ijk" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "ijm" = (
@@ -15248,14 +15487,6 @@
 /obj/machinery/light/small/maintenance/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"ikg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "ikq" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood,
 /turf/open/floor/carpet/royalblack,
@@ -15314,6 +15545,9 @@
 /area/station/security/brig/upper)
 "ilk" = (
 /obj/machinery/power/smes,
+/obj/structure/cable/white{
+	icon_state = "16"
+	},
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/service/chapel/monastery)
 "ill" = (
@@ -15392,9 +15626,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "imS" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "imT" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -15431,13 +15671,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "iol" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15683,19 +15924,11 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "iwD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/checkpoint/customs)
 "iwK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -15850,6 +16083,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "iAN" = (
@@ -15908,9 +16144,12 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "iCm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate/large/ds/green_horizontal,
@@ -16027,9 +16266,14 @@
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
 "iEU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
@@ -16256,13 +16500,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse/upper)
-"iJu" = (
-/obj/structure/cable/multiz,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "iJv" = (
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
@@ -16286,6 +16523,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/slides,
 /area/station/ai_monitored/security/armory)
+"iKl" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/security/warden)
 "iKJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -16333,7 +16577,7 @@
 "iLi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/fore/greater)
@@ -16413,6 +16657,11 @@
 /obj/effect/spawner/random/food_or_drink/booze,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
+"iMw" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "iMy" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/camera/directional/west{
@@ -16536,9 +16785,11 @@
 /turf/open/misc/asteroid,
 /area/station/solars/port/fore)
 "iPb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -16699,6 +16950,14 @@
 "iSV" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
+"iSX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "iSY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16753,7 +17012,9 @@
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
 "iTY" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/white{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
 "iUl" = (
@@ -16986,18 +17247,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "3"
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "jaR" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "jaS" = (
@@ -17019,6 +17279,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "jbL" = (
@@ -17071,11 +17334,16 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jdI" = (
-/obj/structure/cable/yellow{
-	icon_state = "5"
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
 	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/ce)
 "jdK" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -17432,6 +17700,15 @@
 /mob/living/simple_animal/slug,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
+"jmm" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/hallway/secondary/exit/departure_lounge)
 "jmr" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood,
 /obj/effect/floor_decal/ds/spline/fancy/wood/corner{
@@ -17442,6 +17719,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "jmt" = (
@@ -17617,7 +17897,9 @@
 /obj/machinery/light/small/maintenance/directional/north,
 /obj/item/soap,
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/chapel)
 "jpA" = (
@@ -17706,9 +17988,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "jqW" = (
@@ -17832,9 +18116,11 @@
 /area/station/science/breakroom)
 "jtU" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
 	},
@@ -17850,9 +18136,11 @@
 	},
 /area/station/hallway/primary/fore)
 "juy" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
 	},
@@ -17907,10 +18195,12 @@
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse/upper)
 "jwt" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "jwz" = (
@@ -17979,9 +18269,14 @@
 "jyw" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "jyy" = (
@@ -18095,6 +18390,14 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"jCd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "jCn" = (
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
@@ -18182,11 +18485,38 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"jEU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "jFJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/checkpoint/science)
+"jFO" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "jFR" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/grater,
@@ -18404,9 +18734,11 @@
 	name = "Church Storage";
 	req_one_access_txt = "27"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/chapel)
 "jKX" = (
@@ -18435,14 +18767,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "jMK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "jML" = (
@@ -18450,7 +18783,9 @@
 	name = "Unisex Restrooms"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/toilet/restrooms)
 "jMQ" = (
@@ -18672,9 +19007,24 @@
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
 "jSw" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit)
+"jSD" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/female)
 "jSE" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -18924,6 +19274,9 @@
 "jYM" = (
 /obj/machinery/computer/security,
 /obj/machinery/newscaster/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/checkpoint/customs)
 "jYX" = (
@@ -18957,6 +19310,12 @@
 /obj/machinery/vending/assist,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
+"kbb" = (
+/obj/structure/cable/yellow{
+	icon_state = "132"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "kbh" = (
 /obj/effect/landmark{
 	name = "ShuttleRepairPart"
@@ -19110,6 +19469,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/courtroom)
 "kfM" = (
@@ -19362,6 +19724,9 @@
 /obj/machinery/telephone/security,
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/checkpoint/customs)
 "kkf" = (
@@ -19495,6 +19860,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
+"koA" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "koO" = (
 /obj/machinery/light/directional/north,
 /turf/open/misc/asteroid,
@@ -19505,10 +19876,11 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "kpk" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/misc/ironsand,
 /area/aegis/surface)
 "kpy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -19524,10 +19896,10 @@
 "kpP" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "4"
 	},
 /turf/open/floor/plating,
-/area/station/engineering/main)
+/area/station/hallway/secondary/exit)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -19613,9 +19985,11 @@
 /area/station/commons/dorms/laundry)
 "ksC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/cable_start,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ksD" = (
@@ -19671,7 +20045,9 @@
 /area/station/engineering/atmos)
 "ktR" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
 "ktX" = (
@@ -19748,10 +20124,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
-"kwu" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "kwF" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/engine)
@@ -19777,7 +20149,9 @@
 /turf/closed/wall/r_wall,
 /area/station/commons/dorms/laundry)
 "kyb" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "kyd" = (
@@ -19862,12 +20236,17 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "kBD" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "kBN" = (
@@ -19955,12 +20334,14 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
 "kDP" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/area/aegis/surface)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "kEv" = (
 /obj/item/megaphone,
 /obj/structure/table/wood,
@@ -20003,9 +20384,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
@@ -20081,6 +20464,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central/aft)
+"kHw" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "kHQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -20415,6 +20804,15 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
+"kQW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "kRf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -20511,8 +20909,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
 "kSU" = (
@@ -20610,6 +21010,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
 "kVj" = (
@@ -20620,9 +21023,11 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
 "kVv" = (
@@ -20709,13 +21114,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
-"kXP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/maintenance/fore/greater)
 "kYb" = (
 /obj/machinery/holopad,
 /obj/effect/floor_decal/ds/spline/fancy/wood{
@@ -20934,11 +21332,16 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "ldv" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -21166,12 +21569,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
-"lim" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "lip" = (
 /obj/item/wirecutters/abductor,
 /turf/open/floor/stone,
@@ -21289,9 +21686,14 @@
 /area/station/cargo/warehouse/upper)
 "lmj" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/service/chapel/office)
 "lmo" = (
@@ -21457,6 +21859,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/maint_center{
 	dir = 8
 	},
@@ -21469,12 +21874,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"lrC" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "lrH" = (
 /obj/machinery/shower{
 	dir = 8
@@ -21524,6 +21923,12 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
+"ltj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/station/commons/lounge)
 "lty" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
@@ -22229,9 +22634,11 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/airalarm/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
@@ -22325,17 +22732,6 @@
 	dir = 4
 	},
 /area/station/security/brig)
-"lRm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "lRA" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -22450,7 +22846,6 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "lTz" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/male)
@@ -22709,16 +23104,6 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
-"mbQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
 "mbT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -22970,6 +23355,12 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"mjx" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "mjG" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/white,
@@ -22996,12 +23387,14 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "mlt" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "mlw" = (
@@ -23017,6 +23410,13 @@
 	},
 /turf/open/floor/deadspace/roller,
 /area/aegis/surface)
+"mlO" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "mlU" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/effect/spawner/random/vending/snackvend,
@@ -23147,9 +23547,11 @@
 /turf/open/floor/deadspace/grater,
 /area/mine/hydroponics)
 "moE" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/aft)
 "moF" = (
@@ -23269,6 +23671,20 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"mro" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "mry" = (
 /obj/structure/fluff/broken_flooring{
 	icon_state = "singular"
@@ -23360,7 +23776,7 @@
 /area/station/hallway/primary/fore)
 "mtQ" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "24"
 	},
 /turf/open/floor/plating,
 /area/aegis/surface)
@@ -23459,10 +23875,12 @@
 	req_access_txt = "22"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/service/chapel/office)
 "mwK" = (
@@ -23948,7 +24366,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mLO" = (
@@ -24167,9 +24584,11 @@
 	req_access_txt = "61"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "mSl" = (
@@ -24209,6 +24628,13 @@
 /obj/machinery/cryopod,
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/storage)
+"mUb" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "mUd" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment,
@@ -24317,7 +24743,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
@@ -24598,7 +25024,7 @@
 /area/station/maintenance/fore/lesser)
 "ncO" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
@@ -24821,12 +25247,11 @@
 	dir = 1
 	},
 /area/station/security/checkpoint/customs)
-"njK" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
+"njI" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "njM" = (
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/vitals_monitor,
@@ -24893,13 +25318,6 @@
 /obj/effect/landmark/pestspawn,
 /turf/open/water,
 /area/station/hallway/primary/aft)
-"nmO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "nmW" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -25215,6 +25633,13 @@
 "nyU" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/qm)
+"nzd" = (
+/obj/structure/cable/multiz,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "nzi" = (
 /obj/structure/railing,
 /turf/open/openspace,
@@ -25301,6 +25726,11 @@
 /obj/item/clothing/head/beret/sec,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"nAn" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "nAs" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/lizard_plushie/green,
@@ -25351,6 +25781,11 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
+"nAV" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "nBo" = (
 /obj/structure/rack,
 /obj/item/chainsaw/plasma_industrial,
@@ -25371,6 +25806,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/maint_center{
 	dir = 8
 	},
@@ -25392,9 +25830,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "nBX" = (
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/yellow{
+	icon_state = "40"
 	},
+/turf/open/misc/ironsand,
 /area/aegis/surface)
 "nCk" = (
 /obj/effect/turf_decal/box,
@@ -25420,9 +25859,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "nCJ" = (
@@ -25516,9 +25957,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "nGT" = (
@@ -25820,9 +26263,11 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "nOQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/service/chapel)
+/area/station/engineering/break_room)
 "nOX" = (
 /obj/machinery/cryopod,
 /obj/effect/landmark/latejoin,
@@ -25831,17 +26276,6 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
-"nOZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "nPb" = (
 /obj/structure/table,
 /obj/item/stock_parts/scanning_module{
@@ -26082,16 +26516,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"nVq" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/female)
 "nVr" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -26313,7 +26737,7 @@
 /area/station/command/bridge)
 "ocO" = (
 /obj/structure/cable/yellow{
-	icon_state = "18"
+	icon_state = "3"
 	},
 /turf/open/misc/ironsand,
 /area/aegis/surface)
@@ -26350,6 +26774,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/white{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/service/chapel/monastery)
 "odK" = (
@@ -26364,9 +26791,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
@@ -26620,7 +27044,6 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -26648,10 +27071,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/checkpoint/customs)
 "ols" = (
@@ -26702,6 +27127,9 @@
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
 "omC" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/checkpoint/customs)
 "omF" = (
@@ -26714,7 +27142,9 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
 "omO" = (
@@ -26864,10 +27294,10 @@
 "oqy" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "3"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "2"
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
@@ -27045,6 +27475,9 @@
 /area/mine/lobby)
 "ovV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/checkpoint/science)
 "ovW" = (
@@ -27279,13 +27712,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse/upper)
-"oCt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/male)
 "oCw" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/oven,
@@ -27301,7 +27727,9 @@
 "oCO" = (
 /obj/machinery/washing_machine,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
 "oDd" = (
@@ -27331,7 +27759,6 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
 "oEA" = (
@@ -27350,12 +27777,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"oFm" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "oFr" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/disposalpipe/trunk{
@@ -27411,7 +27832,12 @@
 /area/station/hallway/primary/central/aft)
 "oGC" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/white{
+	icon_state = "1"
+	},
+/obj/structure/cable/white{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
 "oGW" = (
@@ -27499,9 +27925,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/cable,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oJH" = (
@@ -27664,8 +28092,10 @@
 "oOL" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/machinery/telephone/service,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/library)
 "oOP" = (
@@ -27951,6 +28381,18 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
+"oVs" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "oWg" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable/yellow{
@@ -28031,6 +28473,16 @@
 	dir = 8
 	},
 /area/station/security/brig)
+"oYi" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "oYm" = (
 /obj/machinery/shower{
 	dir = 4
@@ -28049,6 +28501,9 @@
 "oYE" = (
 /obj/structure/cable/yellow{
 	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -28134,8 +28589,18 @@
 /obj/item/paper_bin,
 /obj/structure/table/wood/fancy/red,
 /obj/item/pen,
+/obj/structure/cable/white{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
+"pbo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/service/janitor)
 "pbp" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plating,
@@ -28190,8 +28655,13 @@
 	pixel_x = 26
 	},
 /obj/machinery/telephone/security,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -28285,14 +28755,16 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "pfG" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "10"
 	},
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/hallway/primary/central)
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "pfH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -28419,8 +28891,10 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "pkp" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/holopad,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
 "pkF" = (
@@ -28527,8 +29001,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "pmL" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "pmR" = (
@@ -28539,14 +29015,11 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "pmS" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "pnj" = (
 /obj/structure/railing{
 	dir = 6
@@ -28611,12 +29084,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
-"ppd" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
 "ppE" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -28711,18 +29178,6 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
-"psi" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
 "psj" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 6
@@ -28749,6 +29204,16 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo)
+"psG" = (
+/obj/effect/floor_decal/ds/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/station/service/library)
 "psI" = (
 /obj/machinery/computer/prisoner/management,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -28948,6 +29413,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/starboard)
 "pyF" = (
@@ -29029,6 +29497,13 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
+"pAp" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "pAu" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -29122,7 +29597,6 @@
 /obj/machinery/power/port_gen/pacman,
 /obj/item/stack/sheet/mineral/plasma/thirty,
 /obj/item/wrench,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/service/chapel/monastery)
 "pCt" = (
@@ -29166,7 +29640,9 @@
 /area/station/engineering/storage_shared)
 "pDD" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -29289,20 +29765,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
-"pGW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "pHp" = (
 /obj/structure/sign/cec/deck/medical{
 	pixel_y = 32
@@ -29448,8 +29910,10 @@
 /area/station/medical/medbay/central)
 "pLY" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/toilet/restrooms)
 "pMj" = (
@@ -29532,9 +29996,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/science)
 "pNq" = (
@@ -29673,6 +30139,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/fore)
+"pPz" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "pPG" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -29691,7 +30163,9 @@
 	name = "Control Room"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
 "pQk" = (
@@ -29709,11 +30183,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
-"pQx" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "pQD" = (
 /obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/plating,
@@ -29768,9 +30237,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
@@ -29832,13 +30298,6 @@
 /obj/item/storage/box/masks,
 /turf/open/floor/deadspace/bathroom,
 /area/station/medical/morgue)
-"pVN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/computer)
 "pVP" = (
 /obj/structure/railing{
 	dir = 5
@@ -29976,9 +30435,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -30012,8 +30476,10 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood/cee{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/service/chapel/office)
 "pZv" = (
@@ -30030,15 +30496,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
-"qaz" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/commons/dorms/cryo)
 "qaC" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -30213,7 +30670,7 @@
 "qfF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
@@ -30262,6 +30719,9 @@
 	c_tag = "Departure Lounge - Starboard Aft"
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qgZ" = (
@@ -30423,7 +30883,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "qli" = (
@@ -30520,9 +30982,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -30599,6 +31066,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"qpo" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "qpp" = (
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/white,
@@ -30856,6 +31329,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
+"qve" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "qvr" = (
 /obj/structure/table/wood,
 /obj/item/clothing/gloves/ring,
@@ -30901,6 +31384,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"qwv" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "qwA" = (
 /obj/structure/railing{
 	dir = 8
@@ -30964,6 +31454,12 @@
 "qyr" = (
 /turf/closed/wall/r_wall,
 /area/station/security/brig)
+"qyQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "qyR" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Clinic"
@@ -30983,17 +31479,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"qzb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "qzA" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/deadspace/mono,
@@ -31220,14 +31705,11 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qHk" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "18"
 	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -31264,7 +31746,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -31402,14 +31886,11 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "qMP" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "qMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -31425,11 +31906,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
-"qNi" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "qNt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -31495,15 +31971,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo)
-"qPh" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/hallway/primary/port)
 "qPk" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/beer{
@@ -31704,11 +32171,14 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "qUM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/brig)
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/hallway/primary/central)
 "qVj" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
@@ -31796,10 +32266,12 @@
 	req_one_access_txt = "23;30"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
 "qXk" = (
@@ -31915,6 +32387,12 @@
 	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
+"rbb" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "rbg" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/structure/noticeboard/directional/north,
@@ -32042,16 +32520,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
-"reA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "reC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32168,11 +32636,22 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
 "riO" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
 "riQ" = (
@@ -32296,7 +32775,12 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "rlP" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/secondary/exit)
 "rlS" = (
@@ -32345,14 +32829,6 @@
 	dir = 1
 	},
 /area/aegis/hanger)
-"rmM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "rmW" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/storage/book/bible/unitology,
@@ -32385,6 +32861,12 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
+"rnV" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "rop" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock/pile/icy,
@@ -32563,8 +33045,10 @@
 "rtC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right{
 	dir = 8
 	},
@@ -32744,14 +33228,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"ryX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig/upper)
 "rzc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
@@ -32810,7 +33286,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -32827,8 +33302,13 @@
 /turf/open/floor/deadspace/grille_spare1,
 /area/mine/storage)
 "rBk" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/obj/structure/cable/white{
+	icon_state = "144"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/service/chapel/monastery)
 "rBn" = (
@@ -32927,15 +33407,17 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "rDI" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/cable_end,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "rDN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -32964,9 +33446,11 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/fore)
 "rEC" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/security/courtroom)
 "rEZ" = (
@@ -32995,9 +33479,14 @@
 /area/station/hallway/primary/fore)
 "rGh" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/secondary/exit/departure_lounge)
 "rGI" = (
@@ -33009,6 +33498,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"rGQ" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "rHx" = (
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
@@ -33098,6 +33596,12 @@
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
+"rJq" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/aegis/surface)
 "rJs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/west{
@@ -33373,16 +33877,14 @@
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
 "rQA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/area/aegis/surface)
 "rQK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/tool,
@@ -33436,18 +33938,14 @@
 /obj/effect/spawner/random/deadspace/rig/scaf,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
-"rTk" = (
-/obj/structure/cable/yellow{
-	icon_state = "24"
-	},
-/turf/open/floor/plating,
-/area/aegis/surface)
 "rTI" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Shuttle Bay"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
 "rTK" = (
@@ -33519,13 +34017,6 @@
 	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/male)
-"rVu" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "rVv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -33565,7 +34056,12 @@
 	},
 /area/station/science/lab)
 "rWq" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/grille_spare3,
 /area/station/security/checkpoint/customs)
 "rWy" = (
@@ -33700,6 +34196,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
+"scu" = (
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "scx" = (
 /obj/structure/cable/yellow{
 	icon_state = "6"
@@ -33980,6 +34482,18 @@
 	},
 /turf/open/misc/asteroid,
 /area/station/solars/port/fore)
+"slg" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "slG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -34108,9 +34622,11 @@
 	},
 /obj/effect/landmark/navigate_destination/tools,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/norn,
 /area/station/commons/storage/tools)
 "sos" = (
@@ -34119,6 +34635,13 @@
 	dir = 8
 	},
 /area/aegis/mining)
+"soz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "soA" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4;
@@ -34253,7 +34776,9 @@
 "ssE" = (
 /obj/machinery/light/small/maintenance/directional/south,
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "64"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/service/chapel/monastery)
 "ssV" = (
@@ -34267,6 +34792,9 @@
 /obj/machinery/computer/secure_data{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/checkpoint/customs)
 "sun" = (
@@ -34275,9 +34803,11 @@
 /area/station/engineering/storage_shared)
 "suq" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right{
 	dir = 8
 	},
@@ -34359,14 +34889,9 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "swY" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -34531,20 +35056,28 @@
 /area/station/security/brig)
 "sBp" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
-"sCc" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+"sBv" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
 	},
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
+/turf/open/misc/asteroid,
 /area/aegis/surface)
+"sCc" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/hallway/primary/port)
 "sCd" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/random/maintenance/two,
@@ -34841,6 +35374,10 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lesser)
+"sLK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "sLV" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/misc/asteroid,
@@ -34855,14 +35392,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
-"sMl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
 "sMm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/norn,
@@ -34990,6 +35519,18 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/rd)
+"sPD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "sPH" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/bot,
@@ -35082,17 +35623,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"sSw" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "sSP" = (
 /obj/structure/table,
 /turf/open/floor/deadspace/random/maint_right,
@@ -35380,7 +35910,6 @@
 	name = "Cabin 3"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/ported/lino,
@@ -35408,6 +35937,17 @@
 "taJ" = (
 /turf/closed/wall/mineral/titanium,
 /area/aegis/hanger)
+"taM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "tbq" = (
 /obj/machinery/conveyor{
 	id = "Lower Marker Conveyor";
@@ -35556,7 +36096,7 @@
 "tfU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "tfW" = (
@@ -35600,7 +36140,9 @@
 /area/station/science/robotics/mechbay)
 "tgY" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
 "thc" = (
@@ -35761,6 +36303,14 @@
 /obj/item/pen/blue,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
+"tmm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "tmo" = (
 /obj/structure/rack/shelf,
 /obj/effect/turf_decal/bot_white,
@@ -35803,12 +36353,6 @@
 /obj/effect/spawner/random/deadspace/ammo/mining,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
-"tnd" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "tnj" = (
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/misc/asteroid,
@@ -35848,13 +36392,6 @@
 /obj/machinery/gibber,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
-"tpb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
 "tpk" = (
 /obj/machinery/door/airlock/external{
 	name = "Cave-In Shelter 2"
@@ -35895,17 +36432,11 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "trK" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "6"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "trL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -36416,12 +36947,6 @@
 /obj/item/storage/medkit/surgery,
 /turf/closed/wall/r_wall,
 /area/station/medical/medbay/aft)
-"tGX" = (
-/obj/structure/cable/yellow{
-	icon_state = "132"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "tHg" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/icecream_vat,
@@ -36539,16 +37064,6 @@
 /obj/structure/table,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
-"tLl" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "tLZ" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
@@ -36686,10 +37201,7 @@
 "tQQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
@@ -36709,14 +37221,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/female)
-"tRd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "tRl" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar{
@@ -36771,7 +37275,9 @@
 /area/station/commons/dorms/barracks/female)
 "tSG" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/white{
+	icon_state = "1"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/storage)
 "tSM" = (
@@ -36972,7 +37478,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/directional/south,
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
@@ -37238,8 +37743,10 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/norn,
 /area/station/service/hydroponics/upper)
 "ugU" = (
@@ -37283,6 +37790,13 @@
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
+"uiU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/maintenance/fore/greater)
 "uiV" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/deadspace/mono,
@@ -37324,12 +37838,6 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/misc/asteroid/snow,
 /area/station/science/breakroom)
-"ujY" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "ukf" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron/dark/side{
@@ -37574,16 +38082,15 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
 "upb" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/red{
 	icon_state = "1"
 	},
 /turf/open/floor/plating,
-/area/station/command/heads_quarters/ce)
+/area/station/engineering/supermatter/room)
 "upl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -37664,18 +38171,6 @@
 /obj/structure/curtain,
 /turf/open/floor/deadspace/grille_spare4,
 /area/station/commons/dorms/barracks/female)
-"ura" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "urb" = (
 /obj/machinery/door/airlock/mining{
 	name = "Warehouse";
@@ -37715,9 +38210,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/customs)
 "ust" = (
@@ -37889,25 +38386,13 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
-"uxe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "uxu" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/corner{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
 "uxv" = (
@@ -37931,9 +38416,11 @@
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation)
 "uyg" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/cable_start,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "uyk" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/vending/hydroseeds,
@@ -38120,8 +38607,10 @@
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/starboard/greater)
 "uCj" = (
@@ -38147,16 +38636,6 @@
 "uCC" = (
 /turf/open/floor/deadspace/grille_spare2,
 /area/aegis/surface)
-"uCH" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/white,
-/area/station/service/kitchen)
 "uCR" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
@@ -38261,9 +38740,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38419,7 +38900,6 @@
 	name = "Chapel Office Maintenance";
 	req_one_access_txt = "22"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/monastery)
 "uNu" = (
@@ -38521,11 +39001,19 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -38561,12 +39049,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/mono,
 /area/mine/hydroponics)
-"uRz" = (
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "uSc" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
@@ -38582,13 +39064,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/command)
-"uSf" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "uSl" = (
 /obj/item/stack/sheet/plasteel{
 	amount = 10;
@@ -38677,6 +39152,14 @@
 	dir = 8
 	},
 /area/station/hallway/primary/port)
+"uTC" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "uTH" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/camera/directional/north{
@@ -38891,9 +39374,11 @@
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "uZP" = (
@@ -39148,8 +39633,10 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
 "vhO" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/chapel)
 "vib" = (
@@ -39464,11 +39951,6 @@
 /obj/machinery/light/small/maintenance/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"vqO" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
 "vqU" = (
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
@@ -39828,6 +40310,13 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"vBi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "vBq" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/cee{
 	dir = 4
@@ -39835,10 +40324,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "vBz" = (
@@ -40064,13 +40555,20 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"vIb" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "1"
+"vIc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "vIf" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -40405,9 +40903,11 @@
 	dir = 8
 	},
 /obj/effect/landmark/navigate_destination/library,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
 "vQr" = (
@@ -40476,13 +40976,6 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse)
-"vRM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/commons/dorms/barracks/male)
 "vRZ" = (
 /turf/closed/wall/r_wall,
 /area/station/service/chapel/office)
@@ -40520,9 +41013,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "vTd" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "vTq" = (
@@ -40857,7 +41352,9 @@
 /obj/structure/table,
 /obj/machinery/telephone/command,
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit)
 "wdL" = (
@@ -40876,6 +41373,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/security/courtroom)
+"weg" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "weo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -40930,9 +41440,11 @@
 /area/station/engineering/supermatter/room)
 "wff" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
 	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/service/chapel/office)
@@ -40947,6 +41459,14 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/bar)
+"wft" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "wfv" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -40995,15 +41515,23 @@
 /area/station/medical/medbay/central)
 "wgO" = (
 /obj/machinery/holopad,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/customs)
 "wgZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/library)
 "whl" = (
@@ -41166,9 +41694,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "wnd" = (
@@ -41211,7 +41736,9 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
 "wov" = (
@@ -41260,12 +41787,16 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/service/janitor)
+/area/station/engineering/break_room)
 "wpl" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
@@ -41318,16 +41849,13 @@
 /obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig/upper)
-"wqx" = (
+"wqu" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
-	},
-/obj/structure/cable/red{
+/obj/structure/cable/yellow{
 	icon_state = "1"
 	},
 /turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/area/station/engineering/monitoring)
 "wqC" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/chair/office{
@@ -41343,8 +41871,10 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/central)
 "wqG" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
 "wqT" = (
@@ -41358,9 +41888,19 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "wrl" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/obj/structure/rack,
+/obj/effect/spawner/random/clothing/costume,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41435,12 +41975,17 @@
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "wtM" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "6"
 	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41505,6 +42050,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/female)
+"wvS" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/grille_spare3,
+/area/station/security/checkpoint/customs)
 "wvY" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
@@ -41540,15 +42091,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"wwV" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "wwW" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -41567,6 +42109,15 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
+"wxA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "wxK" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -41676,12 +42227,14 @@
 "wBg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/camera/directional/east{
 	c_tag = "Chapel - Funerary Crypt"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
 	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
@@ -41844,6 +42397,19 @@
 	},
 /turf/open/floor/deadspace/random/slides,
 /area/aegis/hanger)
+"wFp" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "wFz" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/maint_left,
@@ -41968,8 +42534,10 @@
 /obj/effect/landmark/navigate_destination{
 	location = "Evacuation"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wHL" = (
@@ -42459,7 +43027,9 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/service/chapel/office)
 "wXR" = (
@@ -42699,7 +43269,6 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xdT" = (
@@ -42831,9 +43400,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -43061,12 +43632,6 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
-"xnf" = (
-/obj/structure/cable/yellow{
-	icon_state = "144"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "xni" = (
 /obj/effect/landmark/start/chaplain,
 /obj/structure/chair/wood{
@@ -43118,7 +43683,9 @@
 "xok" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "xoC" = (
@@ -43202,9 +43769,11 @@
 /area/station/hallway/secondary/exit)
 "xrC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/central)
 "xrV" = (
@@ -43224,9 +43793,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "xsj" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/cable,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "xsl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -43384,7 +43957,9 @@
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "xwa" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/library)
 "xwn" = (
@@ -43441,6 +44016,9 @@
 /area/station/science/research)
 "xxI" = (
 /obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -43489,7 +44067,9 @@
 /obj/structure/table/wood/fancy/cyan,
 /obj/effect/floor_decal/ds/spline/fancy/wood,
 /obj/item/flashlight/lamp,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/service/chapel/office)
 "xyp" = (
@@ -43732,8 +44312,10 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/warden)
 "xHg" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
 "xHF" = (
@@ -43906,10 +44488,15 @@
 /area/station/security/brig)
 "xLC" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/poddoor/preopen{
 	id = "miningsecprivacy";
 	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
 	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/science)
@@ -44252,8 +44839,8 @@
 /area/station/hallway/primary/starboard)
 "xYm" = (
 /obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "xYs" = (
@@ -44404,6 +44991,20 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
+"ydc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "ydh" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/deadspace/grater,
@@ -44416,6 +45017,14 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
+"yeq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "yey" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/grater,
@@ -44533,6 +45142,15 @@
 "ygU" = (
 /turf/open/water,
 /area/station/maintenance/fore/lesser)
+"ygZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "132"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/service/chapel/monastery)
 "yhf" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/structure/disposalpipe/segment{
@@ -44555,16 +45173,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
@@ -52947,8 +53560,8 @@ uoP
 trm
 mNO
 mNO
-odB
-efO
+ygZ
+trm
 ssE
 jxc
 jgq
@@ -53105,7 +53718,7 @@ gTe
 mNO
 mNO
 odB
-efO
+trm
 trm
 jxc
 jgq
@@ -53262,7 +53875,7 @@ trm
 mNO
 mNO
 odB
-efO
+trm
 trm
 jxc
 jgq
@@ -53419,7 +54032,7 @@ trm
 mNO
 mNO
 odB
-efO
+trm
 oAN
 jxc
 oQh
@@ -77632,7 +78245,7 @@ xVM
 xVM
 xVM
 fQc
-qPh
+sCc
 pMt
 gRy
 rwp
@@ -78073,7 +78686,7 @@ rwR
 aJv
 hbH
 fXy
-gsA
+hbZ
 iYH
 iYH
 iYH
@@ -78240,7 +78853,7 @@ iWf
 gAV
 aHO
 aHO
-oCt
+cOf
 iWf
 aHO
 gAV
@@ -78248,7 +78861,7 @@ aHO
 aHO
 aHO
 aHO
-cOf
+xRF
 aHO
 iAm
 dYf
@@ -78397,7 +79010,7 @@ mwV
 hfO
 mwV
 mwV
-vRM
+hUd
 mwV
 mwV
 hfO
@@ -78868,7 +79481,7 @@ wbh
 sFi
 dnX
 sNO
-ncO
+koA
 sNO
 dTJ
 sFi
@@ -79011,7 +79624,7 @@ qVP
 anE
 gRv
 gRv
-qaz
+cUw
 sxL
 cYy
 anE
@@ -79025,7 +79638,7 @@ nFb
 sFi
 hFa
 sNO
-guQ
+alq
 sNO
 sWE
 sFi
@@ -79168,7 +79781,7 @@ qVP
 anE
 sxe
 nAx
-qaz
+cUw
 vqU
 bro
 anE
@@ -79182,7 +79795,7 @@ foz
 sFi
 ykX
 sNO
-guQ
+alq
 sNO
 xsV
 sFi
@@ -79325,7 +79938,7 @@ qVP
 anE
 fDg
 mbe
-cUw
+dsr
 wSD
 aqS
 anE
@@ -79338,8 +79951,8 @@ veo
 veo
 sFi
 nAH
-ppd
-alq
+ncO
+wrl
 sNO
 dIR
 sFi
@@ -79482,7 +80095,7 @@ qVP
 anE
 hTF
 tXB
-qaz
+cUw
 vqU
 oJf
 anE
@@ -79496,7 +80109,7 @@ xyR
 sFi
 hiA
 sNO
-guQ
+alq
 sNO
 fpd
 sFi
@@ -79810,7 +80423,7 @@ vxt
 sFi
 xqH
 sNO
-ncO
+koA
 sNO
 jhD
 sFi
@@ -80585,7 +81198,7 @@ nHL
 aJv
 hbH
 dVP
-nVq
+jSD
 jKk
 jKk
 jKk
@@ -81094,7 +81707,7 @@ dmW
 hEO
 mui
 vHE
-uCH
+dUe
 eEt
 qYZ
 fXZ
@@ -81555,8 +82168,8 @@ bYo
 kBk
 ruP
 bwu
+aSP
 jaQ
-iol
 nAc
 wVk
 ijf
@@ -81702,7 +82315,7 @@ fnR
 jfz
 hnk
 tQS
-wpg
+pbo
 lqv
 rCd
 npi
@@ -82131,11 +82744,11 @@ qVP
 qVP
 wuy
 wuy
-nBX
-nBX
-nBX
-nBX
-nBX
+dSu
+dSu
+dSu
+dSu
+dSu
 wuy
 wuy
 wuy
@@ -82207,7 +82820,7 @@ reE
 khL
 qbh
 qbh
-yhZ
+mWE
 akB
 qyr
 qVP
@@ -82287,24 +82900,24 @@ wuy
 wuy
 wuy
 wuy
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
 wuy
 wuy
 vRZ
@@ -82359,7 +82972,7 @@ vky
 vky
 vky
 vky
-qzb
+hJF
 vky
 tCw
 aQM
@@ -82440,29 +83053,29 @@ qVP
 qVP
 qVP
 wuy
-nBX
-nBX
-kDP
-kDP
-kDP
-kDP
-kDP
-kDP
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
+dSu
+dSu
+kpk
+kpk
+kpk
+kpk
+kpk
+kpk
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
+dSu
 qnp
-kDP
-kDP
-kDP
-kDP
-kDP
-nBX
-nBX
+kpk
+kpk
+kpk
+kpk
+kpk
+dSu
+dSu
 wuy
 vRZ
 bzI
@@ -82510,7 +83123,7 @@ uej
 bNV
 bNV
 bNV
-yhZ
+mWE
 bNV
 bNV
 bNV
@@ -82518,7 +83131,7 @@ bNV
 bNV
 bNV
 bNV
-yhZ
+mWE
 bNV
 bNV
 bNV
@@ -82597,29 +83210,29 @@ qVP
 qVP
 qVP
 wuy
-nBX
-kDP
+dSu
+kpk
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-nBX
-nBX
-nBX
+dSu
+dSu
+dSu
 dsu
-nBX
-nBX
-nBX
+dSu
+dSu
+dSu
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-kDP
-nBX
+kpk
+dSu
 wuy
 vRZ
 uho
@@ -82667,7 +83280,7 @@ vHk
 mct
 vmQ
 bHR
-yhZ
+mWE
 qWQ
 qyr
 qyr
@@ -82675,7 +83288,7 @@ qyr
 qyr
 qyr
 uck
-yhZ
+mWE
 daa
 qyr
 qyr
@@ -82754,29 +83367,29 @@ qVP
 qVP
 qVP
 wuy
-nBX
-kDP
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
-nBX
-nBX
+dSu
+kpk
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+dSu
+dSu
+dSu
 nGf
-nBX
-nBX
-nBX
-swY
-swY
-swY
-swY
-swY
-swY
-kDP
-nBX
+dSu
+dSu
+dSu
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+kpk
+dSu
 wuy
 vRZ
 ham
@@ -82824,15 +83437,15 @@ qyr
 qyr
 qyr
 bHR
-pGW
-azW
+ydc
+diA
 tWq
-qUM
+qMP
 cVO
 weY
 qyr
 bHR
-yhZ
+mWE
 daa
 qSo
 qSo
@@ -82911,14 +83524,14 @@ qVP
 qVP
 qVP
 wuy
-nBX
-kDP
-swY
-swY
-swY
-swY
-swY
-swY
+dSu
+kpk
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 gbS
 gbS
 gbS
@@ -82926,14 +83539,14 @@ dsu
 gbS
 gbS
 gbS
-swY
-swY
-swY
-swY
-swY
-swY
-kDP
-nBX
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+kpk
+dSu
 wuy
 vRZ
 vRZ
@@ -82981,7 +83594,7 @@ kGp
 dSB
 aSO
 bHR
-yhZ
+mWE
 qpF
 trI
 iee
@@ -82989,7 +83602,7 @@ qam
 fGV
 qyr
 bHR
-yhZ
+mWE
 daa
 qKU
 qKU
@@ -83068,29 +83681,29 @@ qVP
 qVP
 qVP
 wuy
-nBX
-nBX
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
-nBX
-nBX
+dSu
+dSu
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+dSu
+dSu
+dSu
 nGf
-nBX
-nBX
-nBX
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
-nBX
+dSu
+dSu
+dSu
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+dSu
+dSu
 wuy
 qVP
 qVP
@@ -83133,12 +83746,12 @@ bJz
 wqD
 bJz
 bJz
-bWn
-tLl
-tLl
+qwv
 oqy
+oqy
+qve
 bHR
-yhZ
+mWE
 jYt
 qyr
 qyr
@@ -83146,7 +83759,7 @@ qyr
 qyr
 qyr
 tfu
-iwD
+dQc
 igw
 fpu
 fpu
@@ -83225,29 +83838,29 @@ qVP
 qVP
 qVP
 wuy
-nBX
-kDP
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
-nBX
-nBX
+dSu
+kpk
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+dSu
+dSu
+dSu
 nGf
-nBX
-nBX
-nBX
-swY
-swY
-swY
-swY
-swY
-swY
-kDP
-nBX
+dSu
+dSu
+dSu
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+kpk
+dSu
 wuy
 qVP
 qVP
@@ -83283,27 +83896,27 @@ ohU
 wEZ
 wEZ
 lWL
-pfG
-pfG
+qUM
+qUM
 xPJ
-pfG
-pfG
-pfG
-pfG
-kVf
+qUM
+qUM
+qUM
+qUM
+hat
 uSt
 kVO
-diA
+kVf
 sXZ
 bHX
-azW
+diA
 tWq
-qUM
+qMP
 dHZ
 weY
 qyr
 bHR
-yhZ
+mWE
 daa
 qKU
 qKU
@@ -83382,14 +83995,14 @@ qVP
 qVP
 qVP
 wuy
-nBX
-kDP
-swY
-swY
-swY
-swY
-swY
-swY
+dSu
+kpk
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 gbS
 gbS
 gbS
@@ -83397,13 +84010,13 @@ dsu
 gbS
 gbS
 gbS
-swY
-swY
-swY
-swY
-swY
-swY
-kDP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+kpk
 gbS
 wuy
 qVP
@@ -83452,7 +84065,7 @@ qyr
 qyr
 qyr
 bHR
-yhZ
+mWE
 lQE
 bqe
 iee
@@ -83460,7 +84073,7 @@ qam
 wYH
 qyr
 bHR
-yhZ
+mWE
 daa
 jNW
 jNW
@@ -83539,28 +84152,28 @@ qVP
 qVP
 qVP
 wuy
-nBX
-kDP
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
-nBX
-nBX
+dSu
+kpk
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+dSu
+dSu
+dSu
 nGf
-nBX
-nBX
-nBX
-swY
-swY
-swY
-swY
-swY
-swY
-kDP
+dSu
+dSu
+dSu
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+kpk
 dsu
 wuy
 qVP
@@ -83600,7 +84213,7 @@ rcl
 wUC
 aTw
 crJ
-aoo
+iKl
 svE
 crJ
 crJ
@@ -83617,7 +84230,7 @@ qyr
 qyr
 qyr
 uck
-sSw
+odO
 xIM
 pfC
 pXF
@@ -83696,28 +84309,28 @@ qVP
 qVP
 qVP
 wuy
-nBX
-nBX
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
-nBX
-nBX
+dSu
+dSu
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+dSu
+dSu
+dSu
 nGf
-nBX
-nBX
-nBX
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
+dSu
+dSu
+dSu
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+dSu
 gbS
 wuy
 qVP
@@ -83761,20 +84374,20 @@ veP
 esC
 tdg
 dAi
-aoo
+iKl
 gPB
 qbh
 qbh
 bHR
-iwD
-azW
+dQc
+diA
 tWq
-qUM
+qMP
 aTa
 weY
 qyr
 bHR
-yhZ
+mWE
 daa
 qyr
 qyr
@@ -83853,14 +84466,14 @@ qVP
 qVP
 qVP
 wuy
-nBX
-njK
-swY
-swY
-swY
-swY
-swY
-swY
+dSu
+cxh
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 gbS
 gbS
 gbS
@@ -83868,13 +84481,13 @@ dsu
 gbS
 gbS
 gbS
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+dSu
 gbS
 wuy
 qVP
@@ -83923,7 +84536,7 @@ vky
 vky
 vky
 vky
-uxe
+cvG
 lQE
 aII
 iee
@@ -83931,7 +84544,7 @@ qam
 hHl
 qyr
 bHR
-yhZ
+mWE
 daa
 qbh
 qbh
@@ -84010,26 +84623,26 @@ qVP
 qVP
 qVP
 wuy
-nBX
-njK
+dSu
+cxh
 jeU
-qMP
-sCc
-qMP
-sCc
+rGQ
+iol
+rGQ
+iol
 jeU
-nBX
-nBX
-nBX
+dSu
+dSu
+dSu
 nGf
-nBX
-nBX
-nBX
+dSu
+dSu
+dSu
 jeU
-qMP
-sCc
-qMP
-sCc
+rGQ
+iol
+rGQ
+iol
 jeU
 gbS
 gbS
@@ -84046,7 +84659,7 @@ daT
 daT
 daT
 idA
-nOQ
+wpl
 jqL
 wpl
 wpl
@@ -84080,7 +84693,7 @@ uej
 bNV
 bNV
 bHR
-yhZ
+mWE
 hor
 qyr
 qyr
@@ -84088,12 +84701,12 @@ qyr
 qyr
 qyr
 uck
-odO
-mWE
-mWE
-mWE
-mWE
-mWE
+mro
+ldv
+ldv
+ldv
+ldv
+ldv
 cah
 ioB
 nPD
@@ -84170,10 +84783,10 @@ wuy
 wuy
 qQP
 lhT
-dJx
-dJx
-dJx
-dJx
+imS
+imS
+imS
+imS
 vTc
 qQP
 qQP
@@ -84183,10 +84796,10 @@ qQP
 qQP
 qQP
 pXJ
-wqx
-wqx
-wqx
-wqx
+upb
+upb
+upb
+upb
 rgW
 qQP
 wuy
@@ -84237,15 +84850,15 @@ qyr
 qyr
 qyr
 bHR
-iwD
-azW
+dQc
+diA
 tWq
-qUM
+qMP
 fwd
 weY
 qyr
 bHR
-yhZ
+mWE
 daa
 qnh
 qyr
@@ -84394,7 +85007,7 @@ vMZ
 gmr
 cPb
 oYf
-yhZ
+mWE
 lQE
 tmp
 iee
@@ -84402,7 +85015,7 @@ qam
 kIo
 qyr
 bHR
-yhZ
+mWE
 daa
 wAU
 sBj
@@ -84501,7 +85114,7 @@ isV
 tXh
 uzD
 bAy
-reA
+dAF
 ogk
 qVP
 qVP
@@ -84551,7 +85164,7 @@ wie
 mny
 qyr
 bHR
-yhZ
+mWE
 ebi
 qyr
 qyr
@@ -84559,7 +85172,7 @@ qyr
 qyr
 qyr
 uck
-yhZ
+mWE
 daa
 mdl
 qyr
@@ -84658,7 +85271,7 @@ nzy
 sjI
 bIh
 lyZ
-dAF
+kQW
 rUa
 qVP
 qVP
@@ -84676,7 +85289,7 @@ eRR
 dyb
 aUy
 vQq
-riy
+psG
 riy
 ayu
 dUo
@@ -84708,7 +85321,7 @@ efK
 bwU
 qyr
 bHR
-yhZ
+mWE
 qbh
 gPB
 qbh
@@ -84716,7 +85329,7 @@ qbh
 qbh
 qbh
 qbh
-yhZ
+mWE
 qbh
 qbh
 kFF
@@ -84816,7 +85429,7 @@ eIK
 kit
 edO
 hCO
-dUe
+pmS
 qVP
 qVP
 qVP
@@ -84866,7 +85479,7 @@ nGw
 qyr
 nDq
 xLA
-mWE
+ldv
 ejX
 mfG
 cPn
@@ -84876,7 +85489,7 @@ mfG
 pqx
 mfG
 mfG
-fGx
+wxA
 wmg
 ust
 qyr
@@ -84973,7 +85586,7 @@ jiK
 iMZ
 blO
 cTo
-dUe
+pmS
 qVP
 qVP
 qVP
@@ -85033,7 +85646,7 @@ bNV
 vrG
 bNV
 bNV
-tRd
+gwR
 bNV
 bNV
 qyr
@@ -85128,8 +85741,8 @@ qMD
 gGE
 sVe
 yim
-dSu
-ura
+hYP
+sPD
 dOf
 qVP
 qVP
@@ -85504,7 +86117,7 @@ qVP
 qVP
 wCo
 gvH
-bul
+oYi
 olT
 jdO
 wCo
@@ -85661,7 +86274,7 @@ dTg
 dTg
 dTg
 cmX
-mbQ
+bul
 isb
 tsI
 wCo
@@ -85810,7 +86423,7 @@ lJw
 cFv
 syO
 pgS
-lrC
+xYm
 joj
 woI
 eZS
@@ -85967,7 +86580,7 @@ dmE
 cFv
 crs
 fLg
-xYm
+anC
 dYv
 woI
 qZi
@@ -86241,9 +86854,9 @@ uxc
 wCJ
 vVb
 vVb
-wtM
-wtM
-wtM
+esY
+esY
+esY
 mUn
 mUn
 mUn
@@ -86376,11 +86989,11 @@ xth
 xth
 xth
 xth
-cTT
+pAp
 eIL
 eIL
-gdZ
-vIb
+wFp
+wqu
 xth
 fdA
 uOG
@@ -86396,12 +87009,12 @@ aNP
 aAq
 aGd
 aGd
-tQQ
+brs
 kPt
 oyt
 egd
 kNZ
-jdI
+qpo
 mUn
 mUn
 mUn
@@ -86536,7 +87149,7 @@ cNx
 aJZ
 llM
 gMP
-bqY
+fex
 tEB
 xth
 rRW
@@ -86553,7 +87166,7 @@ ghX
 ojj
 qAi
 vVb
-pVN
+tQQ
 pWI
 bYx
 bYx
@@ -86693,7 +87306,7 @@ bUh
 oRx
 tYl
 hpF
-aCj
+oVs
 iVk
 xth
 nCJ
@@ -86705,7 +87318,7 @@ lSF
 gOY
 mHD
 nPN
-wmL
+slg
 icl
 ojj
 tit
@@ -86862,7 +87475,7 @@ eQw
 sun
 dJK
 hJJ
-pmS
+wmL
 dCM
 ojj
 aVq
@@ -87028,8 +87641,8 @@ gFX
 gFX
 gFX
 kih
-lim
-dpc
+mjx
+pPz
 fsT
 gvY
 qVP
@@ -87045,7 +87658,7 @@ pLY
 ccd
 jML
 cwa
-gDA
+vIc
 jlM
 uwQ
 gqi
@@ -87309,23 +87922,23 @@ qVP
 gsG
 kud
 nQh
-gwR
-gwR
-gwR
-gwR
-gwR
-gwR
-gwR
-idt
-idt
+kDP
+kDP
+kDP
+kDP
+kDP
+kDP
+kDP
+guQ
+guQ
 eCA
-idt
-idt
+guQ
+guQ
 pAx
 gbr
-psi
-ukz
 pSi
+ukz
+gqh
 tfP
 hPr
 jgb
@@ -87333,7 +87946,7 @@ fBA
 tfj
 eFj
 mcE
-rQA
+wpg
 avK
 uiB
 pIx
@@ -87616,7 +88229,7 @@ tuc
 eSR
 rqy
 eSR
-mtQ
+rJq
 eSR
 qVP
 qVP
@@ -87624,7 +88237,7 @@ gsG
 jIe
 kxC
 ccb
-rmM
+jCd
 ccb
 rib
 hmJ
@@ -87773,16 +88386,16 @@ tuc
 rqy
 tuc
 rqy
-mtQ
+rJq
 rqy
 qVP
 qVP
 gsG
 gsG
 gsG
-ahD
+mlO
 adK
-kpP
+aHo
 gsG
 gsG
 pMH
@@ -87793,18 +88406,18 @@ gsG
 rPz
 oDt
 hqb
-gwR
-gwR
+kDP
+kDP
 nau
 iqf
 sSt
 pmf
 jto
 xtH
-upb
+jdI
 fRQ
 xbE
-pmS
+wmL
 bZM
 ojj
 pIx
@@ -87930,7 +88543,7 @@ rqy
 rqy
 rqy
 rqy
-uQN
+rbb
 rqy
 qVP
 qVP
@@ -87958,10 +88571,10 @@ nJs
 jSE
 kPV
 mXQ
-upb
+jdI
 ktu
 xbE
-pmS
+wmL
 nAU
 ojj
 von
@@ -88087,7 +88700,7 @@ qVP
 rqy
 eSR
 rqy
-rTk
+mtQ
 jnM
 qVP
 qVP
@@ -88104,10 +88717,10 @@ qey
 qey
 fhe
 gsG
-kwu
-kwu
+ahD
+ahD
 uop
-kwu
+ahD
 gsG
 djs
 nhz
@@ -88243,7 +88856,7 @@ qVP
 rqy
 rqy
 tuc
-xnf
+afp
 rqy
 srt
 qVP
@@ -88398,8 +89011,8 @@ rqy
 rqy
 rqy
 rqy
-ujY
-oFm
+sBv
+uyg
 rqy
 wyu
 qVP
@@ -88429,7 +89042,7 @@ huG
 aYV
 mrm
 upl
-upb
+jdI
 mKE
 jqC
 dEQ
@@ -88552,9 +89165,9 @@ qVP
 rqy
 rqy
 rqy
+qHk
 ocO
-tnd
-ibh
+rnV
 rqy
 rqy
 rqy
@@ -88586,10 +89199,10 @@ rDV
 iAC
 fRC
 bmS
-upb
+jdI
 pIG
 kNf
-hXb
+nOQ
 lwr
 hPz
 xwH
@@ -88708,7 +89321,7 @@ rqy
 rqy
 rqy
 rqy
-xnf
+afp
 rqy
 qVP
 rqy
@@ -88864,7 +89477,7 @@ rqy
 rqy
 rqy
 rqy
-xnf
+afp
 rqy
 qVP
 qVP
@@ -88898,10 +89511,10 @@ cMl
 oaV
 vBz
 pee
-wrl
+rDI
 jgI
 cAY
-uGU
+swY
 oTl
 sRF
 sRF
@@ -89020,7 +89633,7 @@ qVP
 rqy
 rqy
 tuc
-tGX
+kbb
 qVP
 qVP
 qVP
@@ -89054,11 +89667,11 @@ vPr
 ebH
 fjl
 hfM
-rVu
-vqO
+vBi
+nAn
 tKf
 jYX
-iCe
+sLK
 qoR
 sRF
 keh
@@ -89177,7 +89790,7 @@ qVP
 rqy
 rqy
 tuc
-uQN
+rbb
 qVP
 qVP
 qVP
@@ -89226,7 +89839,7 @@ wDy
 rkU
 vQi
 rkU
-jNC
+gyh
 pZv
 sxj
 wDV
@@ -89334,7 +89947,7 @@ qVP
 rqy
 rqy
 tuc
-ldv
+nBX
 qVP
 qVP
 qVP
@@ -89364,7 +89977,7 @@ mpT
 eGf
 gkJ
 jZb
-nmO
+mUb
 kEE
 ebH
 kRQ
@@ -89383,7 +89996,7 @@ fDt
 rbK
 rbK
 rbK
-wDy
+jFO
 pZv
 sxj
 eLJ
@@ -89492,7 +90105,7 @@ qVP
 qVP
 rqy
 rqy
-cfc
+efO
 qVP
 qVP
 qVP
@@ -89521,8 +90134,8 @@ anZ
 eGf
 eAg
 sxb
-pQx
-gqh
+njI
+iMw
 gkJ
 eAg
 feG
@@ -89649,7 +90262,7 @@ qVP
 qVP
 qVP
 rqy
-afp
+scu
 rqy
 rqy
 rqy
@@ -89678,8 +90291,8 @@ aRD
 exz
 hFC
 gQv
-cZH
 tfU
+uGU
 ohb
 ebH
 mbT
@@ -89807,7 +90420,7 @@ rqy
 qVP
 qVP
 rqy
-cfc
+efO
 rqy
 rqy
 rqy
@@ -90283,7 +90896,7 @@ qVP
 qVP
 rqy
 rHU
-uQN
+rbb
 rqy
 rqy
 rqy
@@ -90440,7 +91053,7 @@ qVP
 qVP
 qVP
 rHU
-uQN
+rbb
 rqy
 rqy
 rqy
@@ -90597,7 +91210,7 @@ qVP
 qVP
 iHy
 ruE
-eoT
+azW
 rqy
 rqy
 rqy
@@ -90639,7 +91252,7 @@ rkX
 bkg
 ieE
 ijk
-dlh
+jEU
 rkU
 sxj
 puN
@@ -90752,9 +91365,9 @@ rqy
 rqy
 rqy
 rqy
-uQN
+rbb
 rEA
-eJm
+dHB
 rEA
 rEA
 sIt
@@ -90781,10 +91394,10 @@ naE
 mCH
 dvF
 hHs
-blf
+iCe
 dwU
-uSf
-uSf
+blf
+blf
 rWy
 woN
 bDj
@@ -90909,9 +91522,9 @@ rqy
 rqy
 rqy
 rqy
-uQN
+rbb
 rek
-oYE
+kHw
 jJJ
 wAN
 sIt
@@ -90948,12 +91561,12 @@ mbT
 jpS
 vwd
 jaR
-haR
+wft
 eYu
 eYu
 qXg
 cAk
-dlh
+jEU
 bvP
 sxj
 eaH
@@ -91066,11 +91679,11 @@ qVP
 rqy
 rqy
 rqy
-kpk
+cNY
 rEA
-wwV
+oYE
 jBo
-uRz
+trK
 quR
 ruE
 ieM
@@ -91223,7 +91836,7 @@ qVP
 rqy
 tuc
 tuc
-uQN
+rbb
 rEA
 aQr
 oXp
@@ -91589,7 +92202,7 @@ yio
 yio
 yio
 yio
-jIB
+erN
 rDZ
 fEk
 vDP
@@ -91755,7 +92368,7 @@ fVs
 sBp
 soj
 juy
-fVy
+uQN
 iGp
 wZK
 snn
@@ -92203,13 +92816,13 @@ cJM
 hHi
 hHi
 rTI
+wvS
 rWq
-rWq
-rWq
+wvS
 fwj
 qIi
-hDv
-hDv
+iwD
+iwD
 cFk
 faY
 qVP
@@ -92516,14 +93129,14 @@ xJv
 hqp
 xTj
 qwA
-fdT
+kpP
 xNF
 eBq
 aKq
 faY
 pDD
 wgO
-hDv
+iwD
 pYw
 faY
 fPT
@@ -92699,7 +93312,7 @@ kyw
 gNo
 rAl
 uXc
-xLC
+fir
 fDQ
 riO
 pkp
@@ -92830,7 +93443,7 @@ uaC
 hqp
 xgO
 kAv
-fdT
+bxn
 wcV
 jSw
 rQc
@@ -92842,7 +93455,7 @@ olg
 faY
 otF
 rkU
-jNC
+etu
 rkU
 rkU
 gmN
@@ -92988,9 +93601,9 @@ hqp
 kAg
 pug
 akZ
-fdT
-fdT
-fdT
+fxU
+weg
+bLq
 faY
 ktR
 bbF
@@ -93170,7 +93783,7 @@ kxK
 lcv
 rAl
 ayx
-xLC
+idt
 tiS
 dVm
 rIm
@@ -93470,7 +94083,7 @@ iel
 iel
 iel
 iel
-iel
+yhZ
 eCC
 njj
 wYA
@@ -93627,7 +94240,7 @@ odc
 odc
 odc
 odc
-iJv
+uTC
 tXH
 njj
 ncl
@@ -93638,7 +94251,7 @@ ayy
 arg
 dQk
 bgx
-imS
+iov
 xQK
 dAY
 izs
@@ -93784,7 +94397,7 @@ fqc
 rgE
 jiI
 ttp
-swD
+heH
 mLN
 njj
 bev
@@ -93794,7 +94407,7 @@ izk
 ayy
 tmQ
 iov
-imS
+iov
 sAo
 sAo
 dki
@@ -93941,7 +94554,7 @@ uxN
 uxN
 uxN
 uxN
-iel
+yhZ
 eCC
 njj
 tNe
@@ -94098,7 +94711,7 @@ iJv
 iJv
 iJv
 iJv
-iJv
+uTC
 aWW
 jfn
 bev
@@ -94255,7 +94868,7 @@ iXU
 ivg
 iXU
 ueC
-swD
+jmm
 hfD
 wHF
 cvC
@@ -94412,7 +95025,7 @@ iel
 iel
 iel
 iel
-iel
+yhZ
 eCC
 jfn
 bev
@@ -94569,7 +95182,7 @@ odc
 odc
 odc
 odc
-iJv
+uTC
 aWW
 njj
 tNe
@@ -94726,7 +95339,7 @@ eqv
 mCl
 pLg
 fal
-swD
+heH
 mLN
 njj
 bev
@@ -94883,7 +95496,7 @@ uxN
 uxN
 uxN
 uxN
-iel
+yhZ
 xdQ
 njj
 ncl
@@ -95040,7 +95653,7 @@ iJv
 iJv
 iJv
 iJv
-iJv
+uTC
 aWW
 njj
 fjW
@@ -95192,11 +95805,11 @@ uaC
 jfn
 swD
 maA
-rDI
-xsj
-xsj
-xsj
-uyg
+cyG
+iXU
+iXU
+iXU
+ueC
 heH
 mLN
 njj
@@ -95350,23 +95963,23 @@ jfn
 iel
 hKR
 cpt
-iel
+ern
 qgU
-iel
-iel
-iel
+ern
+ern
+qyQ
 dtP
 njj
 qwK
-kyb
+dJx
 kyb
 pmL
 vNP
 rsD
 eHS
 cCT
-rKt
-rKt
+chP
+chP
 ldF
 rKt
 hSX
@@ -95520,7 +96133,7 @@ smm
 vqx
 vNP
 xYb
-chP
+rKt
 rKt
 rKt
 rKt
@@ -95677,7 +96290,7 @@ smm
 smm
 vNP
 fKL
-chP
+rKt
 rKt
 rKt
 ouE
@@ -111854,7 +112467,7 @@ wuy
 kBk
 dlm
 fLk
-eCc
+ltj
 uFg
 lse
 lse
@@ -112485,7 +113098,7 @@ wuy
 kBk
 avB
 pOx
-qNi
+nAV
 dRt
 bUr
 noU
@@ -113292,7 +113905,7 @@ hwG
 goF
 tgq
 fzN
-qfF
+soz
 pAc
 bOE
 vvm
@@ -113449,7 +114062,7 @@ pyk
 pvH
 pYv
 aLQ
-tpb
+qfF
 pAc
 bOE
 nRK
@@ -113921,7 +114534,7 @@ wuy
 wuy
 jfa
 vVU
-ryX
+xsj
 wuT
 wuT
 mkD
@@ -115491,10 +116104,10 @@ kRE
 bmz
 bmz
 bmz
-trK
-qHk
-qHk
-qHk
+wtM
+jbI
+jbI
+jbI
 ikZ
 fyZ
 rKj
@@ -115654,7 +116267,7 @@ mpQ
 mpQ
 eJO
 mpQ
-nOZ
+taM
 bCA
 qhL
 qhL
@@ -115810,8 +116423,8 @@ pyh
 ctS
 ctS
 pyh
-iJu
-ciM
+nzd
+eYM
 jfa
 czR
 ggl
@@ -115968,7 +116581,7 @@ qGr
 qQy
 pyh
 mpQ
-nOZ
+taM
 mpQ
 mpQ
 mpQ
@@ -116119,16 +116732,16 @@ aDi
 jlE
 pyh
 hyP
-sMl
+iSX
 hch
 hch
 hQX
 pyh
 mpQ
-lRm
+pfG
 xbH
+tmm
 eWW
-ikg
 uUC
 mpQ
 jfa
@@ -116439,7 +117052,7 @@ sxJ
 jXz
 pyh
 mpQ
-eYM
+yeq
 cPJ
 tdy
 hFz
@@ -116599,7 +117212,7 @@ jjd
 xpH
 cPJ
 ncG
-kXP
+iLi
 pzN
 cPJ
 wuy
@@ -116756,7 +117369,7 @@ mpQ
 xpH
 cPJ
 vsE
-iLi
+uiU
 bmZ
 cPJ
 wuy
@@ -116904,12 +117517,12 @@ lxS
 lxS
 bvM
 rJS
-jbI
-jbI
-jbI
-jbI
-jbI
-jbI
+dpc
+dpc
+dpc
+dpc
+dpc
+dpc
 ivq
 cPJ
 evB

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -489,6 +489,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "9"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "amN" = (
@@ -2273,6 +2276,9 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
 /turf/open/misc/asteroid,
 /area/station/solars/port/fore)
@@ -5012,6 +5018,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/structure/cable/white{
+	icon_state = "6"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/service/chapel/monastery)
 "cxx" = (
@@ -6918,6 +6927,9 @@
 /obj/structure/ladder/invincible,
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "9"
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/service/chapel/monastery)
@@ -9126,6 +9138,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
@@ -13009,6 +13024,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "6"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/hallway/secondary/service)
 "gKQ" = (
@@ -14564,7 +14582,9 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "hxF" = (
@@ -16156,7 +16176,7 @@
 "ilk" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/white{
-	icon_state = "16"
+	icon_state = "4"
 	},
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/service/chapel/monastery)
@@ -16314,6 +16334,9 @@
 /area/station/security/brig)
 "ioE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/eva)
 "ipf" = (
@@ -18903,8 +18926,6 @@
 /area/station/cargo/warehouse/upper)
 "jwt" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
@@ -19398,6 +19419,10 @@
 	c_tag = "Aft Starboard Solar Maintenance"
 	},
 /obj/structure/chair/stool/directional/south,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "jKh" = (
@@ -20624,6 +20649,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/qm)
+"kqi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/eva)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -21016,6 +21052,9 @@
 /area/station/security/brig)
 "kCt" = (
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "kCF" = (
@@ -21355,8 +21394,6 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "kLy" = (
-/obj/structure/table/wood,
-/obj/machinery/telephone/cargo,
 /obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
 	department = "Quartermaster's Desk";
@@ -21368,6 +21405,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "1"
 	},
+/obj/structure/table/wood,
+/obj/machinery/telephone/cargo,
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "kLI" = (
@@ -22847,6 +22886,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"lvH" = (
+/obj/item/electronics/apc,
+/turf/open/floor/deadspace/grater,
+/area/mine/hydroponics)
 "lwb" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/trash,
@@ -24501,6 +24544,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
+"moK" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/service/chapel/monastery)
 "moS" = (
 /obj/structure/table/wood/fancy/cyan,
 /obj/item/folder{
@@ -26741,6 +26790,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"nzv" = (
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/deadspace/grater,
+/area/mine/hydroponics)
 "nzy" = (
 /obj/machinery/atmospherics/components/unary/heat_exchanger{
 	dir = 4
@@ -27904,14 +27957,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "odB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "132"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/station/service/chapel/monastery)
+/obj/item/wallframe/apc,
+/turf/open/floor/deadspace/grater,
+/area/mine/hydroponics)
 "odK" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
@@ -28803,9 +28851,11 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "ozr" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/deadspace/grater,
-/area/mine/hydroponics)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/eva)
 "ozw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -29122,6 +29172,9 @@
 /obj/item/stock_parts/cell,
 /obj/item/stack/cable_coil,
 /obj/item/assembly/igniter,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "oJI" = (
@@ -29626,10 +29679,10 @@
 /area/aegis/mining)
 "oXp" = (
 /obj/machinery/light/small/directional/east,
-/obj/machinery/power/smes,
 /obj/structure/cable/yellow{
 	icon_state = "8"
 	},
+/obj/machinery/power/smes,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "oXu" = (
@@ -29688,6 +29741,9 @@
 "oYE" = (
 /obj/structure/cable/yellow{
 	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -31984,6 +32040,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "qgt" = (
@@ -33280,6 +33339,10 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
+"qNQ" = (
+/obj/item/stack/cable_coil/cut,
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "qOa" = (
 /obj/structure/table,
 /turf/open/floor/deadspace/bathroom,
@@ -34692,10 +34755,10 @@
 "rBk" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "40"
+	icon_state = "12"
 	},
 /obj/structure/cable/white{
-	icon_state = "144"
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/service/chapel/monastery)
@@ -36209,7 +36272,7 @@
 /obj/machinery/light/small/maintenance/directional/south,
 /obj/structure/cable/multiz,
 /obj/structure/cable/yellow{
-	icon_state = "64"
+	icon_state = "1"
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/service/chapel/monastery)
@@ -40681,6 +40744,10 @@
 	},
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/service/chapel/monastery)
+"uQc" = (
+/obj/item/stack/cable_coil/cut,
+/turf/open/misc/asteroid,
+/area/station/solars/port/fore)
 "uQf" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -43986,10 +44053,11 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
 "wAN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /obj/machinery/power/solar_control{
-	dir = 1;
-	id = "starboardsolar";
-	name = "Starboard Quarter Solar Control"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -55475,8 +55543,8 @@ uoP
 trm
 mNO
 mNO
-odB
-trm
+kWh
+moK
 ssE
 jxc
 jgq
@@ -93601,8 +93669,8 @@ jBo
 oYE
 tLC
 ruE
+ruE
 ieM
-rqy
 rqy
 rqy
 eAg
@@ -93757,7 +93825,7 @@ aQr
 oXp
 cuI
 sIt
-rqy
+qNQ
 rqy
 rqy
 rqy
@@ -94700,7 +94768,7 @@ xdC
 qxy
 xdC
 xdC
-cWn
+uQc
 cWn
 pjz
 pjz
@@ -95327,7 +95395,7 @@ rqy
 rqy
 rqy
 rqy
-rqy
+qNQ
 rqy
 iHy
 skX
@@ -95800,7 +95868,7 @@ pPU
 pPU
 bPy
 rqy
-rqy
+qNQ
 rqy
 rqy
 rqy
@@ -95960,7 +96028,7 @@ rqy
 rqy
 rqy
 rqy
-rqy
+qNQ
 qxy
 qbl
 akZ
@@ -97056,7 +97124,7 @@ qxy
 xdC
 xdC
 cWn
-cWn
+uQc
 pjz
 pjz
 qxy
@@ -99095,7 +99163,7 @@ vmk
 vmk
 vmk
 qVP
-qVP
+rqy
 rfo
 rfo
 qVP
@@ -99401,12 +99469,12 @@ fnQ
 vNo
 ekT
 knS
-vNo
+lvH
 vNo
 rpH
 vNo
 vNo
-ozr
+vNo
 vmk
 qVP
 rqy
@@ -99562,7 +99630,7 @@ vNo
 lqL
 vNo
 vNo
-vNo
+odB
 vNo
 vmk
 koO
@@ -100031,7 +100099,7 @@ fnQ
 knS
 vNo
 vNo
-vNo
+nzv
 beo
 xZO
 lPd
@@ -103236,9 +103304,9 @@ qVP
 qVP
 cEn
 ioE
-dOB
-dOB
-wcc
+ozr
+ozr
+kqi
 dOB
 cEn
 jIo

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -12717,7 +12717,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "gAv" = (
@@ -41115,7 +41117,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "vat" = (

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -209,7 +209,7 @@
 /area/station/hallway/primary/central)
 "afp" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "40"
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
@@ -262,19 +262,11 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
-"aht" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "ahD" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "ahQ" = (
@@ -520,6 +512,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
+"aoo" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/security/warden)
 "aot" = (
 /turf/open/floor/deadspace/mono,
 /area/station/security/courtroom)
@@ -651,7 +650,9 @@
 "aqS" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
 "arg" = (
@@ -832,15 +833,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
-"avn" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
 "avB" = (
 /turf/open/openspace,
 /area/station/commons/lounge)
@@ -1001,11 +993,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "azW" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms/cryo)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
+	},
+/area/station/security/brig)
 "aAj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -1054,7 +1048,7 @@
 /area/station/hallway/primary/port)
 "aBf" = (
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
@@ -1078,6 +1072,18 @@
 /obj/structure/lattice,
 /turf/open/openspace,
 /area/station/commons/storage/primary)
+"aCj" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "aCy" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -1103,12 +1109,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hos)
-"aDj" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "aDk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/light/directional/south,
@@ -1321,8 +1321,10 @@
 /area/aegis/hanger)
 "aJv" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "aJH" = (
@@ -2538,7 +2540,7 @@
 "bqd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
@@ -2596,6 +2598,15 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
+"bqY" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "bre" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
@@ -2620,12 +2631,6 @@
 /obj/item/gun/ballistic/automatic/pistol/rivet,
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
-"brq" = (
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "brD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 5
@@ -2709,19 +2714,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore/lesser)
-"btI" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "buf" = (
 /obj/machinery/door/airlock/hydroponics/glass{
 	name = "Abandoned Hydroponics";
@@ -2735,7 +2727,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -3800,6 +3792,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
+"bWn" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "bWt" = (
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
@@ -3892,7 +3891,7 @@
 "bYx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
@@ -4040,12 +4039,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"cbT" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "ccb" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
@@ -4128,6 +4121,12 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
+"cfc" = (
+/obj/structure/cable/yellow{
+	icon_state = "68"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "cfk" = (
 /mob/living/simple_animal/slug,
 /turf/open/floor/wood,
@@ -4140,16 +4139,6 @@
 /obj/structure/chair/office,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
-"cfG" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "cfJ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -4157,20 +4146,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"cfN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "cge" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -4276,6 +4251,20 @@
 /obj/item/clothing/head/welding/demon,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
+"ciM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "cja" = (
 /obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/iron/dark/side{
@@ -5139,12 +5128,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
-"cGR" = (
-/obj/structure/cable/yellow{
-	icon_state = "24"
-	},
-/turf/open/floor/plating,
-/area/aegis/surface)
 "cGY" = (
 /obj/structure/cable/red{
 	icon_state = "12"
@@ -5579,18 +5562,6 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/deadspace/grater,
 /area/station/medical/morgue)
-"cSm" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "cSt" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/grater,
@@ -5640,6 +5611,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"cTT" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "cTU" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/water,
@@ -5664,7 +5642,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
 "cUD" = (
@@ -5843,6 +5826,12 @@
 "cZt" = (
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
+"cZH" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "cZS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5859,24 +5848,6 @@
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
-/area/station/security/brig)
-"dao" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "P-Sec Brig";
-	req_access_txt = "63";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
 "daK" = (
 /obj/structure/chair/office,
@@ -6054,12 +6025,26 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1"
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -6269,11 +6254,11 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/fore)
 "dpc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "dpo" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/right{
@@ -6660,9 +6645,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
+	dir = 8
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -6811,10 +6795,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
@@ -6940,11 +6921,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
-"dIe" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
 "dIj" = (
 /obj/structure/sign/warning{
 	sign_change_name = "Warning: LIVE FIRING"
@@ -7001,13 +6977,15 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "dJx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
@@ -7153,7 +7131,9 @@
 /area/station/cargo/sorting)
 "dOS" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/commons/storage/primary)
 "dPf" = (
@@ -7259,14 +7239,14 @@
 	},
 /area/aegis/mining)
 "dSu" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
 	},
-/area/aegis/surface)
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "dSB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -7453,17 +7433,13 @@
 /obj/effect/landmark/navigate_destination/dockarrival,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/dorms/cryo)
-"dWn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/station/commons/lounge)
 "dWo" = (
 /obj/structure/rack{
 	icon = 'icons/obj/stationobjs.dmi';
@@ -7568,13 +7544,6 @@
 /obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"dZb" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "dZl" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
@@ -8051,19 +8020,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"emc" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/white,
-/area/station/service/kitchen)
 "emt" = (
 /obj/structure/railing/corner,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -8150,6 +8106,15 @@
 "eoM" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/central)
+"eoT" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "eoV" = (
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
@@ -8581,6 +8546,12 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/carpet/red,
 /area/aegis/hanger)
+"eCc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/station/commons/lounge)
 "eCf" = (
 /obj/structure/chair{
 	dir = 4
@@ -8598,6 +8569,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
@@ -8929,13 +8903,27 @@
 "eIL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/monitoring)
 "eIZ" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/office)
+"eJm" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "eJA" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -9442,9 +9430,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "eYU" = (
@@ -9790,16 +9775,6 @@
 /obj/machinery/light/broken/directional/east,
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
-"fjd" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "fjl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
 	dir = 10
@@ -10112,13 +10087,6 @@
 /obj/structure/flora/ausbushes/leafybush,
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
-"fqe" = (
-/obj/structure/cable/multiz,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "fqh" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -10534,13 +10502,6 @@
 "fEk" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/storage/tools)
-"fEn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/service/janitor)
 "fEo" = (
 /obj/structure/sign/warning,
 /turf/closed/wall/mineral/titanium/survival/pod,
@@ -10569,6 +10530,15 @@
 /obj/item/food/soup/blood,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"fGx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "fGV" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet/secure_closet/brig{
@@ -10644,18 +10614,6 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/storage/primary)
-"fJP" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "fKL" = (
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
@@ -11112,12 +11070,6 @@
 "fUM" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/commons/storage/primary)
-"fVi" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "fVp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -11151,12 +11103,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
-"fVH" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "fWv" = (
 /obj/machinery/computer/piratepad_control/civilian,
 /turf/open/floor/deadspace/random/rectangles,
@@ -11174,9 +11120,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/dorms/cryo)
 "fXF" = (
@@ -11346,10 +11294,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "gbS" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "gcw" = (
 /obj/machinery/door/airlock/mining{
 	dir = 1;
@@ -11413,6 +11362,19 @@
 /obj/effect/spawner/random/deadspace/ammo/mining,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
+"gdZ" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "geq" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/deadspace/grater,
@@ -11806,13 +11768,10 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 4
-	},
-/area/station/security/brig)
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -11899,6 +11858,16 @@
 /obj/item/storage/medkit/toxin,
 /turf/open/floor/deadspace/grater,
 /area/station/medical/medbay/aft)
+"gsA" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/male)
 "gsG" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/main)
@@ -11986,10 +11955,11 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
@@ -12663,9 +12633,11 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/cryo)
 "gRy" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/commons/storage/primary)
 "gRD" = (
@@ -12994,13 +12966,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
-"had" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/security/warden)
 "hal" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -13059,9 +13024,11 @@
 /area/station/hallway/primary/central)
 "hbH" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "hbP" = (
@@ -14088,13 +14055,6 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"hFV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "hFY" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -14752,6 +14712,12 @@
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/deadspace/hardwood,
 /area/aegis/telecomms/high)
+"hXb" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "hXv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14877,6 +14843,12 @@
 /obj/machinery/light/small/maintenance/directional/north,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
+"ibh" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "ibp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/monitored/plasma_output{
 	dir = 8
@@ -14921,15 +14893,14 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/red{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "idy" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor{
@@ -15012,13 +14983,6 @@
 	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
-"ieW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/male)
 "ieZ" = (
 /obj/structure/sign/directions/supply{
 	dir = 4;
@@ -15284,6 +15248,14 @@
 /obj/machinery/light/small/maintenance/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"ikg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "ikq" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood,
 /turf/open/floor/carpet/royalblack,
@@ -15459,20 +15431,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "iol" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
-"ion" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15718,10 +15683,19 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "iwD" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "iwK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -15934,7 +15908,7 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/closed/wall/r_wall,
 /area/station/engineering/atmos/storage/gas)
 "iCm" = (
@@ -16282,6 +16256,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse/upper)
+"iJu" = (
+/obj/structure/cable/multiz,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "iJv" = (
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
@@ -16805,14 +16786,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central/aft)
-"iUB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "iVk" = (
 /obj/structure/table,
 /obj/machinery/power/data_terminal,
@@ -17046,12 +17019,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "jbL" = (
@@ -17104,16 +17071,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jdI" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "5"
 	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/ce)
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "jdK" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -17138,10 +17100,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "jeU" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
 	},
+/obj/structure/lattice,
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -17566,7 +17528,9 @@
 /area/aegis/surface)
 "jnN" = (
 /obj/machinery/firealarm/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/commons/storage/primary)
 "jnY" = (
@@ -18614,17 +18578,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/starboard)
-"jPF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "jPR" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/plating,
@@ -19552,12 +19505,11 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "kpk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "kpy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -19570,12 +19522,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "1"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -19796,6 +19748,10 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
+"kwu" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "kwF" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/department/engine)
@@ -19998,27 +19954,13 @@
 /obj/structure/rack,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
-"kDM" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
-"kDN" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "kDP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/area/aegis/surface)
 "kEv" = (
 /obj/item/megaphone,
 /obj/structure/table/wood,
@@ -20200,14 +20142,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/storage)
-"kJM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "kJN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
@@ -20311,15 +20245,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
-"kMM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "kMN" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -20613,15 +20538,6 @@
 /obj/machinery/camera/autoname/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
-"kTE" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "kTJ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -20693,9 +20609,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
@@ -20796,6 +20709,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
+"kXP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/maintenance/fore/greater)
 "kYb" = (
 /obj/machinery/holopad,
 /obj/effect/floor_decal/ds/spline/fancy/wood{
@@ -21015,9 +20935,9 @@
 /area/station/science/breakroom)
 "ldv" = (
 /obj/structure/cable/yellow{
-	icon_state = "129"
+	icon_state = "40"
 	},
-/turf/open/misc/asteroid,
+/turf/open/misc/ironsand,
 /area/aegis/surface)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
@@ -21246,6 +21166,12 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
+"lim" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "lip" = (
 /obj/item/wirecutters/abductor,
 /turf/open/floor/stone,
@@ -21302,17 +21228,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
-"lke" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "lku" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -21323,13 +21238,6 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
-"lld" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/computer)
 "lli" = (
 /obj/machinery/power/floodlight,
 /turf/open/floor/plating,
@@ -21359,13 +21267,6 @@
 	dir = 8
 	},
 /area/station/security/checkpoint/science)
-"llL" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "llM" = (
 /obj/machinery/modular_computer/console/preset/engineering{
 	dir = 4
@@ -21393,15 +21294,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/hardwood,
 /area/station/service/chapel/office)
-"lml" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "lmo" = (
 /obj/structure/table,
 /obj/effect/turf_decal/delivery,
@@ -21577,6 +21469,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"lrC" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "lrH" = (
 /obj/machinery/shower{
 	dir = 8
@@ -22427,6 +22325,17 @@
 	dir = 4
 	},
 /area/station/security/brig)
+"lRm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "lRA" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -22800,6 +22709,16 @@
 /obj/structure/bookcase/random,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
+"mbQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "mbT" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
@@ -22911,11 +22830,11 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
 "mfG" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "3"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
@@ -23569,21 +23488,6 @@
 /obj/structure/chair,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
-"mxC" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
 "mxH" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -23837,12 +23741,6 @@
 /obj/effect/spawner/random/techstorage/security_all,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
-"mDM" = (
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "mEk" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -24419,7 +24317,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
@@ -24923,6 +24821,12 @@
 	dir = 1
 	},
 /area/station/security/checkpoint/customs)
+"njK" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "njM" = (
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/vitals_monitor,
@@ -24989,6 +24893,13 @@
 /obj/effect/landmark/pestspawn,
 /turf/open/water,
 /area/station/hallway/primary/aft)
+"nmO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "nmW" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
@@ -25481,16 +25392,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "nBX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/area/aegis/surface)
 "nCk" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -25670,8 +25575,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "nHM" = (
@@ -25924,6 +25831,17 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
+"nOZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "nPb" = (
 /obj/structure/table,
 /obj/item/stock_parts/scanning_module{
@@ -26100,14 +26018,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/ai_monitored/security/armory)
-"nTb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig/upper)
 "nTe" = (
 /obj/machinery/door/airlock/mining{
 	dir = 4;
@@ -26172,6 +26082,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"nVq" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/female)
 "nVr" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -26393,7 +26313,7 @@
 /area/station/command/bridge)
 "ocO" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "18"
 	},
 /turf/open/misc/ironsand,
 /area/aegis/surface)
@@ -26944,10 +26864,10 @@
 "oqy" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "4"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2"
+	icon_state = "5"
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
@@ -27025,13 +26945,6 @@
 "osC" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
-"osK" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "osQ" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
@@ -27366,6 +27279,13 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse/upper)
+"oCt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/male)
 "oCw" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/oven,
@@ -27430,6 +27350,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"oFm" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "oFr" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/disposalpipe/trunk{
@@ -28122,7 +28048,7 @@
 /area/station/medical/medbay/central)
 "oYE" = (
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -28613,9 +28539,14 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "pmS" = (
+/obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "pnj" = (
 /obj/structure/railing{
 	dir = 6
@@ -28680,6 +28611,12 @@
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
+"ppd" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "ppE" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -28772,6 +28709,18 @@
 /area/station/maintenance/port/lesser)
 "psd" = (
 /obj/effect/landmark/start/station_engineer,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
+"psi" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "psj" = (
@@ -28927,7 +28876,9 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "pwR" = (
@@ -28939,17 +28890,6 @@
 /obj/structure/table/wood/fancy/red,
 /turf/open/floor/wood,
 /area/station/service/chapel)
-"pxr" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "pxs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -29349,6 +29289,20 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
+"pGW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "pHp" = (
 /obj/structure/sign/cec/deck/medical{
 	pixel_y = 32
@@ -29484,13 +29438,6 @@
 /obj/structure/closet/crate/large,
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
-"pLy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/commons/dorms/barracks/male)
 "pLD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -29547,9 +29494,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination/tools,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/storage/primary)
 "pMy" = (
@@ -29760,6 +29709,11 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
+"pQx" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "pQD" = (
 /obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/plating,
@@ -29814,6 +29768,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
@@ -29875,6 +29832,13 @@
 /obj/item/storage/box/masks,
 /turf/open/floor/deadspace/bathroom,
 /area/station/medical/morgue)
+"pVN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "pVP" = (
 /obj/structure/railing{
 	dir = 5
@@ -30066,6 +30030,15 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
+"qaz" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/commons/dorms/cryo)
 "qaC" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -30240,7 +30213,7 @@
 "qfF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "5"
 	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
@@ -30914,13 +30887,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/male)
-"qwh" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "qwp" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/right,
@@ -30956,20 +30922,6 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
-"qxn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "qxy" = (
 /obj/structure/cable/yellow{
 	icon_state = "3"
@@ -31031,6 +30983,17 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"qzb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "qzA" = (
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/deadspace/mono,
@@ -31257,13 +31220,14 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qHk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -31354,14 +31318,6 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"qJS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
 "qKI" = (
 /obj/machinery/light/directional/west,
 /obj/machinery/camera/autoname/directional/west,
@@ -31446,9 +31402,14 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "qMP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "qMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -31464,6 +31425,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
+"qNi" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "qNt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -31529,6 +31495,15 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo)
+"qPh" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/hallway/primary/port)
 "qPk" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/beer{
@@ -31628,14 +31603,6 @@
 /obj/item/book/manual/wiki/robotics_cyborgs,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
-"qSa" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "qSh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 9
@@ -31737,10 +31704,11 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "qUM" = (
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "qVj" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
@@ -32074,6 +32042,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
+"reA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "reC" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32317,13 +32295,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
-"rlH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/maintenance/fore/greater)
 "rlP" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_center,
@@ -32374,6 +32345,14 @@
 	dir = 1
 	},
 /area/aegis/hanger)
+"rmM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "rmW" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/storage/book/bible/unitology,
@@ -32695,8 +32674,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "rwS" = (
@@ -32763,6 +32744,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"ryX" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "rzc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
 	dir = 8
@@ -32865,7 +32854,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
 "rCd" = (
@@ -33382,14 +33373,16 @@
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
 "rQA" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "rQK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/tool,
@@ -33442,6 +33435,12 @@
 "rSR" = (
 /obj/effect/spawner/random/deadspace/rig/scaf,
 /turf/open/floor/deadspace/mono,
+/area/aegis/surface)
+"rTk" = (
+/obj/structure/cable/yellow{
+	icon_state = "24"
+	},
+/turf/open/floor/plating,
 /area/aegis/surface)
 "rTI" = (
 /obj/machinery/door/airlock/command/glass{
@@ -33520,6 +33519,13 @@
 	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/male)
+"rVu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "rVv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -34353,19 +34359,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "swY" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/area/aegis/surface)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -34535,20 +34536,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
-"sBG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "sCc" = (
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -34663,15 +34655,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
-"sEG" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "sEI" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/effect/spawner/random/vending/colavend,
@@ -34748,12 +34731,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"sIn" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "sIt" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -34878,6 +34855,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
+"sMl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "sMm" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/norn,
@@ -35097,6 +35082,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"sSw" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "sSP" = (
 /obj/structure/table,
 /turf/open/floor/deadspace/random/maint_right,
@@ -35807,6 +35803,12 @@
 /obj/effect/spawner/random/deadspace/ammo/mining,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
+"tnd" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "tnj" = (
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/misc/asteroid,
@@ -35846,6 +35848,13 @@
 /obj/machinery/gibber,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
+"tpb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "tpk" = (
 /obj/machinery/door/airlock/external{
 	name = "Cave-In Shelter 2"
@@ -35886,14 +35895,17 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "trK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
-/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "trL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -35931,18 +35943,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"tsL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "ttp" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/east,
@@ -36416,6 +36416,12 @@
 /obj/item/storage/medkit/surgery,
 /turf/closed/wall/r_wall,
 /area/station/medical/medbay/aft)
+"tGX" = (
+/obj/structure/cable/yellow{
+	icon_state = "132"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "tHg" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/icecream_vat,
@@ -36533,6 +36539,16 @@
 /obj/structure/table,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"tLl" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "tLZ" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
@@ -36541,7 +36557,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/dorms/cryo)
 "tMw" = (
@@ -36691,6 +36709,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/female)
+"tRd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "tRl" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/bar{
@@ -37298,6 +37324,12 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/misc/asteroid/snow,
 /area/station/science/breakroom)
+"ujY" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "ukf" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron/dark/side{
@@ -37542,10 +37574,16 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
 "upb" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/ce)
 "upl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -37626,6 +37664,18 @@
 /obj/structure/curtain,
 /turf/open/floor/deadspace/grille_spare4,
 /area/station/commons/dorms/barracks/female)
+"ura" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "urb" = (
 /obj/machinery/door/airlock/mining{
 	name = "Warehouse";
@@ -37831,20 +37881,6 @@
 	dir = 1
 	},
 /area/aegis/mining)
-"uwH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "uwQ" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -37853,6 +37889,20 @@
 /obj/machinery/firealarm/directional/north,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
+"uxe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "uxu" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/corner{
 	dir = 1
@@ -38097,6 +38147,16 @@
 "uCC" = (
 /turf/open/floor/deadspace/grille_spare2,
 /area/aegis/surface)
+"uCH" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/white,
+/area/station/service/kitchen)
 "uCR" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
@@ -38201,11 +38261,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38463,12 +38521,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "12"
 	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -38504,6 +38561,12 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/mono,
 /area/mine/hydroponics)
+"uRz" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "uSc" = (
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
@@ -38519,6 +38582,13 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/command)
+"uSf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "uSl" = (
 /obj/item/stack/sheet/plasteel{
 	amount = 10;
@@ -38903,7 +38973,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "vbA" = (
@@ -38976,12 +39048,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"vdL" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "vdT" = (
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/deadspace/random/maint_left,
@@ -39398,6 +39464,11 @@
 /obj/machinery/light/small/maintenance/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"vqO" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "vqU" = (
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
@@ -39414,13 +39485,6 @@
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
 /area/station/science/breakroom)
-"vrh" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "vri" = (
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
@@ -39818,12 +39882,6 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
-"vCr" = (
-/obj/structure/cable/yellow{
-	icon_state = "68"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "vCt" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -39995,6 +40053,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "vHV" = (
@@ -40003,6 +40064,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"vIb" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "vIf" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -40020,12 +40088,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
-"vIp" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "vIJ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -40414,6 +40476,13 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse)
+"vRM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/commons/dorms/barracks/male)
 "vRZ" = (
 /turf/closed/wall/r_wall,
 /area/station/service/chapel/office)
@@ -41097,6 +41166,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "wnd" = (
@@ -41151,12 +41223,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/office)
-"woD" = (
-/obj/structure/cable/yellow{
-	icon_state = "132"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "woF" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 5
@@ -41194,11 +41260,12 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/brig)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/service/janitor)
 "wpl" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
@@ -41251,6 +41318,16 @@
 /obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig/upper)
+"wqx" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "wqC" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/chair/office{
@@ -41281,11 +41358,9 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "wrl" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41360,15 +41435,12 @@
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "wtM" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
-	},
-/obj/structure/cable/red{
-	icon_state = "2"
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
 /turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/area/station/tcommsat/server)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41468,6 +41540,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"wwV" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "wwW" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -42146,7 +42227,9 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
 "wSD" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
 "wSF" = (
@@ -42463,15 +42546,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/maintenance/fore/lesser)
-"xaW" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "xba" = (
 /obj/structure/closet/secure_closet/ds/medical3,
 /turf/open/floor/deadspace/bathroom,
@@ -42987,6 +43061,12 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
+"xnf" = (
+/obj/structure/cable/yellow{
+	icon_state = "144"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "xni" = (
 /obj/effect/landmark/start/chaplain,
 /obj/structure/chair/wood{
@@ -43416,7 +43496,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "xyB" = (
@@ -43940,12 +44022,6 @@
 "xOZ" = (
 /turf/closed/wall/r_wall,
 /area/mine/living_quarters)
-"xPb" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
 "xPd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44176,8 +44252,8 @@
 /area/station/hallway/primary/starboard)
 "xYm" = (
 /obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "xYs" = (
@@ -44340,16 +44416,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
-"ydG" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
 "yey" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/grater,
@@ -44489,11 +44555,16 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "144"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
@@ -77561,7 +77632,7 @@ xVM
 xVM
 xVM
 fQc
-xVM
+qPh
 pMt
 gRy
 rwp
@@ -78002,7 +78073,7 @@ rwR
 aJv
 hbH
 fXy
-dTk
+gsA
 iYH
 iYH
 iYH
@@ -78169,7 +78240,7 @@ iWf
 gAV
 aHO
 aHO
-ieW
+oCt
 iWf
 aHO
 gAV
@@ -78326,7 +78397,7 @@ mwV
 hfO
 mwV
 mwV
-pLy
+vRM
 mwV
 mwV
 hfO
@@ -78940,7 +79011,7 @@ qVP
 anE
 gRv
 gRv
-cUw
+qaz
 sxL
 cYy
 anE
@@ -79097,7 +79168,7 @@ qVP
 anE
 sxe
 nAx
-cUw
+qaz
 vqU
 bro
 anE
@@ -79267,7 +79338,7 @@ veo
 veo
 sFi
 nAH
-xPb
+ppd
 alq
 sNO
 dIR
@@ -79411,7 +79482,7 @@ qVP
 anE
 hTF
 tXB
-cUw
+qaz
 vqU
 oJf
 anE
@@ -80511,10 +80582,10 @@ anE
 nOX
 ijC
 nHL
-azW
+aJv
 hbH
 dVP
-beQ
+nVq
 jKk
 jKk
 jKk
@@ -81022,8 +81093,8 @@ tyr
 dmW
 hEO
 mui
-emc
 vHE
+uCH
 eEt
 qYZ
 fXZ
@@ -81474,7 +81545,7 @@ fnR
 sMY
 tQS
 hnk
-fEn
+bqd
 msD
 ayh
 npi
@@ -81485,7 +81556,7 @@ kBk
 ruP
 bwu
 jaQ
-kJM
+iol
 nAc
 wVk
 ijf
@@ -81631,7 +81702,7 @@ fnR
 jfz
 hnk
 tQS
-bqd
+wpg
 lqv
 rCd
 npi
@@ -82060,11 +82131,11 @@ qVP
 qVP
 wuy
 wuy
-qUM
-qUM
-qUM
-qUM
-qUM
+nBX
+nBX
+nBX
+nBX
+nBX
 wuy
 wuy
 wuy
@@ -82136,7 +82207,7 @@ reE
 khL
 qbh
 qbh
-mWE
+yhZ
 akB
 qyr
 qVP
@@ -82216,24 +82287,24 @@ wuy
 wuy
 wuy
 wuy
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
 wuy
 wuy
 vRZ
@@ -82288,11 +82359,11 @@ vky
 vky
 vky
 vky
-jPF
+qzb
 vky
 tCw
 aQM
-kMM
+mfG
 nqY
 daa
 qyr
@@ -82369,29 +82440,29 @@ qVP
 qVP
 qVP
 wuy
-qUM
-qUM
-qwh
-qwh
-qwh
-qwh
-qwh
-qwh
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
-qUM
+nBX
+nBX
+kDP
+kDP
+kDP
+kDP
+kDP
+kDP
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
+nBX
 qnp
-qwh
-qwh
-qwh
-qwh
-qwh
-qUM
-qUM
+kDP
+kDP
+kDP
+kDP
+kDP
+nBX
+nBX
 wuy
 vRZ
 bzI
@@ -82439,7 +82510,7 @@ uej
 bNV
 bNV
 bNV
-mWE
+yhZ
 bNV
 bNV
 bNV
@@ -82447,7 +82518,7 @@ bNV
 bNV
 bNV
 bNV
-mWE
+yhZ
 bNV
 bNV
 bNV
@@ -82526,29 +82597,29 @@ qVP
 qVP
 qVP
 wuy
-qUM
-qwh
+nBX
+kDP
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-qUM
-qUM
-qUM
+nBX
+nBX
+nBX
 dsu
-qUM
-qUM
-qUM
+nBX
+nBX
+nBX
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-qwh
-qUM
+kDP
+nBX
 wuy
 vRZ
 uho
@@ -82596,7 +82667,7 @@ vHk
 mct
 vmQ
 bHR
-mWE
+yhZ
 qWQ
 qyr
 qyr
@@ -82604,7 +82675,7 @@ qyr
 qyr
 qyr
 uck
-mWE
+yhZ
 daa
 qyr
 qyr
@@ -82683,29 +82754,29 @@ qVP
 qVP
 qVP
 wuy
-qUM
-qwh
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qUM
-qUM
-qUM
+nBX
+kDP
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
+nBX
+nBX
 nGf
-qUM
-qUM
-qUM
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qwh
-qUM
+nBX
+nBX
+nBX
+swY
+swY
+swY
+swY
+swY
+swY
+kDP
+nBX
 wuy
 vRZ
 ham
@@ -82753,15 +82824,15 @@ qyr
 qyr
 qyr
 bHR
-cfN
-gqh
+pGW
+azW
 tWq
-wpg
+qUM
 cVO
 weY
 qyr
 bHR
-mWE
+yhZ
 daa
 qSo
 qSo
@@ -82840,29 +82911,29 @@ qVP
 qVP
 qVP
 wuy
-qUM
-qwh
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-sCc
-sCc
-sCc
+nBX
+kDP
+swY
+swY
+swY
+swY
+swY
+swY
+gbS
+gbS
+gbS
 dsu
-sCc
-sCc
-sCc
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qwh
-qUM
+gbS
+gbS
+gbS
+swY
+swY
+swY
+swY
+swY
+swY
+kDP
+nBX
 wuy
 vRZ
 vRZ
@@ -82910,7 +82981,7 @@ kGp
 dSB
 aSO
 bHR
-mWE
+yhZ
 qpF
 trI
 iee
@@ -82918,7 +82989,7 @@ qam
 fGV
 qyr
 bHR
-mWE
+yhZ
 daa
 qKU
 qKU
@@ -82997,29 +83068,29 @@ qVP
 qVP
 qVP
 wuy
-qUM
-qUM
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qUM
-qUM
-qUM
+nBX
+nBX
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
+nBX
+nBX
 nGf
-qUM
-qUM
-qUM
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qUM
-qUM
+nBX
+nBX
+nBX
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
+nBX
 wuy
 qVP
 qVP
@@ -83062,12 +83133,12 @@ bJz
 wqD
 bJz
 bJz
-vrh
+bWn
+tLl
+tLl
 oqy
-oqy
-fjd
 bHR
-mWE
+yhZ
 jYt
 qyr
 qyr
@@ -83075,7 +83146,7 @@ qyr
 qyr
 qyr
 tfu
-swY
+iwD
 igw
 fpu
 fpu
@@ -83154,29 +83225,29 @@ qVP
 qVP
 qVP
 wuy
-qUM
-qwh
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qUM
-qUM
-qUM
+nBX
+kDP
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
+nBX
+nBX
 nGf
-qUM
-qUM
-qUM
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qwh
-qUM
+nBX
+nBX
+nBX
+swY
+swY
+swY
+swY
+swY
+swY
+kDP
+nBX
 wuy
 qVP
 qVP
@@ -83219,20 +83290,20 @@ pfG
 pfG
 pfG
 pfG
-dao
+kVf
 uSt
 kVO
-kVf
+diA
 sXZ
 bHX
-gqh
+azW
 tWq
-wpg
+qUM
 dHZ
 weY
 qyr
 bHR
-mWE
+yhZ
 daa
 qKU
 qKU
@@ -83311,29 +83382,29 @@ qVP
 qVP
 qVP
 wuy
-qUM
-qwh
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-sCc
-sCc
-sCc
+nBX
+kDP
+swY
+swY
+swY
+swY
+swY
+swY
+gbS
+gbS
+gbS
 dsu
-sCc
-sCc
-sCc
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qwh
-sCc
+gbS
+gbS
+gbS
+swY
+swY
+swY
+swY
+swY
+swY
+kDP
+gbS
 wuy
 qVP
 qVP
@@ -83381,7 +83452,7 @@ qyr
 qyr
 qyr
 bHR
-mWE
+yhZ
 lQE
 bqe
 iee
@@ -83389,7 +83460,7 @@ qam
 wYH
 qyr
 bHR
-mWE
+yhZ
 daa
 jNW
 jNW
@@ -83468,28 +83539,28 @@ qVP
 qVP
 qVP
 wuy
-qUM
-qwh
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qUM
-qUM
-qUM
+nBX
+kDP
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
+nBX
+nBX
 nGf
-qUM
-qUM
-qUM
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qwh
+nBX
+nBX
+nBX
+swY
+swY
+swY
+swY
+swY
+swY
+kDP
 dsu
 wuy
 qVP
@@ -83529,7 +83600,7 @@ rcl
 wUC
 aTw
 crJ
-had
+aoo
 svE
 crJ
 crJ
@@ -83546,7 +83617,7 @@ qyr
 qyr
 qyr
 uck
-pxr
+sSw
 xIM
 pfC
 pXF
@@ -83625,29 +83696,29 @@ qVP
 qVP
 qVP
 wuy
-qUM
-qUM
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qUM
-qUM
-qUM
+nBX
+nBX
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
+nBX
+nBX
 nGf
-qUM
-qUM
-qUM
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qUM
-sCc
+nBX
+nBX
+nBX
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
+gbS
 wuy
 qVP
 qVP
@@ -83690,20 +83761,20 @@ veP
 esC
 tdg
 dAi
-had
+aoo
 gPB
 qbh
 qbh
 bHR
-swY
-gqh
+iwD
+azW
 tWq
-wpg
+qUM
 aTa
 weY
 qyr
 bHR
-mWE
+yhZ
 daa
 qyr
 qyr
@@ -83782,29 +83853,29 @@ qVP
 qVP
 qVP
 wuy
-qUM
-sIn
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-sCc
-sCc
-sCc
+nBX
+njK
+swY
+swY
+swY
+swY
+swY
+swY
+gbS
+gbS
+gbS
 dsu
-sCc
-sCc
-sCc
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-qUM
-sCc
+gbS
+gbS
+gbS
+swY
+swY
+swY
+swY
+swY
+swY
+nBX
+gbS
 wuy
 qVP
 kZJ
@@ -83852,7 +83923,7 @@ vky
 vky
 vky
 vky
-qxn
+uxe
 lQE
 aII
 iee
@@ -83860,7 +83931,7 @@ qam
 hHl
 qyr
 bHR
-mWE
+yhZ
 daa
 qbh
 qbh
@@ -83939,29 +84010,29 @@ qVP
 qVP
 qVP
 wuy
-qUM
-sIn
-iol
+nBX
+njK
 jeU
-dSu
+qMP
+sCc
+qMP
+sCc
 jeU
-dSu
-iol
-qUM
-qUM
-qUM
+nBX
+nBX
+nBX
 nGf
-qUM
-qUM
-qUM
-iol
+nBX
+nBX
+nBX
 jeU
-dSu
+qMP
+sCc
+qMP
+sCc
 jeU
-dSu
-iol
-sCc
-sCc
+gbS
+gbS
 wuy
 qVP
 kZJ
@@ -84009,7 +84080,7 @@ uej
 bNV
 bNV
 bHR
-mWE
+yhZ
 hor
 qyr
 qyr
@@ -84018,11 +84089,11 @@ qyr
 qyr
 uck
 odO
-nBX
-nBX
-nBX
-nBX
-nBX
+mWE
+mWE
+mWE
+mWE
+mWE
 cah
 ioB
 nPD
@@ -84099,10 +84170,10 @@ wuy
 wuy
 qQP
 lhT
-wtM
-wtM
-wtM
-wtM
+dJx
+dJx
+dJx
+dJx
 vTc
 qQP
 qQP
@@ -84112,10 +84183,10 @@ qQP
 qQP
 qQP
 pXJ
-idt
-idt
-idt
-idt
+wqx
+wqx
+wqx
+wqx
 rgW
 qQP
 wuy
@@ -84166,15 +84237,15 @@ qyr
 qyr
 qyr
 bHR
-swY
-gqh
+iwD
+azW
 tWq
-wpg
+qUM
 fwd
 weY
 qyr
 bHR
-mWE
+yhZ
 daa
 qnh
 qyr
@@ -84323,7 +84394,7 @@ vMZ
 gmr
 cPb
 oYf
-mWE
+yhZ
 lQE
 tmp
 iee
@@ -84331,7 +84402,7 @@ qam
 kIo
 qyr
 bHR
-mWE
+yhZ
 daa
 wAU
 sBj
@@ -84430,7 +84501,7 @@ isV
 tXh
 uzD
 bAy
-dAF
+reA
 ogk
 qVP
 qVP
@@ -84480,7 +84551,7 @@ wie
 mny
 qyr
 bHR
-mWE
+yhZ
 ebi
 qyr
 qyr
@@ -84488,7 +84559,7 @@ qyr
 qyr
 qyr
 uck
-mWE
+yhZ
 daa
 mdl
 qyr
@@ -84587,7 +84658,7 @@ nzy
 sjI
 bIh
 lyZ
-trK
+dAF
 rUa
 qVP
 qVP
@@ -84637,7 +84708,7 @@ efK
 bwU
 qyr
 bHR
-mWE
+yhZ
 qbh
 gPB
 qbh
@@ -84645,7 +84716,7 @@ qbh
 qbh
 qbh
 qbh
-mWE
+yhZ
 qbh
 qbh
 kFF
@@ -84795,17 +84866,17 @@ nGw
 qyr
 nDq
 xLA
-nBX
+mWE
 ejX
-kMM
-cPn
-kMM
-kMM
-kMM
-pqx
-kMM
-kMM
 mfG
+cPn
+mfG
+mfG
+mfG
+pqx
+mfG
+mfG
+fGx
 wmg
 ust
 qyr
@@ -84962,7 +85033,7 @@ bNV
 vrG
 bNV
 bNV
-dJx
+tRd
 bNV
 bNV
 qyr
@@ -85057,8 +85128,8 @@ qMD
 gGE
 sVe
 yim
-avn
-sBG
+dSu
+ura
 dOf
 qVP
 qVP
@@ -85433,7 +85504,7 @@ qVP
 qVP
 wCo
 gvH
-ydG
+bul
 olT
 jdO
 wCo
@@ -85590,7 +85661,7 @@ dTg
 dTg
 dTg
 cmX
-bul
+mbQ
 isb
 tsI
 wCo
@@ -85739,7 +85810,7 @@ lJw
 cFv
 syO
 pgS
-xYm
+lrC
 joj
 woI
 eZS
@@ -85896,7 +85967,7 @@ dmE
 cFv
 crs
 fLg
-vIp
+xYm
 dYv
 woI
 qZi
@@ -86170,9 +86241,9 @@ uxc
 wCJ
 vVb
 vVb
-bYx
-bYx
-bYx
+wtM
+wtM
+wtM
 mUn
 mUn
 mUn
@@ -86305,11 +86376,11 @@ xth
 xth
 xth
 xth
-llL
-cfG
-cfG
-btI
+cTT
 eIL
+eIL
+gdZ
+vIb
 xth
 fdA
 uOG
@@ -86330,7 +86401,7 @@ kPt
 oyt
 egd
 kNZ
-brq
+jdI
 mUn
 mUn
 mUn
@@ -86465,7 +86536,7 @@ cNx
 aJZ
 llM
 gMP
-xaW
+bqY
 tEB
 xth
 rRW
@@ -86477,17 +86548,17 @@ xdT
 sun
 ajy
 gWu
-qHk
+dEQ
 ghX
 ojj
 qAi
 vVb
-lld
+pVN
 pWI
-uQN
-uQN
-uQN
-fVH
+bYx
+bYx
+bYx
+aBf
 mUn
 dpz
 mUn
@@ -86622,7 +86693,7 @@ bUh
 oRx
 tYl
 hpF
-cSm
+aCj
 iVk
 xth
 nCJ
@@ -86634,7 +86705,7 @@ lSF
 gOY
 mHD
 nPN
-fJP
+wmL
 icl
 ojj
 tit
@@ -86644,7 +86715,7 @@ iqB
 gvY
 pkg
 cqi
-fVH
+aBf
 jDd
 dxU
 tsG
@@ -86791,7 +86862,7 @@ eQw
 sun
 dJK
 hJJ
-wmL
+pmS
 dCM
 ojj
 aVq
@@ -86801,7 +86872,7 @@ smA
 gvY
 mUn
 mUn
-fVH
+aBf
 lch
 gvY
 gvY
@@ -86948,7 +87019,7 @@ cLU
 cLU
 ojj
 hFY
-qHk
+dEQ
 dJK
 ojj
 gFX
@@ -86957,8 +87028,8 @@ gFX
 gFX
 gFX
 kih
-aBf
-wrl
+lim
+dpc
 fsT
 gvY
 qVP
@@ -87105,7 +87176,7 @@ fpO
 gsG
 tuG
 xbE
-qHk
+dEQ
 eFo
 iNX
 pIx
@@ -87238,23 +87309,23 @@ qVP
 gsG
 kud
 nQh
-kDP
-kDP
-kDP
-kDP
-kDP
-kDP
-kDP
+gwR
+gwR
+gwR
+gwR
+gwR
+gwR
+gwR
+idt
+idt
 eCA
-eCA
-tsL
-eCA
-eCA
+idt
+idt
 pAx
 gbr
-pSi
+psi
 ukz
-mxC
+pSi
 tfP
 hPr
 jgb
@@ -87262,7 +87333,7 @@ fBA
 tfj
 eFj
 mcE
-dEQ
+rQA
 avK
 uiB
 pIx
@@ -87553,7 +87624,7 @@ gsG
 jIe
 kxC
 ccb
-gwR
+rmM
 ccb
 rib
 hmJ
@@ -87576,7 +87647,7 @@ djs
 djs
 ojj
 hFY
-qHk
+dEQ
 dJK
 ojj
 pIx
@@ -87709,9 +87780,9 @@ qVP
 gsG
 gsG
 gsG
-dZb
+ahD
 adK
-diA
+kpP
 gsG
 gsG
 pMH
@@ -87722,18 +87793,18 @@ gsG
 rPz
 oDt
 hqb
-kDP
-kDP
+gwR
+gwR
 nau
 iqf
 sSt
 pmf
 jto
 xtH
-jdI
+upb
 fRQ
 xbE
-wmL
+pmS
 bZM
 ojj
 pIx
@@ -87859,7 +87930,7 @@ rqy
 rqy
 rqy
 rqy
-afp
+uQN
 rqy
 qVP
 qVP
@@ -87887,10 +87958,10 @@ nJs
 jSE
 kPV
 mXQ
-jdI
+upb
 ktu
 xbE
-wmL
+pmS
 nAU
 ojj
 von
@@ -88016,7 +88087,7 @@ qVP
 rqy
 eSR
 rqy
-cGR
+rTk
 jnM
 qVP
 qVP
@@ -88033,10 +88104,10 @@ qey
 qey
 fhe
 gsG
-ahD
-ahD
+kwu
+kwu
 uop
-ahD
+kwu
 gsG
 djs
 nhz
@@ -88172,7 +88243,7 @@ qVP
 rqy
 rqy
 tuc
-yhZ
+xnf
 rqy
 srt
 qVP
@@ -88327,8 +88398,8 @@ rqy
 rqy
 rqy
 rqy
-kDN
-fVi
+ujY
+oFm
 rqy
 wyu
 qVP
@@ -88358,10 +88429,10 @@ huG
 aYV
 mrm
 upl
-jdI
+upb
 mKE
 jqC
-qHk
+dEQ
 jzk
 uiB
 pIx
@@ -88481,9 +88552,9 @@ qVP
 rqy
 rqy
 rqy
-aDj
-vdL
-ldv
+ocO
+tnd
+ibh
 rqy
 rqy
 rqy
@@ -88515,10 +88586,10 @@ rDV
 iAC
 fRC
 bmS
-jdI
+upb
 pIG
 kNf
-mDM
+hXb
 lwr
 hPz
 xwH
@@ -88637,7 +88708,7 @@ rqy
 rqy
 rqy
 rqy
-yhZ
+xnf
 rqy
 qVP
 rqy
@@ -88793,7 +88864,7 @@ rqy
 rqy
 rqy
 rqy
-yhZ
+xnf
 rqy
 qVP
 qVP
@@ -88827,10 +88898,10 @@ cMl
 oaV
 vBz
 pee
-iCe
+wrl
 jgI
 cAY
-qMP
+uGU
 oTl
 sRF
 sRF
@@ -88949,7 +89020,7 @@ qVP
 rqy
 rqy
 tuc
-woD
+tGX
 qVP
 qVP
 qVP
@@ -88983,11 +89054,11 @@ vPr
 ebH
 fjl
 hfM
-hFV
-dIe
+rVu
+vqO
 tKf
 jYX
-pmS
+iCe
 qoR
 sRF
 keh
@@ -89106,7 +89177,7 @@ qVP
 rqy
 rqy
 tuc
-afp
+uQN
 qVP
 qVP
 qVP
@@ -89263,7 +89334,7 @@ qVP
 rqy
 rqy
 tuc
-kDM
+ldv
 qVP
 qVP
 qVP
@@ -89293,7 +89364,7 @@ mpT
 eGf
 gkJ
 jZb
-osK
+nmO
 kEE
 ebH
 kRQ
@@ -89421,7 +89492,7 @@ qVP
 qVP
 rqy
 rqy
-vCr
+cfc
 qVP
 qVP
 qVP
@@ -89450,8 +89521,8 @@ anZ
 eGf
 eAg
 sxb
-iwD
-gbS
+pQx
+gqh
 gkJ
 eAg
 feG
@@ -89578,7 +89649,7 @@ qVP
 qVP
 qVP
 rqy
-cbT
+afp
 rqy
 rqy
 rqy
@@ -89607,7 +89678,7 @@ aRD
 exz
 hFC
 gQv
-ion
+cZH
 tfU
 ohb
 ebH
@@ -89736,7 +89807,7 @@ rqy
 qVP
 qVP
 rqy
-vCr
+cfc
 rqy
 rqy
 rqy
@@ -90212,7 +90283,7 @@ qVP
 qVP
 rqy
 rHU
-afp
+uQN
 rqy
 rqy
 rqy
@@ -90369,7 +90440,7 @@ qVP
 qVP
 qVP
 rHU
-afp
+uQN
 rqy
 rqy
 rqy
@@ -90526,7 +90597,7 @@ qVP
 qVP
 iHy
 ruE
-lml
+eoT
 rqy
 rqy
 rqy
@@ -90681,9 +90752,9 @@ rqy
 rqy
 rqy
 rqy
-afp
+uQN
 rEA
-aht
+eJm
 rEA
 rEA
 sIt
@@ -90712,8 +90783,8 @@ dvF
 hHs
 blf
 dwU
-kpP
-kpP
+uSf
+uSf
 rWy
 woN
 bDj
@@ -90838,9 +90909,9 @@ rqy
 rqy
 rqy
 rqy
-afp
+uQN
 rek
-uGU
+oYE
 jJJ
 wAN
 sIt
@@ -90995,11 +91066,11 @@ qVP
 rqy
 rqy
 rqy
-ocO
+kpk
 rEA
-sEG
+wwV
 jBo
-oYE
+uRz
 quR
 ruE
 ieM
@@ -91152,7 +91223,7 @@ qVP
 rqy
 tuc
 tuc
-afp
+uQN
 rEA
 aQr
 oXp
@@ -111783,7 +111854,7 @@ wuy
 kBk
 dlm
 fLk
-dWn
+eCc
 uFg
 lse
 lse
@@ -112414,7 +112485,7 @@ wuy
 kBk
 avB
 pOx
-upb
+qNi
 dRt
 bUr
 noU
@@ -113221,7 +113292,7 @@ hwG
 goF
 tgq
 fzN
-kpk
+qfF
 pAc
 bOE
 vvm
@@ -113378,7 +113449,7 @@ pyk
 pvH
 pYv
 aLQ
-qfF
+tpb
 pAc
 bOE
 nRK
@@ -113850,7 +113921,7 @@ wuy
 wuy
 jfa
 vVU
-nTb
+ryX
 wuT
 wuT
 mkD
@@ -115420,10 +115491,10 @@ kRE
 bmz
 bmz
 bmz
-jbI
-kTE
-kTE
-kTE
+trK
+qHk
+qHk
+qHk
 ikZ
 fyZ
 rKj
@@ -115583,7 +115654,7 @@ mpQ
 mpQ
 eJO
 mpQ
-lke
+nOZ
 bCA
 qhL
 qhL
@@ -115739,8 +115810,8 @@ pyh
 ctS
 ctS
 pyh
-fqe
-uwH
+iJu
+ciM
 jfa
 czR
 ggl
@@ -115897,7 +115968,7 @@ qGr
 qQy
 pyh
 mpQ
-lke
+nOZ
 mpQ
 mpQ
 mpQ
@@ -116048,16 +116119,16 @@ aDi
 jlE
 pyh
 hyP
-qJS
+sMl
 hch
 hch
 hQX
 pyh
 mpQ
-eYM
+lRm
 xbH
 eWW
-iUB
+ikg
 uUC
 mpQ
 jfa
@@ -116368,7 +116439,7 @@ sxJ
 jXz
 pyh
 mpQ
-qSa
+eYM
 cPJ
 tdy
 hFz
@@ -116528,7 +116599,7 @@ jjd
 xpH
 cPJ
 ncG
-rlH
+kXP
 pzN
 cPJ
 wuy
@@ -116833,12 +116904,12 @@ lxS
 lxS
 bvM
 rJS
-dpc
-dpc
-dpc
-dpc
-dpc
-dpc
+jbI
+jbI
+jbI
+jbI
+jbI
+jbI
 ivq
 cPJ
 evB

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -199,10 +199,6 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/misc/asteroid,
 /area/station/hallway/primary/fore)
-"afd" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "afk" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/greater)
@@ -217,14 +213,6 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"afN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "afX" = (
 /turf/open/floor/deadspace/grille_spare1,
 /area/mine/storage)
@@ -276,9 +264,6 @@
 /area/station/engineering/break_room)
 "ahD" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "ahQ" = (
@@ -806,6 +791,11 @@
 /obj/structure/railing,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"avf" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "avk" = (
 /obj/structure/railing{
 	dir = 4
@@ -867,6 +857,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"awG" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "awR" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -1038,7 +1034,7 @@
 /area/station/hallway/primary/port)
 "aBf" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
@@ -1224,18 +1220,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse/upper)
-"aHr" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "aHO" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
@@ -2240,6 +2224,16 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
+"bhV" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "bid" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/door/airlock/command/glass{
@@ -2524,6 +2518,9 @@
 /area/aegis/mining)
 "bqd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
 "bqe" = (
@@ -2700,7 +2697,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "10"
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -2824,6 +2821,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"bxd" = (
+/obj/structure/cable/multiz,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "bxp" = (
 /obj/machinery/power/floodlight,
 /obj/effect/turf_decal/box,
@@ -2865,12 +2869,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"bxY" = (
-/obj/structure/cable/yellow{
-	icon_state = "132"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "bym" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/grater,
@@ -3211,12 +3209,6 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
-"bGR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/station/commons/lounge)
 "bHy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -3370,6 +3362,12 @@
 /obj/item/bikehorn/rubberducky,
 /turf/open/water,
 /area/station/maintenance/port/lesser)
+"bMB" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "bMD" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "sciencehallwayshutter";
@@ -3777,6 +3775,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
+"bWp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "bWt" = (
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
@@ -3869,7 +3875,7 @@
 "bYx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
@@ -3930,15 +3936,6 @@
 /obj/item/folder/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
-"bZO" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "cac" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/cee{
 	dir = 8
@@ -4431,6 +4428,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
+"cpL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "cqa" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -5733,13 +5734,6 @@
 /obj/item/plate_shard/marker_shard,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
-"cYv" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "cYy" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance,
@@ -5977,14 +5971,22 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
+/turf/open/misc/asteroid,
 /area/aegis/surface)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/fore/lesser)
+"djb" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "djs" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/ce)
@@ -6056,6 +6058,13 @@
 /obj/effect/spawner/random/structure/crate,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"dkE" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "dkR" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/electrical,
@@ -6190,11 +6199,11 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/fore)
 "dpc" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "dpo" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/right{
@@ -6443,12 +6452,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
-"dxJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "dxM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
@@ -6476,20 +6479,6 @@
 /obj/structure/flora/junglebush/c,
 /turf/open/floor/grass,
 /area/station/service/library)
-"dyi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "dyl" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
@@ -6601,11 +6590,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
+	dir = 8
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -6754,7 +6740,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
@@ -6769,12 +6758,6 @@
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
 /area/mine/production)
-"dFO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/brig)
 "dFV" = (
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
@@ -6942,12 +6925,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "dJx" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "8"
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/station/security/warden)
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
@@ -7199,11 +7182,16 @@
 	},
 /area/aegis/mining)
 "dSu" = (
-/obj/structure/cable/yellow{
-	icon_state = "144"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "dSB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -7318,14 +7306,10 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "dUe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron/ported/techfloor,
+/turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "dUl" = (
 /obj/structure/disposalpipe/segment{
@@ -7624,12 +7608,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
-"ecu" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "ecy" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/deadspace/random/slides{
@@ -7646,24 +7624,6 @@
 /obj/structure/closet/lasertag/blue,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"ecM" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "P-Sec Brig";
-	req_access_txt = "63";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig)
 "eda" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/firecloset,
@@ -8868,10 +8828,7 @@
 "eIL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "1"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/monitoring)
@@ -9002,12 +8959,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
-"eNn" = (
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "eNq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -9151,6 +9102,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
+"eQU" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "eRc" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/deadspace/random/slides{
@@ -9333,7 +9290,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "5"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
@@ -10164,13 +10121,6 @@
 	},
 /turf/open/floor/plating,
 /area/misc/testroom)
-"ftX" = (
-/obj/structure/cable/multiz,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "ful" = (
 /obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plating,
@@ -10204,6 +10154,14 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
+"fvm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "fvJ" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/table,
@@ -10340,6 +10298,20 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
+"fAT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "fBk" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning,
 /turf/open/misc/asteroid,
@@ -10408,6 +10380,16 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
+"fDl" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "fDt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -11253,13 +11235,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "gbS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig/upper)
+/area/aegis/surface)
 "gcw" = (
 /obj/machinery/door/airlock/mining{
 	dir = 1;
@@ -11716,11 +11695,14 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "18"
+	icon_state = "12"
 	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -11749,6 +11731,11 @@
 "gqU" = (
 /obj/machinery/atmospherics/pipe/layer_manifold/cyan/visible,
 /turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
+"grs" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "grv" = (
 /obj/machinery/telephone,
@@ -11891,14 +11878,14 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "gxI" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_center,
@@ -13221,15 +13208,6 @@
 "hku" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
-"hkQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "hkR" = (
 /obj/structure/stairs/south,
 /turf/open/floor/iron/dark/side,
@@ -13282,16 +13260,20 @@
 "hnk" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
-"hnl" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "hnF" = (
 /turf/open/water/beach,
 /area/station/hallway/primary/port)
+"hnJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "hoj" = (
 /obj/machinery/light/directional/north,
 /obj/structure/rack,
@@ -13920,12 +13902,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "hDf" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "hDv" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/customs)
@@ -14092,6 +14072,19 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
+"hHk" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "hHl" = (
 /obj/machinery/light/small/directional/south,
 /obj/structure/closet/secure_closet/brig{
@@ -14218,12 +14211,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"hLl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "hLv" = (
 /obj/machinery/button/door/directional/south{
 	id = "window command blast";
@@ -14668,6 +14655,12 @@
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/deadspace/hardwood,
 /area/aegis/telecomms/high)
+"hXr" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "hXv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -14691,13 +14684,6 @@
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
-"hXO" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "hXP" = (
 /mob/living/simple_animal/mouse/gray,
 /turf/open/floor/plating,
@@ -14844,11 +14830,16 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "idy" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor{
@@ -15039,13 +15030,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
-"ihd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "ihh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -15376,17 +15360,16 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "iol" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "3"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "9"
 	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15434,6 +15417,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/primary/central/aft)
+"ipO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/service/janitor)
 "iqf" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -15632,15 +15622,11 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "iwD" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
+/obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/red{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "iwK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -15853,13 +15839,11 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "144"
 	},
-/turf/open/floor/carpet/red,
-/area/station/security/office)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "iCm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate/large/ds/green_horizontal,
@@ -16046,20 +16030,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
-"iGQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "iGV" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/engine_smes)
@@ -16149,6 +16119,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
@@ -16972,6 +16945,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "jbL" = (
@@ -17024,14 +17000,12 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jdI" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "9"
 	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/maintenance/fore/greater)
 "jdK" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -17339,6 +17313,12 @@
 /obj/machinery/telecomms/relay/preset/station,
 /turf/open/floor/deadspace/hardwood,
 /area/aegis/telecomms)
+"jlp" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "jlu" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17831,6 +17811,14 @@
 	},
 /turf/open/floor/engine/air,
 /area/station/engineering/atmos)
+"jvq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "jvw" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -17901,15 +17889,6 @@
 "jxc" = (
 /turf/closed/wall/r_wall,
 /area/station/service/chapel/monastery)
-"jxf" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "jxk" = (
 /obj/machinery/autolathe,
 /turf/open/floor/plating,
@@ -18257,12 +18236,6 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"jIA" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "jIB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -18691,8 +18664,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
+"jUa" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "jUL" = (
 /obj/structure/sign/cec/deck{
 	pixel_y = 34
@@ -18919,6 +18904,12 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"kaK" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "kaO" = (
 /obj/machinery/vending/assist,
 /turf/open/floor/iron/dark,
@@ -18992,10 +18983,15 @@
 /obj/effect/turf_decal/tile/dark/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"kda" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/turf/open/floor/plating,
-/area/station/engineering/main)
+"kcK" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "kdk" = (
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/fax_machine,
@@ -19018,16 +19014,6 @@
 /obj/effect/spawner/random/food_or_drink/snack,
 /turf/open/floor/plating,
 /area/aegis/surface)
-"kdT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/computer)
 "keh" = (
 /obj/machinery/power/smes/engineering{
 	input_level = 60000;
@@ -19485,9 +19471,11 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "kpk" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/service/janitor)
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "kpy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -19500,12 +19488,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
+/area/aegis/surface)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -19561,6 +19549,17 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
+"krx" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "krD" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/starboard/upper)
@@ -19781,18 +19780,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/female)
-"kzw" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "kzI" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -19941,14 +19928,19 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
 "kDP" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/area/station/security/brig)
 "kEv" = (
 /obj/item/megaphone,
 /obj/structure/table/wood,
@@ -20155,17 +20147,6 @@
 /obj/machinery/rnd/production/circuit_imprinter/robotics,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
-"kKm" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "kLe" = (
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
@@ -20244,6 +20225,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
+"kMK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "kMN" = (
 /obj/machinery/computer/secure_data{
 	dir = 4
@@ -20493,7 +20482,6 @@
 	name = "Cabin 7"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/ported/lino,
@@ -20775,15 +20763,6 @@
 	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/medical/morgue)
-"kZE" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "kZJ" = (
 /turf/closed/wall/r_wall,
 /area/station/service/chapel)
@@ -20939,14 +20918,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "ldv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -21362,13 +21338,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"lnN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+"lnX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "10"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "lnY" = (
 /obj/structure/flora/rock/icy,
 /turf/open/misc/ironsand,
@@ -21435,9 +21415,14 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
 "lqF" = (
@@ -21728,10 +21713,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "9"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -22720,6 +22702,11 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
+"mcV" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "mcZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
@@ -22813,11 +22800,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
-"mfY" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "mgj" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -22945,6 +22927,15 @@
 	dir = 9
 	},
 /area/station/hallway/primary/fore)
+"mjn" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "mjp" = (
 /obj/structure/extinguisher_cabinet/directional/east,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
@@ -23217,6 +23208,18 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
+"mri" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "mrm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -23255,19 +23258,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"mrN" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "mrS" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced/spawner/east,
@@ -23311,7 +23301,6 @@
 /area/station/service/hydroponics/upper)
 "msD" = (
 /obj/effect/landmark/start/janitor,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
 "msH" = (
@@ -23798,10 +23787,6 @@
 	dir = 4
 	},
 /area/station/hallway/secondary/exit)
-"mHB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "mHD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24317,6 +24302,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "mXc" = (
@@ -24646,6 +24634,15 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
+"net" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "ney" = (
 /turf/closed/wall/r_wall,
 /area/mine/storage)
@@ -24840,12 +24837,6 @@
 	},
 /turf/open/floor/plating,
 /area/aegis/surface)
-"nkB" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "nkV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -24878,14 +24869,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
-"nmw" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "nmA" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/mono,
@@ -24976,12 +24959,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
-"npw" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "npG" = (
 /obj/structure/rack,
 /obj/item/clothing/under/shorts/red,
@@ -25084,17 +25061,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"nta" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "nth" = (
 /obj/machinery/light,
 /turf/open/misc/asteroid,
@@ -25175,6 +25141,16 @@
 /obj/structure/closet/crate/large/ds/green_horizontal,
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
+"nwG" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "nxn" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -25405,10 +25381,12 @@
 /area/station/engineering/atmos)
 "nBX" = (
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
+	},
+/area/station/security/brig)
 "nCk" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -25490,11 +25468,6 @@
 "nDA" = (
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"nDB" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "nED" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -25609,6 +25582,24 @@
 	},
 /turf/open/floor/plating,
 /area/aegis/surface)
+"nIh" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "nIi" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -25988,10 +25979,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/female)
-"nRT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "nSr" = (
 /obj/machinery/light/small/maintenance/directional/west,
 /obj/structure/table/wood,
@@ -26294,6 +26281,14 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"ocB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "ocF" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -26312,7 +26307,7 @@
 /area/station/command/bridge)
 "ocO" = (
 /obj/structure/cable/yellow{
-	icon_state = "129"
+	icon_state = "40"
 	},
 /turf/open/misc/ironsand,
 /area/aegis/surface)
@@ -26804,6 +26799,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/female)
 "opu" = (
@@ -26859,9 +26857,6 @@
 /area/station/medical/medbay/central)
 "oqy" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2"
 	},
@@ -27054,11 +27049,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
-"own" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
 "owH" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/stripes/line{
@@ -27126,11 +27116,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/toilet/restrooms)
-"oym" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "oys" = (
 /obj/machinery/computer/cargo{
 	dir = 4
@@ -27457,14 +27442,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"oID" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
 "oIM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -27646,6 +27623,12 @@
 /obj/item/cautery,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
+"oNL" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "oOD" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/medical/glass{
@@ -28286,11 +28269,14 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "pfG" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/hallway/primary/central)
 "pfH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -28342,6 +28328,18 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"phf" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "phm" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
@@ -28537,10 +28535,14 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "pmS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "pnj" = (
 /obj/structure/railing{
@@ -28803,6 +28805,15 @@
 	dir = 4
 	},
 /area/station/security/courtroom)
+"puP" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "puQ" = (
 /obj/structure/table/wood,
 /obj/machinery/fax_machine,
@@ -29295,17 +29306,6 @@
 /obj/structure/railing,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
-"pIe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "pIk" = (
 /obj/item/wallframe/apc,
 /turf/open/floor/plating,
@@ -29379,6 +29379,17 @@
 /obj/effect/landmark/navigate_destination/court,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
+"pKl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
+"pKo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "pKp" = (
 /obj/machinery/computer/arcade{
 	dir = 4
@@ -29410,6 +29421,13 @@
 /obj/structure/closet/crate/large,
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
+"pLu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "pLD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -29491,6 +29509,17 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"pMR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "pNe" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint #2";
@@ -29654,16 +29683,6 @@
 "pPU" = (
 /turf/open/floor/deadspace/random/golf_brown,
 /area/misc/testroom)
-"pQg" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
 "pQi" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Control Room"
@@ -29741,6 +29760,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
@@ -30167,7 +30189,7 @@
 "qfF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "5"
 	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
@@ -30195,13 +30217,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
-"qgJ" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "qgK" = (
 /obj/machinery/door/airlock/hatch{
 	dir = 8
@@ -30218,20 +30233,6 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/deadspace/mono,
 /area/station/medical/exam_room)
-"qgR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "qgU" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Departure Lounge - Starboard Aft"
@@ -30367,6 +30368,16 @@
 	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/command/heads_quarters/captain/private)
+"qkK" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/white,
+/area/station/service/kitchen)
 "qkV" = (
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 8
@@ -30606,6 +30617,20 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/aegis/mining)
+"qpR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "qqk" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/water,
@@ -30816,21 +30841,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/ai_monitored/security/armory)
-"quL" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
 "quN" = (
 /obj/machinery/chem_dispenser,
 /turf/open/floor/deadspace/grater,
@@ -30842,7 +30852,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -31199,14 +31209,15 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qHk" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/yellow{
+	icon_state = "2"
 	},
-/area/aegis/surface)
+/turf/open/floor/plating,
+/area/station/security/brig)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -31379,16 +31390,13 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "qMP" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "3"
 	},
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/ce)
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "qMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -31574,6 +31582,13 @@
 	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
+"qSj" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "qSo" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
@@ -31669,14 +31684,15 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "qUM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/hallway/primary/central)
+/obj/structure/cable/red{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "qVj" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
@@ -32335,6 +32351,12 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
+"rnW" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "rop" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock/pile/icy,
@@ -32529,14 +32551,6 @@
 	dir = 8
 	},
 /area/station/security/lockers)
-"rtX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "ruf" = (
 /obj/structure/rack,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -32603,12 +32617,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/hanger)
-"rvF" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "rvT" = (
 /obj/machinery/light/cold/directional/east,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
@@ -32811,21 +32819,15 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
-"rBW" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 4
-	},
-/area/station/security/brig)
 "rCd" = (
 /obj/structure/table,
 /obj/machinery/telephone/service,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
@@ -32837,20 +32839,6 @@
 /obj/machinery/airalarm/directional/south,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
-"rCm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "rCD" = (
 /obj/machinery/light/directional/west,
 /obj/structure/table,
@@ -33345,10 +33333,10 @@
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
 "rQA" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -33565,17 +33553,6 @@
 /obj/machinery/power/floodlight,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
-"rXK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "rYJ" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -33836,6 +33813,13 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
+"shq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "shF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/mob_spawn/corpse/human/charredskeleton,
@@ -33981,18 +33965,6 @@
 /obj/effect/spawner/random/clothing/lizardboots,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"slV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "smg" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -34337,11 +34309,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "swY" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -34511,6 +34486,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
+"sBG" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "sCc" = (
 /obj/structure/lattice,
 /turf/open/misc/asteroid{
@@ -34960,14 +34941,6 @@
 /obj/item/chainsaw/plasma_industrial,
 /turf/open/floor/deadspace/mono,
 /area/station/commons/storage/primary)
-"sPO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "sQr" = (
 /obj/machinery/ntnet_relay,
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -35221,6 +35194,11 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
+"sWp" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "sWE" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/deadspace/heavy,
@@ -35843,14 +35821,13 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "trK" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "trL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -35870,6 +35847,18 @@
 "tsl" = (
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/security/courtroom)
+"tsn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "tsG" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/camera/directional/east{
@@ -36245,13 +36234,6 @@
 	dir = 1
 	},
 /area/aegis/mining)
-"tCo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/maintenance/fore/greater)
 "tCv" = (
 /obj/structure/table,
 /turf/open/floor/deadspace/grater,
@@ -36442,7 +36424,6 @@
 "tKA" = (
 /obj/item/restraints/legcuffs/beartrap,
 /obj/item/restraints/legcuffs/beartrap,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
 "tKI" = (
@@ -36621,7 +36602,10 @@
 "tQQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
@@ -36669,12 +36653,6 @@
 /obj/structure/flora/ausbushes/fullgrass,
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
-"tRt" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "tRy" = (
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -36983,6 +36961,12 @@
 /obj/structure/table,
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/female)
+"uau" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "uaz" = (
 /obj/structure/table/reinforced/rglass,
 /obj/effect/floor_decal/ds/spline/fancy/wood/cee,
@@ -37498,11 +37482,16 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
 "upb" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
+	},
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "1"
 	},
 /turf/open/floor/plating,
-/area/aegis/surface)
+/area/station/command/heads_quarters/ce)
 "upl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -37706,6 +37695,12 @@
 "utU" = (
 /turf/closed/wall/r_wall,
 /area/station/service/bar)
+"uuj" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "uum" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -38144,12 +38139,15 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
 	},
-/area/aegis/surface)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38407,16 +38405,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "6"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -38499,14 +38498,6 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
-"uSz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "uSY" = (
 /obj/structure/table,
 /obj/item/clothing/head/cone{
@@ -39367,6 +39358,13 @@
 "vri" = (
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
+"vrs" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/security/warden)
 "vrv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39707,6 +39705,12 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"vAW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/station/commons/lounge)
 "vBq" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/cee{
 	dir = 4
@@ -39931,6 +39935,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
@@ -40190,6 +40197,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/commons/dorms/barracks/female)
 "vNo" = (
@@ -40697,6 +40707,13 @@
 /obj/effect/spawner/random/trash/mess,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"wcD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "wcH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/pdapainter/engineering,
@@ -41025,6 +41042,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "wnd" = (
@@ -41116,18 +41136,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpg" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "129"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/white,
-/area/station/service/kitchen)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "wpl" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
@@ -41210,16 +41223,11 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "wrl" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
 /turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
+/area/aegis/surface)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41270,6 +41278,10 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
+"wsH" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "wtg" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -41294,15 +41306,11 @@
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "wtM" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
+/obj/structure/cable/yellow{
+	icon_state = "132"
 	},
-/obj/structure/cable/red{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41887,11 +41895,22 @@
 /turf/open/floor/deadspace/mono,
 /area/mine/hydroponics)
 "wJx" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/station/service/janitor)
+"wJG" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "wKa" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
@@ -43005,6 +43024,9 @@
 /area/station/medical/medbay/central)
 "xqt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "xqH" = (
@@ -43172,12 +43194,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/landmark/navigate_destination{
 	location = "Custodial Closet"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "xtQ" = (
@@ -43869,6 +43893,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"xPh" = (
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "xPq" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/techstorage/command_all,
@@ -43880,16 +43910,6 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
-"xPI" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "xPJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
@@ -43931,6 +43951,9 @@
 "xRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "xRl" = (
@@ -44401,11 +44424,12 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
-/area/aegis/surface)
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
@@ -44533,13 +44557,15 @@
 "yll" = (
 /turf/open/floor/catwalk_floor,
 /area/station/command/bridge)
-"ylx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+"ylm" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
 	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "ylW" = (
 /obj/structure/table/wood/poker,
 /obj/item/storage/bag/money,
@@ -80941,8 +80967,8 @@ tyr
 dmW
 hEO
 mui
-wpg
 vHE
+qkK
 eEt
 qYZ
 fXZ
@@ -81237,7 +81263,7 @@ gho
 lfY
 tQS
 xqt
-kpk
+hnk
 czr
 npi
 fki
@@ -81393,7 +81419,7 @@ fnR
 sMY
 tQS
 hnk
-bqd
+ipO
 msD
 ayh
 npi
@@ -81404,7 +81430,7 @@ kBk
 ruP
 bwu
 jaQ
-uSz
+ocB
 nAc
 wVk
 ijf
@@ -81979,11 +82005,11 @@ qVP
 qVP
 wuy
 wuy
-diA
-diA
-diA
-diA
-diA
+gbS
+gbS
+gbS
+gbS
+gbS
 wuy
 wuy
 wuy
@@ -82055,7 +82081,7 @@ reE
 khL
 qbh
 qbh
-mWE
+dSu
 akB
 qyr
 qVP
@@ -82135,24 +82161,24 @@ wuy
 wuy
 wuy
 wuy
-diA
-diA
-diA
-diA
-diA
-diA
-diA
-diA
-diA
-diA
-diA
-diA
-diA
-diA
-diA
-diA
-diA
-diA
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
 wuy
 wuy
 vRZ
@@ -82195,7 +82221,7 @@ mwp
 yfI
 cZh
 uEm
-iCe
+xRk
 xfD
 vky
 dAe
@@ -82207,7 +82233,7 @@ vky
 vky
 vky
 vky
-pIe
+iol
 vky
 tCw
 aQM
@@ -82288,29 +82314,29 @@ qVP
 qVP
 qVP
 wuy
-diA
-diA
-uGU
-uGU
-uGU
-uGU
-uGU
-uGU
-diA
-diA
-diA
-diA
-diA
-diA
-diA
+gbS
+gbS
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
 qnp
-uGU
-uGU
-uGU
-uGU
-uGU
-diA
-diA
+kpP
+kpP
+kpP
+kpP
+kpP
+gbS
+gbS
 wuy
 vRZ
 bzI
@@ -82351,14 +82377,14 @@ elo
 mwp
 tTg
 blQ
-xRk
-xRk
+hDf
+hDf
 mwp
 uej
 bNV
 bNV
 bNV
-mWE
+dSu
 bNV
 bNV
 bNV
@@ -82366,7 +82392,7 @@ bNV
 bNV
 bNV
 bNV
-mWE
+dSu
 bNV
 bNV
 bNV
@@ -82445,29 +82471,29 @@ qVP
 qVP
 qVP
 wuy
-diA
-uGU
+gbS
+kpP
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-diA
-diA
-diA
+gbS
+gbS
+gbS
 dsu
-diA
-diA
-diA
+gbS
+gbS
+gbS
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-uGU
-diA
+kpP
+gbS
 wuy
 vRZ
 uho
@@ -82515,7 +82541,7 @@ vHk
 mct
 vmQ
 bHR
-mWE
+dSu
 qWQ
 qyr
 qyr
@@ -82523,7 +82549,7 @@ qyr
 qyr
 qyr
 uck
-mWE
+dSu
 daa
 qyr
 qyr
@@ -82602,29 +82628,29 @@ qVP
 qVP
 qVP
 wuy
-diA
-uGU
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-diA
-diA
-diA
+gbS
+kpP
+swY
+swY
+swY
+swY
+swY
+swY
+gbS
+gbS
+gbS
 nGf
-diA
-diA
-diA
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-uGU
-diA
+gbS
+gbS
+gbS
+swY
+swY
+swY
+swY
+swY
+swY
+kpP
+gbS
 wuy
 vRZ
 ham
@@ -82672,15 +82698,15 @@ qyr
 qyr
 qyr
 bHR
-dyi
-rBW
+qpR
+nBX
 tWq
-dFO
+hXr
 cVO
 weY
 qyr
 bHR
-mWE
+dSu
 daa
 qSo
 qSo
@@ -82759,14 +82785,14 @@ qVP
 qVP
 qVP
 wuy
-diA
-uGU
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
+gbS
+kpP
+swY
+swY
+swY
+swY
+swY
+swY
 sCc
 sCc
 sCc
@@ -82774,14 +82800,14 @@ dsu
 sCc
 sCc
 sCc
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-uGU
-diA
+swY
+swY
+swY
+swY
+swY
+swY
+kpP
+gbS
 wuy
 vRZ
 vRZ
@@ -82829,7 +82855,7 @@ kGp
 dSB
 aSO
 bHR
-mWE
+dSu
 qpF
 trI
 iee
@@ -82837,7 +82863,7 @@ qam
 fGV
 qyr
 bHR
-mWE
+dSu
 daa
 qKU
 qKU
@@ -82916,29 +82942,29 @@ qVP
 qVP
 qVP
 wuy
-diA
-diA
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-diA
-diA
-diA
+gbS
+gbS
+swY
+swY
+swY
+swY
+swY
+swY
+gbS
+gbS
+gbS
 nGf
-diA
-diA
-diA
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-diA
-diA
+gbS
+gbS
+gbS
+swY
+swY
+swY
+swY
+swY
+swY
+gbS
+gbS
 wuy
 qVP
 qVP
@@ -82981,12 +83007,12 @@ bJz
 wqD
 bJz
 bJz
-qgJ
 oqy
-oqy
-xPI
+qHk
+qHk
+fDl
 bHR
-mWE
+dSu
 jYt
 qyr
 qyr
@@ -82994,7 +83020,7 @@ qyr
 qyr
 qyr
 tfu
-iGQ
+kDP
 igw
 fpu
 fpu
@@ -83073,29 +83099,29 @@ qVP
 qVP
 qVP
 wuy
-diA
-uGU
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-diA
-diA
-diA
+gbS
+kpP
+swY
+swY
+swY
+swY
+swY
+swY
+gbS
+gbS
+gbS
 nGf
-diA
-diA
-diA
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-uGU
-diA
+gbS
+gbS
+gbS
+swY
+swY
+swY
+swY
+swY
+swY
+kpP
+gbS
 wuy
 qVP
 qVP
@@ -83131,27 +83157,27 @@ ohU
 wEZ
 wEZ
 lWL
-qUM
-qUM
+pfG
+pfG
 xPJ
-qUM
-qUM
-qUM
-qUM
-ecM
+pfG
+pfG
+pfG
+pfG
+nIh
 uSt
 kVO
 kVf
 sXZ
 bHX
-rBW
+nBX
 tWq
-dFO
+hXr
 dHZ
 weY
 qyr
 bHR
-mWE
+dSu
 daa
 qKU
 qKU
@@ -83230,14 +83256,14 @@ qVP
 qVP
 qVP
 wuy
-diA
-uGU
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
+gbS
+kpP
+swY
+swY
+swY
+swY
+swY
+swY
 sCc
 sCc
 sCc
@@ -83245,13 +83271,13 @@ dsu
 sCc
 sCc
 sCc
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-uGU
+swY
+swY
+swY
+swY
+swY
+swY
+kpP
 sCc
 wuy
 qVP
@@ -83300,7 +83326,7 @@ qyr
 qyr
 qyr
 bHR
-mWE
+dSu
 lQE
 bqe
 iee
@@ -83308,7 +83334,7 @@ qam
 wYH
 qyr
 bHR
-mWE
+dSu
 daa
 jNW
 jNW
@@ -83387,28 +83413,28 @@ qVP
 qVP
 qVP
 wuy
-diA
-uGU
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-diA
-diA
-diA
+gbS
+kpP
+swY
+swY
+swY
+swY
+swY
+swY
+gbS
+gbS
+gbS
 nGf
-diA
-diA
-diA
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-uGU
+gbS
+gbS
+gbS
+swY
+swY
+swY
+swY
+swY
+swY
+kpP
 dsu
 wuy
 qVP
@@ -83465,7 +83491,7 @@ qyr
 qyr
 qyr
 uck
-kKm
+krx
 xIM
 pfC
 pXF
@@ -83544,28 +83570,28 @@ qVP
 qVP
 qVP
 wuy
-diA
-diA
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-diA
-diA
-diA
+gbS
+gbS
+swY
+swY
+swY
+swY
+swY
+swY
+gbS
+gbS
+gbS
 nGf
-diA
-diA
-diA
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-diA
+gbS
+gbS
+gbS
+swY
+swY
+swY
+swY
+swY
+swY
+gbS
 sCc
 wuy
 qVP
@@ -83614,15 +83640,15 @@ gPB
 qbh
 qbh
 bHR
-iGQ
-rBW
+kDP
+nBX
 tWq
-dFO
+hXr
 aTa
 weY
 qyr
 bHR
-mWE
+dSu
 daa
 qyr
 qyr
@@ -83701,14 +83727,14 @@ qVP
 qVP
 qVP
 wuy
-diA
-yhZ
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
+gbS
+bMB
+swY
+swY
+swY
+swY
+swY
+swY
 sCc
 sCc
 sCc
@@ -83716,13 +83742,13 @@ dsu
 sCc
 sCc
 sCc
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-diA
+swY
+swY
+swY
+swY
+swY
+swY
+gbS
 sCc
 wuy
 qVP
@@ -83771,7 +83797,7 @@ vky
 vky
 vky
 vky
-qgR
+mWE
 lQE
 aII
 iee
@@ -83779,7 +83805,7 @@ qam
 hHl
 qyr
 bHR
-mWE
+dSu
 daa
 qbh
 qbh
@@ -83858,27 +83884,27 @@ qVP
 qVP
 qVP
 wuy
-diA
-yhZ
-qHk
+gbS
+bMB
+ylm
 jeU
-trK
+rQA
 jeU
-trK
-qHk
-diA
-diA
-diA
+rQA
+ylm
+gbS
+gbS
+gbS
 nGf
-diA
-diA
-diA
-qHk
+gbS
+gbS
+gbS
+ylm
 jeU
-trK
+rQA
 jeU
-trK
-qHk
+rQA
+ylm
 sCc
 sCc
 wuy
@@ -83923,12 +83949,12 @@ psI
 pnG
 bpE
 faw
-dJx
+vrs
 uej
 bNV
 bNV
 bHR
-mWE
+dSu
 hor
 qyr
 qyr
@@ -83937,11 +83963,11 @@ qyr
 qyr
 uck
 odO
-uQN
-uQN
-uQN
-uQN
-uQN
+pMR
+pMR
+pMR
+pMR
+pMR
 cah
 ioB
 nPD
@@ -84018,10 +84044,10 @@ wuy
 wuy
 qQP
 lhT
-iwD
-iwD
-iwD
-iwD
+bhV
+bhV
+bhV
+bhV
 vTc
 qQP
 qQP
@@ -84031,10 +84057,10 @@ qQP
 qQP
 qQP
 pXJ
-wtM
-wtM
-wtM
-wtM
+qUM
+qUM
+qUM
+qUM
 rgW
 qQP
 wuy
@@ -84085,15 +84111,15 @@ qyr
 qyr
 qyr
 bHR
-iGQ
-rBW
+kDP
+nBX
 tWq
-dFO
+hXr
 fwd
 weY
 qyr
 bHR
-mWE
+dSu
 daa
 qnh
 qyr
@@ -84242,7 +84268,7 @@ vMZ
 gmr
 cPb
 oYf
-mWE
+dSu
 lQE
 tmp
 iee
@@ -84250,7 +84276,7 @@ qam
 kIo
 qyr
 bHR
-mWE
+dSu
 daa
 wAU
 sBj
@@ -84349,7 +84375,7 @@ isV
 tXh
 uzD
 bAy
-dUe
+pmS
 ogk
 qVP
 qVP
@@ -84399,7 +84425,7 @@ wie
 mny
 qyr
 bHR
-mWE
+dSu
 ebi
 qyr
 qyr
@@ -84407,7 +84433,7 @@ qyr
 qyr
 qyr
 uck
-mWE
+dSu
 daa
 mdl
 qyr
@@ -84506,7 +84532,7 @@ nzy
 sjI
 bIh
 lyZ
-gwR
+dAF
 rUa
 qVP
 qVP
@@ -84556,7 +84582,7 @@ efK
 bwU
 qyr
 bHR
-mWE
+dSu
 qbh
 gPB
 qbh
@@ -84564,7 +84590,7 @@ qbh
 qbh
 qbh
 qbh
-mWE
+dSu
 qbh
 qbh
 kFF
@@ -84664,7 +84690,7 @@ eIK
 kit
 edO
 hCO
-pmS
+dUe
 qVP
 qVP
 qVP
@@ -84714,7 +84740,7 @@ nGw
 qyr
 nDq
 xLA
-uQN
+pMR
 ejX
 mfG
 cPn
@@ -84724,7 +84750,7 @@ mfG
 pqx
 mfG
 mfG
-hkQ
+net
 wmg
 ust
 qyr
@@ -84821,7 +84847,7 @@ jiK
 iMZ
 blO
 cTo
-pmS
+dUe
 qVP
 qVP
 qVP
@@ -84881,7 +84907,7 @@ bNV
 vrG
 bNV
 bNV
-sPO
+bWp
 bNV
 bNV
 qyr
@@ -84976,8 +85002,8 @@ qMD
 gGE
 sVe
 yim
-ldv
-dAF
+jUa
+tsn
 dOf
 qVP
 qVP
@@ -85352,7 +85378,7 @@ qVP
 qVP
 wCo
 gvH
-bul
+nwG
 olT
 jdO
 wCo
@@ -85509,7 +85535,7 @@ dTg
 dTg
 dTg
 cmX
-pQg
+bul
 isb
 tsI
 wCo
@@ -85658,7 +85684,7 @@ lJw
 cFv
 syO
 pgS
-swY
+uau
 joj
 woI
 eZS
@@ -86089,9 +86115,9 @@ uxc
 wCJ
 vVb
 vVb
-bYx
-bYx
-bYx
+yhZ
+yhZ
+yhZ
 mUn
 mUn
 mUn
@@ -86224,11 +86250,11 @@ xth
 xth
 xth
 xth
-hXO
+qSj
+uGU
+uGU
+hHk
 eIL
-eIL
-mrN
-cYv
 xth
 fdA
 uOG
@@ -86244,12 +86270,12 @@ aNP
 aAq
 aGd
 aGd
-kdT
+tQQ
 kPt
 oyt
 egd
 kNZ
-eNn
+uuj
 mUn
 mUn
 mUn
@@ -86384,7 +86410,7 @@ cNx
 aJZ
 llM
 gMP
-jxf
+kcK
 tEB
 xth
 rRW
@@ -86396,17 +86422,17 @@ xdT
 sun
 ajy
 gWu
-dEQ
+jvq
 ghX
 ojj
 qAi
 vVb
-tQQ
+pLu
 pWI
-hDf
-hDf
-hDf
-aBf
+bYx
+bYx
+bYx
+eQU
 mUn
 dpz
 mUn
@@ -86541,7 +86567,7 @@ bUh
 oRx
 tYl
 hpF
-kzw
+phf
 iVk
 xth
 nCJ
@@ -86553,7 +86579,7 @@ lSF
 gOY
 mHD
 nPN
-aHr
+wmL
 icl
 ojj
 tit
@@ -86563,7 +86589,7 @@ iqB
 gvY
 pkg
 cqi
-aBf
+eQU
 jDd
 dxU
 tsG
@@ -86710,7 +86736,7 @@ eQw
 sun
 dJK
 hJJ
-wmL
+gqh
 dCM
 ojj
 aVq
@@ -86720,7 +86746,7 @@ smA
 gvY
 mUn
 mUn
-aBf
+eQU
 lch
 gvY
 gvY
@@ -86867,7 +86893,7 @@ cLU
 cLU
 ojj
 hFY
-dEQ
+jvq
 dJK
 ojj
 gFX
@@ -86876,8 +86902,8 @@ gFX
 gFX
 gFX
 kih
-ecu
-rvF
+ldv
+aBf
 fsT
 gvY
 qVP
@@ -87024,7 +87050,7 @@ fpO
 gsG
 tuG
 xbE
-dEQ
+jvq
 eFo
 iNX
 pIx
@@ -87157,23 +87183,23 @@ qVP
 gsG
 kud
 nQh
-kDP
-kDP
-kDP
-kDP
-kDP
-kDP
-kDP
+gwR
+gwR
+gwR
+gwR
+gwR
+gwR
+gwR
 eCA
 eCA
-slV
+mri
 eCA
 eCA
 pAx
 gbr
-pSi
+wJG
 ukz
-quL
+pSi
 tfP
 hPr
 jgb
@@ -87181,7 +87207,7 @@ fBA
 tfj
 eFj
 mcE
-nta
+dEQ
 avK
 uiB
 pIx
@@ -87464,7 +87490,7 @@ tuc
 eSR
 rqy
 eSR
-upb
+wrl
 eSR
 qVP
 qVP
@@ -87472,7 +87498,7 @@ gsG
 jIe
 kxC
 ccb
-afN
+trK
 ccb
 rib
 hmJ
@@ -87495,7 +87521,7 @@ djs
 djs
 ojj
 hFY
-dEQ
+jvq
 dJK
 ojj
 pIx
@@ -87621,16 +87647,16 @@ tuc
 rqy
 tuc
 rqy
-upb
+wrl
 rqy
 qVP
 qVP
 gsG
 gsG
 gsG
-hnl
+dkE
 adK
-ahD
+djb
 gsG
 gsG
 pMH
@@ -87641,18 +87667,18 @@ gsG
 rPz
 oDt
 hqb
-kDP
-kDP
+gwR
+gwR
 nau
 iqf
 sSt
 pmf
 jto
 xtH
-qMP
+upb
 fRQ
 xbE
-wmL
+gqh
 bZM
 ojj
 pIx
@@ -87778,7 +87804,7 @@ rqy
 rqy
 rqy
 rqy
-dpc
+diA
 rqy
 qVP
 qVP
@@ -87806,10 +87832,10 @@ nJs
 jSE
 kPV
 mXQ
-qMP
+upb
 ktu
 xbE
-wmL
+gqh
 nAU
 ojj
 von
@@ -87952,10 +87978,10 @@ qey
 qey
 fhe
 gsG
-kda
-kda
+ahD
+ahD
 uop
-kda
+ahD
 gsG
 djs
 nhz
@@ -88091,7 +88117,7 @@ qVP
 rqy
 rqy
 tuc
-dSu
+iCe
 rqy
 srt
 qVP
@@ -88246,8 +88272,8 @@ rqy
 rqy
 rqy
 rqy
-jIA
-ocO
+oNL
+kpk
 rqy
 wyu
 qVP
@@ -88277,10 +88303,10 @@ huG
 aYV
 mrm
 upl
-qMP
+upb
 mKE
 jqC
-dEQ
+jvq
 jzk
 uiB
 pIx
@@ -88400,9 +88426,9 @@ qVP
 rqy
 rqy
 rqy
-gqh
-idt
-nkB
+kaK
+iwD
+wpg
 rqy
 rqy
 rqy
@@ -88434,10 +88460,10 @@ rDV
 iAC
 fRC
 bmS
-qMP
+upb
 pIG
 kNf
-nBX
+jlp
 lwr
 hPz
 xwH
@@ -88556,7 +88582,7 @@ rqy
 rqy
 rqy
 rqy
-dSu
+iCe
 rqy
 qVP
 rqy
@@ -88712,7 +88738,7 @@ rqy
 rqy
 rqy
 rqy
-dSu
+iCe
 rqy
 qVP
 qVP
@@ -88746,10 +88772,10 @@ cMl
 oaV
 vBz
 pee
-afd
+wsH
 jgI
 cAY
-mHB
+cpL
 oTl
 sRF
 sRF
@@ -88868,7 +88894,7 @@ qVP
 rqy
 rqy
 tuc
-bxY
+wtM
 qVP
 qVP
 qVP
@@ -88902,11 +88928,11 @@ vPr
 ebH
 fjl
 hfM
-ihd
-own
+dJx
+sWp
 tKf
 jYX
-nRT
+pKl
 qoR
 sRF
 keh
@@ -89025,7 +89051,7 @@ qVP
 rqy
 rqy
 tuc
-dpc
+diA
 qVP
 qVP
 qVP
@@ -89182,7 +89208,7 @@ qVP
 rqy
 rqy
 tuc
-tRt
+ocO
 qVP
 qVP
 qVP
@@ -89212,7 +89238,7 @@ mpT
 eGf
 gkJ
 jZb
-ylx
+wcD
 kEE
 ebH
 kRQ
@@ -89369,8 +89395,8 @@ anZ
 eGf
 eAg
 sxb
-nDB
-mfY
+mcV
+grs
 gkJ
 eAg
 feG
@@ -89497,7 +89523,7 @@ qVP
 qVP
 qVP
 rqy
-dxJ
+xPh
 rqy
 rqy
 rqy
@@ -89526,7 +89552,7 @@ aRD
 exz
 hFC
 gQv
-hLl
+sBG
 tfU
 ohb
 ebH
@@ -90131,7 +90157,7 @@ qVP
 qVP
 rqy
 rHU
-dpc
+diA
 rqy
 rqy
 rqy
@@ -90288,7 +90314,7 @@ qVP
 qVP
 qVP
 rHU
-dpc
+diA
 rqy
 rqy
 rqy
@@ -90445,7 +90471,7 @@ qVP
 qVP
 iHy
 ruE
-kZE
+puP
 rqy
 rqy
 rqy
@@ -90600,9 +90626,9 @@ rqy
 rqy
 rqy
 rqy
-dpc
+diA
 rEA
-wrl
+quR
 rEA
 rEA
 sIt
@@ -90629,7 +90655,7 @@ naE
 mCH
 dvF
 hHs
-lnN
+shq
 dwU
 blf
 blf
@@ -90757,9 +90783,9 @@ rqy
 rqy
 rqy
 rqy
-dpc
+diA
 rek
-npw
+rnW
 jJJ
 wAN
 sIt
@@ -90914,12 +90940,12 @@ qVP
 rqy
 rqy
 rqy
-pfG
+awG
 rEA
-bZO
+mjn
 jBo
 oYE
-quR
+idt
 ruE
 ieM
 rqy
@@ -91071,7 +91097,7 @@ qVP
 rqy
 tuc
 tuc
-dpc
+diA
 rEA
 aQr
 oXp
@@ -111702,7 +111728,7 @@ wuy
 kBk
 dlm
 fLk
-bGR
+vAW
 uFg
 lse
 lse
@@ -112333,7 +112359,7 @@ wuy
 kBk
 avB
 pOx
-oym
+avf
 dRt
 bUr
 noU
@@ -113140,7 +113166,7 @@ hwG
 goF
 tgq
 fzN
-kpP
+qfF
 pAc
 bOE
 vvm
@@ -113297,7 +113323,7 @@ pyk
 pvH
 pYv
 aLQ
-qfF
+pKo
 pAc
 bOE
 nRK
@@ -113769,7 +113795,7 @@ wuy
 wuy
 jfa
 vVU
-gbS
+kMK
 wuT
 wuT
 mkD
@@ -115339,10 +115365,10 @@ kRE
 bmz
 bmz
 bmz
-iol
-jdI
-jdI
-jdI
+uQN
+jbI
+jbI
+jbI
 ikZ
 fyZ
 rKj
@@ -115658,8 +115684,8 @@ pyh
 ctS
 ctS
 pyh
-ftX
-rCm
+bxd
+fAT
 jfa
 czR
 ggl
@@ -115810,7 +115836,7 @@ prI
 pVm
 pyh
 oer
-lAk
+hnJ
 uuA
 qGr
 qQy
@@ -115967,16 +115993,16 @@ aDi
 jlE
 pyh
 hyP
-oID
+lAk
 hch
 hch
 hQX
 pyh
 mpQ
-rXK
+lnX
 xbH
+qMP
 eWW
-rtX
 uUC
 mpQ
 jfa
@@ -116287,7 +116313,7 @@ sxJ
 jXz
 pyh
 mpQ
-nmw
+fvm
 cPJ
 tdy
 hFz
@@ -116604,7 +116630,7 @@ mpQ
 xpH
 cPJ
 vsE
-tCo
+jdI
 bmZ
 cPJ
 wuy
@@ -116752,12 +116778,12 @@ lxS
 lxS
 bvM
 rJS
-jbI
-jbI
-jbI
-jbI
-jbI
-jbI
+dpc
+dpc
+dpc
+dpc
+dpc
+dpc
 ivq
 cPJ
 evB

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -1446,6 +1446,7 @@
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
 /obj/effect/spawner/random/entertainment/lighter,
+/obj/item/storage/briefcase/crimekit,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "aLW" = (
@@ -7305,11 +7306,11 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
 "dIM" = (
-/obj/item/camera_film,
-/obj/item/camera_film,
-/obj/item/camera_film,
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/paper_bin,
+/obj/item/folder/red,
+/obj/item/stamp/law,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
@@ -10928,10 +10929,11 @@
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/port)
 "fzN" = (
-/obj/item/paper_bin,
 /obj/structure/table/wood,
-/obj/item/stamp/law,
-/obj/item/folder/red,
+/obj/machinery/computer/security/wooden_tv{
+	pixel_x = 3;
+	pixel_y = 2
+	},
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
@@ -11712,7 +11714,6 @@
 	},
 /area/station/hallway/primary/fore)
 "fWv" = (
-/obj/machinery/computer/piratepad_control/civilian,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "fXn" = (
@@ -12338,7 +12339,7 @@
 "goF" = (
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/effect/turf_decal/box,
-/obj/structure/closet/secure_closet/ds/detective,
+/obj/machinery/microscope,
 /obj/structure/cable/yellow{
 	icon_state = "2"
 	},
@@ -18778,6 +18779,9 @@
 /obj/item/hand_labeler,
 /obj/item/camera/detective,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/item/camera_film,
+/obj/item/camera_film,
+/obj/item/camera_film,
 /obj/structure/cable/yellow{
 	icon_state = "5"
 	},
@@ -24714,7 +24718,8 @@
 /area/station/service/janitor)
 "msH" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/wiki/detective,
+/obj/item/storage/box/fingerprints,
+/obj/item/storage/evidence,
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
 "msK" = (
@@ -24818,6 +24823,7 @@
 /area/station/hallway/primary/port)
 "mvL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/closet/secure_closet/ds/detective,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
@@ -25614,8 +25620,6 @@
 	},
 /area/mine/production)
 "mRr" = (
-/obj/structure/table,
-/obj/item/detective_scanner,
 /turf/open/floor/deadspace/bathroom,
 /area/station/medical/morgue)
 "mRL" = (
@@ -26244,6 +26248,7 @@
 "nhO" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/gloves,
+/obj/item/book/manual/wiki/detective,
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
 "nhU" = (
@@ -30593,11 +30598,7 @@
 	id = "forensic_shutters";
 	name = "Privacy Shutters"
 	},
-/obj/structure/table/wood,
-/obj/machinery/computer/security/wooden_tv{
-	pixel_x = 3;
-	pixel_y = 2
-	},
+/obj/machinery/dna_analyzer,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "pvL" = (
@@ -38994,8 +38995,8 @@
 /area/station/cargo)
 "tUg" = (
 /obj/item/storage/box/evidence,
-/obj/item/storage/box/evidence,
 /obj/structure/table/wood,
+/obj/item/storage/box/swabs,
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
 "tUq" = (
@@ -40457,7 +40458,6 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "uGc" = (
-/obj/structure/table/reinforced,
 /obj/structure/table/wood,
 /obj/machinery/power/data_terminal,
 /obj/item/restraints/handcuffs,
@@ -59531,7 +59531,7 @@ qWI
 dIS
 pwR
 pwR
-mRr
+qOa
 qWI
 qVP
 qVP
@@ -96084,7 +96084,7 @@ uMl
 oyI
 hZj
 ayy
-fWv
+emH
 emH
 qDb
 iae

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -26,19 +26,25 @@
 	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
+"aaw" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse/upper)
 "aaE" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "abd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
+/area/aegis/surface)
 "abi" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment{
@@ -189,12 +195,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "aeI" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -217,6 +225,12 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"afD" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "afX" = (
 /turf/open/floor/deadspace/grille_spare1,
 /area/mine/storage)
@@ -329,6 +343,13 @@
 	dir = 5
 	},
 /area/station/hallway/primary/central)
+"ako" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "akr" = (
 /obj/machinery/shower,
 /obj/effect/spawner/random/trash/soap,
@@ -459,23 +480,6 @@
 	},
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/commons/dorms/barracks/male)
-"amf" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Mining Privacy";
-	name = "Mining Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/qm)
 "ami" = (
 /obj/machinery/light/directional/west,
 /turf/open/misc/beach/sand/coastline_t,
@@ -703,6 +707,10 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
+"arS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "asa" = (
 /obj/machinery/door/window/left/directional/west{
 	name = "P-Sec Infirmary Station"
@@ -897,10 +905,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"awP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo/warehouse)
 "awR" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
@@ -1006,16 +1010,6 @@
 /obj/structure/holohoop,
 /turf/open/floor/deadspace/hardwood,
 /area/station/maintenance/port/lesser)
-"azf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
 "azp" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_center,
@@ -1031,13 +1025,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "azW" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms/cryo)
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "aAj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -1088,7 +1084,7 @@
 /area/station/hallway/primary/port)
 "aBf" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
@@ -1200,7 +1196,9 @@
 "aEb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/primary/central/aft)
 "aEu" = (
@@ -1221,13 +1219,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
-"aEF" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "aEG" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Atmospherics Monitoring";
@@ -1254,7 +1245,9 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/starboard/upper)
 "aGd" = (
@@ -1365,26 +1358,13 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
 "aJv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
-"aJA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms/cryo)
 "aJH" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -1449,6 +1429,19 @@
 /obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
+"aLT" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/white,
+/area/station/service/kitchen)
 "aLW" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark/side,
@@ -1462,12 +1455,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
-"aMR" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "aMT" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/deadspace/random/maint_left{
@@ -1574,9 +1561,6 @@
 "aPX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "aQd" = (
@@ -1632,7 +1616,9 @@
 "aRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
 "aRn" = (
@@ -1692,6 +1678,12 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
+"aSt" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "aSD" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 4
@@ -1782,12 +1774,14 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "aTj" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -1930,7 +1924,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
@@ -1985,14 +1979,6 @@
 	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
-"aYP" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
 "aYU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -2071,7 +2057,9 @@
 /area/station/security/brig)
 "bbp" = (
 /obj/machinery/light/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "bbq" = (
@@ -2093,6 +2081,9 @@
 	},
 /area/station/hallway/primary/fore)
 "bbC" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "bbF" = (
@@ -2135,7 +2126,7 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "3"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
@@ -2158,16 +2149,6 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"bcN" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock/cafeteria)
 "bcW" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock/pile,
@@ -2246,13 +2227,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/fore)
-"bfq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/service/janitor)
 "bfv" = (
 /obj/structure/railing{
 	dir = 1
@@ -2298,6 +2272,14 @@
 	dir = 4
 	},
 /area/station/hallway/primary/starboard)
+"bge" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "bgg" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Engineering";
@@ -2324,17 +2306,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
-"bgl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "bgx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -2386,10 +2357,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
-"bhY" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "bid" = (
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/machinery/door/airlock/command/glass{
@@ -2482,6 +2449,18 @@
 /obj/structure/water_source/puddle,
 /turf/open/floor/grass,
 /area/station/service/library)
+"bkE" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "bkR" = (
 /obj/structure/table,
 /obj/effect/spawner/random/deadspace/ammo,
@@ -2607,6 +2586,13 @@
 /obj/effect/mob_spawn/corpse/human/miner,
 /turf/open/floor/wood,
 /area/aegis/mining)
+"bnC" = (
+/obj/machinery/light/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "bnO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -2878,12 +2864,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"but" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "buu" = (
 /obj/structure/chair/stool/bar/directional/west,
 /obj/effect/turf_decal/tile/bar{
@@ -3089,7 +3069,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /obj/item/bikehorn/airhorn,
 /obj/structure/closet/secure_closet/personal,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/wood,
 /area/aegis/mining)
 "bzE" = (
@@ -3122,6 +3101,10 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"bAk" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "bAs" = (
 /obj/structure/cable/yellow{
 	icon_state = "12"
@@ -3333,17 +3316,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"bFI" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse/upper)
 "bFP" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 1
@@ -3411,9 +3383,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bHF" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "bHR" = (
@@ -3583,6 +3560,15 @@
 	dir = 8
 	},
 /area/aegis/hanger)
+"bNj" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/hallway/secondary/exit/departure_lounge)
 "bNl" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/sheet/mineral/gold,
@@ -3604,6 +3590,9 @@
 	id = "FL room"
 	},
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/hop)
 "bNV" = (
@@ -3669,12 +3658,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
-"bPf" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "bPk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -3976,16 +3959,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
-"bVH" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/male)
 "bWf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
@@ -4084,7 +4057,7 @@
 "bYx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
@@ -4423,12 +4396,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "chP" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock/cafeteria)
+/area/aegis/surface)
 "ciq" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
@@ -4632,7 +4603,6 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "coK" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_center,
 /area/aegis/mining)
 "cpf" = (
@@ -4697,7 +4667,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/fax_machine,
 /obj/structure/fireaxecabinet/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
@@ -4850,9 +4819,14 @@
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/hop)
 "cuI" = (
@@ -4987,6 +4961,11 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/deadspace/random/maint_center,
 /area/aegis/mining)
+"cyz" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "cyG" = (
 /turf/open/floor/deadspace/cable_end,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -5365,7 +5344,6 @@
 "cHi" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/poddoor/preopen{
 	id = "captain hideout";
 	dir = 4
@@ -5414,6 +5392,14 @@
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"cHQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "cHY" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap{
@@ -5439,7 +5425,9 @@
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
 "cIg" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -5459,16 +5447,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
-"cIz" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
-	},
-/obj/structure/cable/red{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "cIF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5517,14 +5495,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "cKw" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/hallway/primary/port)
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/lobby)
 "cKy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -5560,6 +5535,18 @@
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"cLC" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "cLD" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -5652,27 +5639,24 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
+"cOq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
+"cOG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "cON" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"cOO" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
 "cOP" = (
 /obj/structure/stairs/north,
 /turf/open/floor/iron/dark/side{
@@ -5695,6 +5679,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cPb" = (
@@ -5706,6 +5693,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"cPe" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "cPg" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/loading_area{
@@ -5748,6 +5746,15 @@
 "cPJ" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/fore/greater)
+"cPN" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "cPQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "12"
@@ -5758,7 +5765,9 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "cPX" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/central)
 "cQh" = (
@@ -5882,10 +5891,14 @@
 /turf/open/water,
 /area/station/maintenance/port/lesser)
 "cUc" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "132"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/service/chapel/monastery)
 "cUs" = (
 /obj/machinery/disposal/bin,
 /obj/effect/floor_decal/ds/spline/fancy/wood{
@@ -5900,7 +5913,10 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
@@ -6012,6 +6028,13 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central/aft)
+"cXH" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "cXW" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/deadspace/medical,
@@ -6108,7 +6131,9 @@
 /area/station/command/heads_quarters/cmo)
 "daQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
 "daT" = (
@@ -6259,11 +6284,6 @@
 "dhr" = (
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
-"dhS" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
 "dhT" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -6286,11 +6306,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/brig)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -6349,20 +6370,6 @@
 /obj/item/plate_shard/marker_shard,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
-"dka" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/maint_center{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
 "dki" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/norn,
@@ -6410,6 +6417,15 @@
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/carpet/red,
 /area/station/commons/lounge)
+"dlp" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "dlH" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 8;
@@ -6601,16 +6617,6 @@
 /obj/structure/rack,
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
-"drk" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
-	},
-/obj/structure/cable/red{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "dru" = (
 /obj/item/clothing/head/collectable/paper{
 	desc = "What looks like an ordinary paper hat is actually a rare and valuable collector's edition paper hat. Keep away from fire, Curators, and ocean waves."
@@ -6735,20 +6741,6 @@
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
-"dvw" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "dvD" = (
 /obj/structure/beebox/premade/random,
 /turf/open/floor/plating,
@@ -6777,6 +6769,12 @@
 	dir = 4
 	},
 /area/station/command/bridge)
+"dwN" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dwU" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 1
@@ -6812,6 +6810,10 @@
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
+"dxV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/slides,
+/area/station/cargo/warehouse)
 "dya" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -6864,13 +6866,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
-"dzg" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "dzm" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
@@ -6885,10 +6880,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/medical/psychology)
-"dzp" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/deadspace/mono,
-/area/station/cargo)
 "dzw" = (
 /obj/structure/ladder/invincible,
 /obj/structure/disposalpipe/trunk/multiz{
@@ -6907,6 +6898,10 @@
 "dzC" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"dzP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "dAe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6953,8 +6948,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -7020,19 +7018,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
-"dCz" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "dCD" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/tool,
@@ -7121,7 +7106,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
@@ -7307,29 +7295,17 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "dJx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/station/commons/lounge)
-"dJK" = (
-/obj/item/kirbyplants/random,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
-"dJM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
+"dJK" = (
+/obj/item/kirbyplants/random,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "dJY" = (
 /turf/open/floor/eighties/red,
 /area/aegis/surface)
@@ -7362,8 +7338,10 @@
 "dKR" = (
 /obj/structure/table/wood/fancy/green,
 /obj/machinery/telephone/command,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/captain)
 "dLe" = (
@@ -7404,15 +7382,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"dLH" = (
-/obj/effect/turf_decal/siding/wood{
-	dir = 1
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/wood,
-/area/station/medical/psychology)
 "dLK" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
@@ -7604,16 +7573,16 @@
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
 /area/aegis/mining)
 "dSu" = (
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "dSB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -7645,18 +7614,18 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "dSI" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/obj/effect/turf_decal/bot,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/bathroom,
-/area/aegis/mining)
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/maintenance/starboard/upper)
 "dSZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 8
 	},
@@ -7732,11 +7701,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "dUe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "dUl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -7749,13 +7716,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"dUm" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
 "dUn" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -7865,6 +7825,13 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lesser)
+"dWU" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "dWV" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/maint_right,
@@ -7952,7 +7919,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "window command hallway"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "dZE" = (
@@ -8012,12 +7981,6 @@
 /obj/structure/chair/stool/directional/west,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"ebu" = (
-/obj/structure/cable/yellow{
-	icon_state = "68"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "ebw" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
 	dir = 8
@@ -8060,9 +8023,11 @@
 	},
 /area/aegis/mining)
 "ecH" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/tech,
 /area/station/hallway/primary/central/aft)
 "ecL" = (
@@ -8181,12 +8146,9 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "efO" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides,
+/area/station/cargo/warehouse)
 "efQ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -8412,6 +8374,17 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/deadspace/mono,
 /area/station/service/chapel)
+"elN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/command/bridge)
 "elY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -8548,17 +8521,6 @@
 /obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
-"epK" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/medbay/aft)
 "epU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -8736,15 +8698,22 @@
 "evC" = (
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
+"evE" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "ewa" = (
-/obj/effect/turf_decal/bot_white,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/command/bridge)
 "ewj" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/disposal/bin,
@@ -8800,7 +8769,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/bathroom,
 /area/aegis/mining)
 "exz" = (
@@ -8857,6 +8825,14 @@
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
+"eyJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "eyK" = (
 /obj/machinery/power/floodlight,
 /obj/effect/turf_decal/stripes/line{
@@ -8891,12 +8867,6 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
-"ezg" = (
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "ezM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/siding/wood,
@@ -8985,9 +8955,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
@@ -9260,9 +9227,18 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_center,
 /area/aegis/mining)
+"eHR" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "eHS" = (
 /obj/structure/chair{
 	dir = 4
@@ -9277,9 +9253,11 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/surgery)
 "eIj" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain)
 "eIq" = (
@@ -9319,10 +9297,7 @@
 "eIL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "1"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/monitoring)
@@ -9444,6 +9419,10 @@
 /obj/structure/foamedmetal,
 /turf/open/floor/eighties/red,
 /area/aegis/surface)
+"eMX" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "eNc" = (
 /obj/machinery/door/poddoor/shutters/window{
 	id = "armory";
@@ -9506,20 +9485,29 @@
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
-"eOp" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
+"eOt" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/station/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "eON" = (
 /obj/structure/chair/office{
 	dir = 1
 	},
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "ePf" = (
@@ -9668,6 +9656,10 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
+"eTi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/commons/dorms/barracks/male)
 "eTs" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/closet/secure_closet/ds/miner,
@@ -9683,20 +9675,6 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
-"eTF" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "eTK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9755,9 +9733,11 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "eVG" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "eVH" = (
@@ -9792,13 +9772,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"eWy" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "eWE" = (
 /obj/structure/railing/corner{
 	dir = 1
@@ -9831,8 +9804,10 @@
 /area/station/engineering/atmos)
 "eXP" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -9880,7 +9855,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
@@ -10049,16 +10024,10 @@
 /obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
-"fdE" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "fdT" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
@@ -10070,11 +10039,10 @@
 	},
 /area/station/hallway/primary/starboard)
 "feD" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "feG" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Distribution Loop";
@@ -10104,16 +10072,14 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ffw" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/hardwood,
+/area/station/command/heads_quarters/captain)
 "ffz" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -10369,21 +10335,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/misc_lab)
 "flr" = (
-/obj/structure/disposalpipe/segment,
+/obj/machinery/conveyor{
+	id = "Lower Marker Conveyor"
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
-"flF" = (
-/obj/machinery/light/directional/west,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/stone,
-/area/aegis/surface)
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "flJ" = (
 /obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron/dark,
@@ -10735,12 +10693,6 @@
 	},
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
-"fvx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "fvJ" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/table,
@@ -10776,14 +10728,19 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/customs)
 "fwp" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/area/aegis/surface)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "fwt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10873,14 +10830,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/port)
-"fzJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "fzN" = (
 /obj/item/paper_bin,
 /obj/structure/table/wood,
@@ -10889,7 +10838,9 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "fAI" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "fBk" = (
@@ -10918,23 +10869,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "fBC" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "6"
 	},
-/turf/open/floor/stone,
-/area/aegis/surface)
-"fBE" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "fCw" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -10963,13 +10905,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
-"fCB" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
 "fDg" = (
 /obj/structure/ladder/invincible,
 /obj/structure/lattice,
@@ -11152,6 +11087,16 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/storage/primary)
+"fKB" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/cargo/miningoffice)
 "fKL" = (
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
@@ -11240,17 +11185,6 @@
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/grass,
 /area/station/service/library)
-"fMx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "fML" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/hanger)
@@ -11320,6 +11254,17 @@
 /obj/machinery/lapvend,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"fOb" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "fOe" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/misc/asteroid,
@@ -11378,7 +11323,9 @@
 /area/station/tcommsat/server)
 "fPN" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/starboard/central)
 "fPP" = (
@@ -11662,6 +11609,14 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
+"fWl" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
+	},
+/area/station/security/brig)
 "fWv" = (
 /obj/machinery/computer/piratepad_control/civilian,
 /turf/open/floor/deadspace/random/rectangles,
@@ -11763,7 +11718,6 @@
 	dir = 4;
 	name = "Computer Recycling Room"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/mono,
 /area/aegis/mining)
 "fZe" = (
@@ -12295,9 +12249,11 @@
 	},
 /area/station/hallway/primary/port)
 "gpu" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/mono,
-/area/aegis/mining)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "gpv" = (
 /obj/structure/cable/yellow{
 	icon_state = "12"
@@ -12331,9 +12287,14 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -12349,20 +12310,6 @@
 /obj/machinery/light/small/maintenance/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"gqG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "gqO" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/deepfryer,
@@ -12467,12 +12414,11 @@
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/captain)
 "guQ" = (
-/obj/effect/turf_decal/box,
-/obj/effect/spawner/random/clothing/wardrobe_closet,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "gva" = (
 /obj/structure/railing,
 /turf/open/floor/deadspace/random/rectangles,
@@ -12522,13 +12468,13 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 4
-	},
-/area/station/security/brig)
+/turf/open/floor/deadspace/mono,
+/area/station/cargo/sorting)
 "gxI" = (
 /obj/structure/cable/yellow{
 	icon_state = "3"
@@ -12587,6 +12533,19 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood/three_quarters,
 /turf/open/floor/carpet/blue,
 /area/station/service/chapel/office)
+"gzn" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "gzq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -12645,26 +12604,39 @@
 /obj/structure/lattice,
 /turf/open/openspace,
 /area/station/maintenance/starboard/central)
-"gAR" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
 "gAV" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
+"gAY" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "gAZ" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
 	power_setting = 50
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"gBa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "gBe" = (
 /obj/structure/sign/map/right{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -12690,13 +12662,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/hallway/primary/central)
-"gBn" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
 "gBt" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/griddle,
@@ -12715,6 +12680,12 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
+"gCH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "gCT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -12788,13 +12759,15 @@
 /turf/open/floor/engine/airless,
 /area/station/engineering/supermatter/room)
 "gEz" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "gER" = (
@@ -12849,14 +12822,6 @@
 "gFX" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/aft)
-"gGD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "gGE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -12937,6 +12902,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"gKK" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "gKO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -12956,6 +12927,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/female)
+"gLi" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "gMl" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -13152,17 +13130,10 @@
 	name = "Bridge"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/tech{
 	dir = 8
 	},
 /area/station/hallway/primary/central/aft)
-"gQj" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "gQq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -13335,14 +13306,6 @@
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
-"gTX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "gUk" = (
 /obj/effect/spawner/random/trash/mess,
 /turf/open/openspace,
@@ -13595,6 +13558,14 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/misc_lab)
+"gZP" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/exam_room)
 "gZQ" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/corner,
 /obj/structure/disposalpipe/junction/yjunction,
@@ -13646,7 +13617,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
@@ -13761,6 +13732,15 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/misc/testroom)
+"hff" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "hfg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -13784,6 +13764,17 @@
 	dir = 8
 	},
 /area/station/science/lobby)
+"hfy" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "hfD" = (
 /obj/structure/disposalpipe/junction/yjunction,
 /obj/structure/cable/yellow{
@@ -13807,13 +13798,6 @@
 	},
 /turf/open/floor/plating,
 /area/aegis/surface)
-"hgB" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/security/warden)
 "hgC" = (
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
@@ -13932,6 +13916,13 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/lobby)
+"hjz" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "hjQ" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
@@ -14070,6 +14061,20 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"hph" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "hpk" = (
 /obj/structure/chair{
 	dir = 1
@@ -14401,9 +14406,16 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
 "hvU" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/wood,
-/area/aegis/mining)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/hardwood,
+/area/station/command/heads_quarters/captain)
 "hwp" = (
 /obj/structure/cable/yellow{
 	icon_state = "9"
@@ -14503,6 +14515,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"hyt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "hyK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/north,
@@ -14526,16 +14549,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
-"hyS" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/floor/has_bulb,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "hzd" = (
 /obj/machinery/light/small/maintenance/directional/east,
 /obj/item/clothing/suit/apron/chef,
@@ -14600,7 +14613,9 @@
 "hAM" = (
 /obj/structure/cable/multiz,
 /obj/structure/closet/firecloset,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/central)
 "hAU" = (
@@ -14869,6 +14884,22 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"hHG" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command hallway"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "hHW" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -14885,6 +14916,21 @@
 	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/engine_smes)
+"hIo" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "hJm" = (
 /obj/structure/chair{
 	dir = 1
@@ -15012,12 +15058,6 @@
 /obj/machinery/power/floodlight,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
-"hMH" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/checkpoint/customs)
 "hMJ" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/box,
@@ -15155,6 +15195,12 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/greater)
+"hPy" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/warehouse)
 "hPz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
@@ -15344,6 +15390,14 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"hTT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "hUi" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -15604,26 +15658,16 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "P-Sec Brig";
-	req_access_txt = "63";
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command blast"
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "4"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig)
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "idy" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor{
@@ -15740,12 +15784,6 @@
 "ifl" = (
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/female)
-"ifH" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/mine/lobby)
 "ifO" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -15871,40 +15909,35 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
-"ihP" = (
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/hallway/secondary/exit/departure_lounge)
 "iib" = (
 /obj/machinery/light/small/maintenance/directional/east,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lesser)
 "iix" = (
-/obj/structure/disposalpipe/segment{
+/obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "iiK" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"ija" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
+"iiX" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "ijd" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/two,
@@ -16099,7 +16132,7 @@
 /area/station/security/checkpoint/medical)
 "ilS" = (
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
@@ -16148,13 +16181,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "imS" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "10"
 	},
-/turf/open/floor/iron/dark,
-/area/station/medical/break_room)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "imT" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -16177,6 +16208,16 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
+"inN" = (
+/obj/effect/floor_decal/ds/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/station/service/library)
 "iof" = (
 /obj/effect/spawner/structure/window/reinforced/tinted/prepainted/daedalus,
 /obj/structure/cable/yellow{
@@ -16191,16 +16232,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "iol" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "40"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16242,9 +16278,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "ipM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/primary/central/aft)
 "iqf" = (
@@ -16451,11 +16489,11 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "iwD" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
+/area/station/cargo/warehouse)
 "iwK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -16520,13 +16558,6 @@
 /obj/effect/spawner/random/deadspace/rig,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
-"izE" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "izF" = (
 /obj/effect/landmark/pestspawn,
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -16670,6 +16701,15 @@
 /obj/item/electronics/apc,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
+"iBT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "iBX" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/box/white{
@@ -16684,11 +16724,18 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
 	},
-/area/station/cargo/warehouse)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "iCm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate/large/ds/green_horizontal,
@@ -16856,10 +16903,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
-"iFY" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/deadspace/mono,
-/area/station/cargo)
 "iGf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -17004,6 +17047,9 @@
 /area/station/medical/pharmacy)
 "iIq" = (
 /obj/machinery/light/small/maintenance/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "iIK" = (
@@ -17058,16 +17104,13 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "iJI" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "10"
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/breakroom)
+/turf/open/floor/deadspace/medical,
+/area/station/medical/morgue)
 "iJV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 4
@@ -17234,10 +17277,12 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "window command hallway"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/command/bridge)
 "iMB" = (
@@ -17392,9 +17437,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "iPC" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -17702,6 +17749,14 @@
 	},
 /turf/open/floor/plating,
 /area/aegis/hanger)
+"iXR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "iXU" = (
 /turf/open/floor/deadspace/cable,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -17826,10 +17881,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
@@ -17883,16 +17935,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jdI" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
+/obj/structure/cable/red{
 	icon_state = "1"
 	},
 /turf/open/floor/plating,
-/area/station/command/heads_quarters/ce)
+/area/station/engineering/supermatter/room)
 "jdK" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -17917,10 +17968,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "jeU" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
 	},
+/obj/structure/lattice,
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -18172,6 +18223,14 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
+"jkF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "jkH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -18426,7 +18485,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "9"
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/sorting)
@@ -18499,12 +18558,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "jpV" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
+/area/station/cargo/warehouse)
 "jpX" = (
 /obj/structure/rack,
 /obj/item/storage/lunchbox/cec,
@@ -18582,17 +18641,6 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
-"jrY" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "jsp" = (
 /obj/effect/spawner/random/trash/garbage{
 	spawn_loot_count = 3
@@ -18642,23 +18690,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
-"jtr" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Cargo Privacy";
-	name = "Cargo Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/qm)
 "jtu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
@@ -18735,6 +18766,13 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"juQ" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "jvn" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/air_input{
 	dir = 8
@@ -18820,12 +18858,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "jxE" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -18837,6 +18877,13 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"jyb" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/maintenance/fore/greater)
 "jyl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
@@ -18981,15 +19028,6 @@
 /obj/structure/table/wood/fancy/blue,
 /turf/open/floor/iron/ported/lino,
 /area/station/service/library)
-"jCN" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
 "jDd" = (
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
@@ -19022,7 +19060,6 @@
 /area/station/engineering/main)
 "jDq" = (
 /obj/machinery/light/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -19048,6 +19085,14 @@
 /obj/structure/girder/displaced,
 /turf/open/floor/plating,
 /area/aegis/surface)
+"jDZ" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/break_room)
 "jEf" = (
 /obj/machinery/button/door/directional/north{
 	name = "Armory Shutters";
@@ -19174,12 +19219,6 @@
 /obj/structure/flora/rock,
 /turf/open/misc/asteroid,
 /area/station/cargo/miningdock/oresilo)
-"jIq" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "jIr" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/medical/minor_healing,
@@ -19435,12 +19474,6 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"jOG" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
 "jON" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -19475,6 +19508,13 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"jPn" = (
+/obj/effect/turf_decal/box,
+/obj/effect/spawner/random/clothing/wardrobe_closet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "jPs" = (
 /turf/open/floor/iron/dark/corner{
 	dir = 1
@@ -19537,7 +19577,7 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "9"
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
@@ -19616,7 +19656,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
@@ -19820,16 +19860,17 @@
 /area/station/cargo/storage)
 "jYE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "jYG" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "jYM" = (
@@ -20155,6 +20196,12 @@
 	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
+"khU" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "khV" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/directional/west,
@@ -20184,11 +20231,16 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "kis" = (
-/obj/structure/rack,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/grater,
-/area/aegis/mining)
+/area/station/cargo/warehouse/upper)
 "kit" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
@@ -20254,14 +20306,6 @@
 /obj/structure/closet/secure_closet/ds/chief_medical,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
-"kjn" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
 "kjv" = (
 /turf/closed/wall/r_wall,
 /area/station/security/range)
@@ -20353,7 +20397,9 @@
 /area/station/commons/dorms/barracks/male)
 "kmy" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "kmF" = (
@@ -20430,31 +20476,16 @@
 /obj/machinery/light/directional/north,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"koP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "kpe" = (
 /obj/structure/table/wood,
 /obj/item/storage/photo_album/library,
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "kpk" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides,
+/area/station/cargo/warehouse)
 "kpy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -20467,14 +20498,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/grille_spare3,
+/area/station/security/checkpoint/customs)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -20622,14 +20653,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"ktN" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/norn,
-/area/station/hallway/primary/starboard)
 "ktR" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
@@ -20739,7 +20762,7 @@
 /area/station/commons/dorms/laundry)
 "kyb" = (
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "3"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
@@ -20766,6 +20789,20 @@
 "kyT" = (
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/maintenance/fore/lesser)
+"kzg" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command blast"
+	},
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "kzp" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_left,
@@ -20809,6 +20846,17 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/engine_smes)
+"kBf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo/warehouse)
+"kBg" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "kBk" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/lounge)
@@ -21063,6 +21111,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central/aft)
+"kHh" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "kHQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -21600,6 +21654,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
 "kVj" = (
@@ -21775,7 +21832,6 @@
 /obj/item/paper_bin,
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
 "lao" = (
@@ -21901,14 +21957,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
-"lcL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
 "lcV" = (
 /obj/machinery/newscaster/directional/east,
 /obj/structure/cable/yellow{
@@ -21935,12 +21983,19 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "ldv" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "8"
+/obj/structure/disposalpipe/junction{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -21953,9 +22008,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
@@ -21982,6 +22034,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"leg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/station/commons/lounge)
 "lem" = (
 /obj/structure/railing{
 	dir = 4
@@ -22436,6 +22494,12 @@
 "lpI" = (
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/port/lesser)
+"lqp" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "lqv" = (
 /obj/structure/sink{
 	dir = 8;
@@ -22540,6 +22604,12 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
+"ltp" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "lty" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
@@ -22664,6 +22734,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/hallway/primary/central/aft)
+"lxT" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/security/warden)
 "lxX" = (
 /obj/structure/railing,
 /obj/structure/closet/crate/large/ds/green_horizontal,
@@ -22730,16 +22807,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"lzz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "lzS" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 1
@@ -22766,7 +22833,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -22850,12 +22920,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/bar)
-"lCi" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "lCt" = (
 /obj/structure/destructible/cult/item_dispenser/archives/library,
 /obj/item/book/codex_gigas,
@@ -23194,6 +23258,16 @@
 /obj/structure/grille,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"lMs" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "lMy" = (
 /mob/living/simple_animal/hostile/rat,
 /turf/open/floor/deadspace/grater,
@@ -23561,12 +23635,6 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
-"lWk" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "lWw" = (
 /obj/structure/railing,
 /turf/open/water,
@@ -23677,7 +23745,6 @@
 "mao" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -23873,11 +23940,11 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
 "mfG" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "3"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
@@ -24118,6 +24185,16 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"mmH" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "mmQ" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -24178,11 +24255,15 @@
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "mou" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/female)
 "moB" = (
 /obj/machinery/door/airlock/hydroponics/glass{
 	name = "Abandoned Hydroponics";
@@ -24230,9 +24311,11 @@
 /area/station/security/range)
 "mpA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
@@ -24333,7 +24416,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "msk" = (
@@ -24403,6 +24488,18 @@
 	dir = 4
 	},
 /area/station/hallway/primary/fore)
+"mtB" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "mtQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "12"
@@ -24544,6 +24641,15 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
+"mxJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/command/bridge)
 "mxM" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/east,
@@ -24574,6 +24680,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
+"mzA" = (
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "mzU" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_left{
@@ -24601,12 +24713,39 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
+"mAh" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "mAl" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"mAD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
+"mAN" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/morgue)
 "mAV" = (
 /obj/machinery/rnd/production/fabricator/department/security,
 /obj/machinery/airalarm/directional/west,
@@ -24648,11 +24787,14 @@
 /turf/open/floor/engine,
 /area/station/command/heads_quarters/rd)
 "mBv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "mBz" = (
 /obj/machinery/door/airlock/medical{
 	name = "Bioprosthetics Lab";
@@ -24678,10 +24820,13 @@
 	},
 /area/mine/production)
 "mCd" = (
-/obj/structure/cable/yellow{
-	icon_state = "6"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/turf/open/floor/stone,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "mCl" = (
 /obj/structure/window/reinforced/spawner/west,
@@ -24886,6 +25031,12 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
+"mIv" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "mIX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -24916,6 +25067,24 @@
 /mob/living/simple_animal/butterfly,
 /turf/open/floor/grass,
 /area/station/hallway/primary/fore)
+"mJG" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "mJN" = (
 /obj/structure/railing{
 	dir = 8
@@ -24954,6 +25123,17 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
+"mKV" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "mLj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -25183,7 +25363,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "Maints Lockdown"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "mQN" = (
@@ -25297,23 +25479,6 @@
 "mUn" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
-"mUx" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "mUC" = (
 /obj/machinery/door/poddoor,
 /obj/machinery/conveyor{
@@ -25336,13 +25501,6 @@
 	dir = 5
 	},
 /area/station/hallway/primary/starboard)
-"mVx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
-	},
-/area/station/cargo/warehouse)
 "mVI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -25424,9 +25582,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "mXc" = (
@@ -25497,14 +25652,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
-"mYN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
 "mYP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch/directional/south,
@@ -25537,7 +25684,9 @@
 /obj/structure/cable/multiz,
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/primary/central/aft)
 "mZz" = (
@@ -25987,10 +26136,6 @@
 /obj/item/clothing/head/cone,
 /turf/open/floor/stone,
 /area/aegis/surface)
-"nll" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/slides,
-/area/station/cargo/warehouse)
 "nlK" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/toy,
@@ -26012,14 +26157,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
-"nmy" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "nmA" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/mono,
@@ -26286,6 +26423,14 @@
 	dir = 4
 	},
 /area/aegis/mining)
+"nwl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "nwv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26316,8 +26461,10 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "window command blast"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "nyu" = (
@@ -26537,12 +26684,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "nBX" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "nCk" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -26613,12 +26761,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"nDn" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "nDq" = (
 /obj/machinery/camera/motion/directional/north,
 /turf/open/floor/deadspace/random/slides{
@@ -26634,6 +26776,17 @@
 "nDA" = (
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"nDH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
+"nEm" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "nED" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -26662,15 +26815,6 @@
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
-"nGv" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "nGw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -26770,6 +26914,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/aft)
+"nID" = (
+/obj/structure/cable/multiz,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "nIX" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/deadspace/grater,
@@ -26883,6 +27034,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"nMn" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "nMp" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -26907,8 +27062,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/checkpoint/customs)
 "nMM" = (
 /obj/machinery/air_sensor/plasma_tank,
 /obj/machinery/camera/directional/east{
@@ -26916,14 +27071,6 @@
 	},
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
-"nMR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/stone,
-/area/aegis/surface)
 "nMS" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -27008,16 +27155,12 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "nOQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/area/aegis/surface)
 "nOX" = (
 /obj/machinery/cryopod,
 /obj/effect/landmark/latejoin,
@@ -27045,7 +27188,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "nPd" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "nPr" = (
@@ -27167,13 +27312,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/female)
-"nSo" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
 "nSr" = (
 /obj/machinery/light/small/maintenance/directional/west,
 /obj/structure/table/wood,
@@ -27410,16 +27548,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
-"oab" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "oam" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/deadspace/mono,
@@ -27458,19 +27586,6 @@
 /obj/machinery/meter/monitored/distro_loop,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"obj" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/white,
-/area/station/service/kitchen)
 "obr" = (
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible,
 /turf/open/floor/deadspace/random/rectangles,
@@ -27516,12 +27631,14 @@
 /area/station/service/chapel/funeral)
 "ocJ" = (
 /obj/structure/railing,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "ocO" = (
 /obj/structure/cable/yellow{
-	icon_state = "40"
+	icon_state = "3"
 	},
 /turf/open/misc/ironsand,
 /area/aegis/surface)
@@ -27575,6 +27692,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
@@ -27701,7 +27821,6 @@
 /area/station/hallway/primary/port)
 "ohf" = (
 /obj/structure/closet/secure_closet/personal,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/wood,
 /area/aegis/mining)
 "ohM" = (
@@ -27732,7 +27851,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -27825,6 +27946,14 @@
 /obj/effect/landmark,
 /turf/open/floor/deadspace/roller,
 /area/aegis/surface)
+"okh" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "okw" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable/orange{
@@ -27894,7 +28023,6 @@
 	dir = 4;
 	name = "Auxiliary Storage"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/mono,
 /area/aegis/mining)
 "omr" = (
@@ -28074,11 +28202,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/security/range)
-"oqg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "oqn" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -28193,13 +28316,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
-"otp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
 "otu" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
@@ -28240,11 +28356,6 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
-"ouq" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "ouE" = (
 /obj/effect/landmark/navigate_destination{
 	location = "Mining"
@@ -28575,22 +28686,45 @@
 /obj/item/circular_saw/bonecutter,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"oDC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
+"oDD" = (
+/obj/structure/cable/yellow{
+	icon_state = "132"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "oDH" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/station/engineering/main)
-"oDX" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
+"oEb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "5"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "oEw" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 4
@@ -28610,10 +28744,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"oEC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "oET" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	name = "Air to Ports"
@@ -28716,6 +28846,17 @@
 	},
 /turf/open/floor/plating,
 /area/aegis/surface)
+"oHX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "oHZ" = (
 /obj/machinery/light/small/maintenance/directional/east,
 /turf/open/floor/plating,
@@ -28850,6 +28991,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central/aft)
+"oLh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "oLQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "UndergroundMining";
@@ -28993,6 +29140,13 @@
 "oQh" = (
 /turf/closed/wall/r_wall,
 /area/station/service/chapel/storage)
+"oQo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "oQE" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/engine,
@@ -29027,13 +29181,15 @@
 	req_access_txt = "20"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/poddoor/preopen{
 	id = "captain hideout";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain)
 "oQX" = (
@@ -29164,6 +29320,13 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
+"oTJ" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "oTX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29254,6 +29417,15 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
+"oWK" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock/cafeteria)
 "oWL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
@@ -29346,7 +29518,10 @@
 /area/station/medical/medbay/central)
 "oYE" = (
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -29423,7 +29598,6 @@
 /area/station/cargo/warehouse)
 "paC" = (
 /obj/machinery/light/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
 "pba" = (
@@ -29543,6 +29717,14 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"pep" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "pev" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -29597,14 +29779,12 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "pfG" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "10"
 	},
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/hallway/primary/central)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "pfH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -29615,6 +29795,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
+"pfQ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "pfX" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/deadspace/mono,
@@ -29674,16 +29860,6 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"phP" = (
-/obj/machinery/light/directional/north,
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
 "piB" = (
 /obj/structure/railing{
 	dir = 8
@@ -29861,6 +30037,14 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"pmQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "pmR" = (
 /obj/item/shard,
 /obj/machinery/computer{
@@ -29869,15 +30053,11 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "pmS" = (
-/obj/effect/floor_decal/ds/spline/fancy/wood{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/carpet/royalblue,
-/area/station/service/library)
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "pnj" = (
 /obj/structure/railing{
 	dir = 6
@@ -29960,7 +30140,6 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "window command blast"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/command{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -30106,18 +30285,18 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/iron,
 /area/station/maintenance/fore/lesser)
-"ptq" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/warehouse)
 "ptu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
+"pty" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/command/bridge)
 "ptP" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
@@ -30177,17 +30356,6 @@
 /obj/structure/railing/corner,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
-"pvC" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Mining Privacy";
-	name = "Mining Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/qm)
 "pvH" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/button/door/directional/north{
@@ -30204,6 +30372,14 @@
 "pvL" = (
 /turf/open/floor/plating,
 /area/station/cargo/storage)
+"pvO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "pvW" = (
 /obj/item/pickaxe/rock,
 /turf/open/misc/asteroid,
@@ -30217,32 +30393,10 @@
 	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
-"pwG" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/clothing/costume,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
 "pwR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/bathroom,
 /area/station/medical/morgue)
-"pwU" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
 "pwW" = (
 /obj/structure/railing,
 /obj/structure/table/wood/fancy/red,
@@ -30776,14 +30930,6 @@
 	},
 /turf/open/floor/eighties/red,
 /area/aegis/surface)
-"pKq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig/upper)
 "pKA" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -30894,6 +31040,12 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"pMO" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "pNe" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint #2";
@@ -31048,17 +31200,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/fore)
-"pPq" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Cargo Privacy";
-	name = "Cargo Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/qm)
 "pPG" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -31104,12 +31245,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "pQH" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -31212,11 +31358,15 @@
 /obj/item/clothing/head/cseco,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hos)
-"pVu" = (
-/obj/structure/chair/stool/directional/south,
+"pVC" = (
+/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "pVI" = (
 /obj/item/storage/box/gloves,
 /obj/structure/table,
@@ -31607,7 +31757,7 @@
 "qfF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
@@ -31718,11 +31868,10 @@
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "qhR" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "qhZ" = (
 /obj/structure/rack,
 /obj/item/clothing/under/rank/medical/scrubs/purple,
@@ -31759,7 +31908,9 @@
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "qjg" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "qjl" = (
@@ -31845,12 +31996,16 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "qly" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/computer)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "qlA" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plating,
@@ -32201,6 +32356,20 @@
 /obj/structure/ladder/invincible,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"qtJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "qtR" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -32280,7 +32449,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -32457,30 +32626,19 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/norn,
 /area/station/medical/office)
-"qAC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/morgue)
-"qAU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/wood,
-/area/station/cargo/qm)
 "qAY" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "qBi" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
@@ -32574,7 +32732,6 @@
 	name = "First Lieutenant's Office";
 	req_access_txt = "57"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "FL room"
@@ -32582,6 +32739,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "qEC" = (
@@ -32659,21 +32819,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
-"qHf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "qHk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/golf_brown,
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "qHm" = (
 /obj/structure/table,
@@ -32789,6 +32940,12 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse)
+"qLd" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "qLg" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/bureaucracy/briefcase{
@@ -32804,17 +32961,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"qLI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
 "qLV" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -32846,14 +32992,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
-"qME" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/stone,
-/area/aegis/surface)
 "qMH" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/structure/crate,
@@ -32872,13 +33010,14 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "qMP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "qMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -33083,15 +33222,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
-"qSC" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/deadspace/grille_spare3,
-/area/station/security/checkpoint/customs)
 "qSL" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/slides{
@@ -33114,6 +33244,20 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"qTm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/lobby)
 "qTV" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -33171,13 +33315,14 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "qUM" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/hallway/primary/central)
 "qVj" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
@@ -33274,9 +33419,11 @@
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
 "qXk" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 8
 	},
@@ -33286,6 +33433,12 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/lobby)
+"qXx" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/bathroom,
+/area/mine/production)
 "qXD" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/deadspace/random/maint_center,
@@ -33443,6 +33596,16 @@
 	dir = 8
 	},
 /area/mine/production)
+"rcj" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "rcl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33506,6 +33669,15 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/fore)
+"rep" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/norn,
+/area/station/hallway/primary/central)
 "rez" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
@@ -33546,11 +33718,6 @@
 /obj/structure/filingcabinet,
 /turf/open/water,
 /area/station/maintenance/fore/lesser)
-"rfU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/mono,
-/area/station/cargo)
 "rfV" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -33631,13 +33798,6 @@
 /obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
-"rir" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/maintenance/fore/greater)
 "rit" = (
 /obj/structure/ore_box,
 /turf/open/misc/asteroid,
@@ -33699,16 +33859,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
-"rjR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+"rjT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
 	},
-/turf/open/floor/carpet/royalblack,
-/area/station/cargo/miningoffice)
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "rkf" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33727,6 +33887,13 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"rkA" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "rkL" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -33813,10 +33980,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "rlW" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "rma" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Cryo - Left"
@@ -33858,7 +34028,6 @@
 /area/station/maintenance/fore/lesser)
 "rnc" = (
 /obj/effect/landmark/pestspawn,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -33881,35 +34050,11 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
-"rnQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "rop" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock/pile/icy,
 /turf/open/misc/asteroid/snow,
 /area/station/science/breakroom)
-"ror" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/commons/dorms/cryo)
 "roG" = (
 /turf/open/floor/iron/dark/side{
 	dir = 6
@@ -33935,9 +34080,17 @@
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
 "rpe" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/grater,
-/area/aegis/mining)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "rpp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34238,6 +34391,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/cargo/qm)
+"rxm" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "rxo" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
@@ -34420,12 +34588,10 @@
 	},
 /area/station/hallway/primary/central/aft)
 "rCI" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/engineering/tool,
-/obj/effect/spawner/random/engineering/tool,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/maint_center,
-/area/aegis/mining)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo/warehouse)
 "rCX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -34455,6 +34621,15 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"rDy" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/central)
 "rDE" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 4
@@ -34468,14 +34643,12 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "rDI" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock/cafeteria)
 "rDN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -34500,6 +34673,12 @@
 /obj/machinery/light/small/maintenance/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"rEc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "rEA" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/fore)
@@ -34512,20 +34691,11 @@
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/security/courtroom)
 "rEZ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
-"rFk" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/stone,
-/area/aegis/surface)
 "rFp" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -34534,6 +34704,13 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
+"rFO" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command hallway"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "rFX" = (
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
@@ -34733,9 +34910,14 @@
 /turf/open/floor/deadspace/mono,
 /area/station/cargo)
 "rKO" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "rKS" = (
@@ -34787,12 +34969,6 @@
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/station/maintenance/fore/lesser)
-"rMh" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/deadspace/mono,
-/area/station/cargo)
 "rMK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/binary/pump/on,
@@ -34842,7 +35018,6 @@
 /area/station/maintenance/port/lesser)
 "rNh" = (
 /obj/machinery/light/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
 "rND" = (
@@ -34863,6 +35038,12 @@
 /obj/item/pen,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
+"rOt" = (
+/obj/structure/cable/yellow{
+	icon_state = "68"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "rOE" = (
 /obj/structure/sign/poster/official/moth_epi{
 	pixel_x = -32
@@ -34885,13 +35066,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"rOW" = (
-/obj/structure/cable/multiz,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "rOY" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -34944,10 +35118,14 @@
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
 "rQA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "rQK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/tool,
@@ -35033,13 +35211,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/command/bridge)
 "rTT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/morgue)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/command/bridge)
 "rTW" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -35117,6 +35293,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/mechbay)
+"rVD" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command hallway"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "rVF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 8
@@ -35163,18 +35355,9 @@
 /turf/open/floor/plating,
 /area/station/medical/surgery/theatre)
 "rXD" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo/warehouse)
 "rXE" = (
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
@@ -35302,10 +35485,6 @@
 /obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
-"sdz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
 "sdK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/maintenance,
@@ -35484,7 +35663,9 @@
 "sjv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain)
 "sjI" = (
@@ -35529,9 +35710,11 @@
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/toilet/restrooms)
 "sku" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/hallway/primary/central/aft)
 "skN" = (
@@ -35667,15 +35850,6 @@
 	},
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
-"snt" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/server)
 "snw" = (
 /obj/machinery/conveyor_switch/oneway{
 	dir = 8;
@@ -35866,19 +36040,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"stk" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "sua" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -35913,6 +36074,14 @@
 /obj/machinery/light/small/maintenance/directional/east,
 /turf/open/floor/deadspace/hardwood,
 /area/station/maintenance/port/lesser)
+"suG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "suL" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse/upper)
@@ -35958,6 +36127,20 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse/upper)
+"svP" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command blast"
+	},
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "swq" = (
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/female)
@@ -35980,14 +36163,16 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "swY" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Mining Privacy";
+	name = "Mining Shutters"
 	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/yellow{
+	icon_state = "8"
 	},
-/area/aegis/surface)
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -36164,9 +36349,17 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "sCc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "sCd" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/random/maintenance/two,
@@ -36221,10 +36414,6 @@
 /obj/machinery/light/small/red,
 /turf/open/floor/deadspace/grille_spare3,
 /area/station/cargo/warehouse)
-"sDh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "sDl" = (
 /obj/effect/landmark/navigate_destination/hydro,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -36243,14 +36432,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
-"sDX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "sDZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/flashlight,
@@ -36317,12 +36498,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/fore)
-"sEX" = (
-/obj/structure/cable/yellow{
-	icon_state = "24"
-	},
-/turf/open/floor/plating,
-/area/aegis/surface)
 "sFc" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/maint_right,
@@ -36442,6 +36617,17 @@
 /obj/structure/table,
 /turf/open/floor/stone,
 /area/aegis/surface)
+"sKj" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "sKB" = (
 /obj/machinery/conveyor{
 	id = "Lower Marker Conveyor";
@@ -36624,15 +36810,11 @@
 /area/station/medical/medbay/central)
 "sPk" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "miningsecprivacy";
-	name = "privacy shutter"
-	},
 /obj/structure/cable/yellow{
-	icon_state = "2"
+	icon_state = "1"
 	},
 /turf/open/floor/plating,
-/area/station/security/checkpoint/science)
+/area/station/engineering/main)
 "sPH" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/bot,
@@ -36757,13 +36939,15 @@
 	dir = 1;
 	name = "Bridge"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -36896,6 +37080,11 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
+"sWD" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "sWE" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/deadspace/heavy,
@@ -37012,6 +37201,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "sYz" = (
@@ -37040,6 +37232,12 @@
 /obj/effect/spawner/random/clothing/mafia_outfit,
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
+"sZZ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/cargo/qm)
 "tak" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -37106,9 +37304,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -37301,6 +37496,12 @@
 "thU" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/warehouse/upper)
+"tih" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "tij" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37328,6 +37529,23 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom,
 /area/station/medical/coldroom)
+"tiD" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command blast"
+	},
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "tiS" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/deadspace/random/slides,
@@ -37379,21 +37597,20 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
-"tkh" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "tkF" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/computer/med_data,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"tkM" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "tkZ" = (
 /obj/item/stack/rods,
 /turf/open/floor/deadspace/grater,
@@ -37448,18 +37665,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
-"tmB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "tmQ" = (
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
 /area/station/hallway/primary/starboard)
+"tmU" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "tmW" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Quartermaster";
@@ -37560,9 +37777,15 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "trK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "trL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37608,10 +37831,12 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ttr" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/button/door/directional/south{
 	id = "Maints Lockdown";
 	name = "Maints Lockdown"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
@@ -37660,6 +37885,14 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"tuw" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "tux" = (
 /obj/structure/table,
 /obj/item/crowbar/red,
@@ -37734,6 +37967,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/male)
+"tvi" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "tvx" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -38097,33 +38336,25 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "tHh" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/starboard/upper)
 "tHX" = (
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/male)
 "tIj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/structure/railing{
+	dir = 4
 	},
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "tIu" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/female)
-"tIJ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/exam_room)
 "tIM" = (
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
@@ -38154,16 +38385,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
-"tKm" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/female)
 "tKq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -38172,6 +38393,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
@@ -38284,9 +38508,6 @@
 	},
 /area/station/hallway/primary/starboard)
 "tNh" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
@@ -38294,7 +38515,7 @@
 	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/area/station/command/bridge)
 "tNI" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4;
@@ -38370,10 +38591,7 @@
 "tQQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
@@ -38798,6 +39016,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
+"ucc" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "uck" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/deadspace/random/slides{
@@ -38915,6 +39139,10 @@
 /obj/item/clothing/head/welding/knight,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"ugs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "ugt" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -39131,7 +39359,6 @@
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
 "umU" = (
@@ -39139,15 +39366,6 @@
 /obj/item/toy/plush/beeplushie,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"unh" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "unk" = (
 /obj/machinery/disposal/delivery_chute{
 	dir = 4
@@ -39274,18 +39492,16 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
 "upb" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "6"
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "1"
 	},
 /turf/open/floor/plating,
-/area/station/engineering/monitoring)
+/area/station/command/heads_quarters/ce)
 "upl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -39393,6 +39609,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"urz" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/hallway/primary/port)
+"urC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "urO" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/closet_empty/crate,
@@ -39414,10 +39645,6 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/customs)
-"urW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "ust" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -39457,13 +39684,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"utg" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "utw" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/deadspace/random/maint_center,
@@ -39534,14 +39754,10 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "uuS" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock/cafeteria)
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "uvc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39628,6 +39844,17 @@
 /obj/item/clothing/gloves/ring/diamond,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"uxL" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "uxN" = (
 /obj/structure/chair{
 	dir = 4
@@ -39643,11 +39870,8 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "uyk" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/vending/hydroseeds,
@@ -39787,7 +40011,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
 "uAN" = (
@@ -39868,6 +40094,15 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/primary)
+"uCr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "uCC" = (
 /turf/open/floor/deadspace/grille_spare2,
 /area/aegis/surface)
@@ -39878,10 +40113,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
@@ -39900,12 +40132,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
-"uDI" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
 "uDQ" = (
 /turf/closed/wall/r_wall,
 /area/station/command/bridge)
@@ -39995,12 +40221,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "12"
 	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40021,6 +40246,10 @@
 "uHK" = (
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/hallway/primary/central/aft)
+"uHY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "uHZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_left,
@@ -40187,12 +40416,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plating,
 /area/misc/testroom)
-"uNE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/cargo/qm)
 "uNG" = (
 /obj/structure/filingcabinet,
 /turf/open/floor/plating,
@@ -40274,19 +40497,42 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"uQx" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "uQL" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
-/obj/machinery/conveyor{
-	id = "Lower Marker Conveyor"
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Mining Privacy";
+	name = "Mining Shutters"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/area/station/cargo/qm)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -40334,8 +40580,10 @@
 /turf/open/floor/deadspace/mono,
 /area/mine/eva)
 "uSd" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -40363,6 +40611,14 @@
 "uSq" = (
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics)
+"uSr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "uSt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40372,12 +40628,6 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
-"uSu" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/deadspace/bathroom,
-/area/mine/production)
 "uSY" = (
 /obj/structure/table,
 /obj/item/clothing/head/cone{
@@ -40410,11 +40660,6 @@
 	dir = 8
 	},
 /area/station/security/lockers)
-"uSZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo/warehouse)
 "uTc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40499,6 +40744,24 @@
 	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
+"uVg" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
+"uVx" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "uVy" = (
 /turf/open/floor/carpet,
 /area/station/maintenance/fore/lesser)
@@ -40544,6 +40807,18 @@
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
+"uXf" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "uXj" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -40888,7 +41163,6 @@
 /area/station/engineering/atmos/storage/gas)
 "vfL" = (
 /obj/machinery/door/airlock/mining,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
 "vfS" = (
@@ -41140,17 +41414,13 @@
 "vmK" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/machinery/door/poddoor/preopen{
-	id = "miningsecprivacy";
-	name = "privacy shutter"
+	id = "window command hallway"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
-/area/station/security/checkpoint/science)
+/area/station/command/bridge)
 "vmO" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -41242,6 +41512,23 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"vqq" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Cargo Privacy";
+	name = "Cargo Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "vqr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41281,12 +41568,6 @@
 "vri" = (
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
-"vrp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "vrv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -41441,7 +41722,6 @@
 /obj/structure/window/reinforced/spawner/east,
 /obj/item/clothing/mask/gas/clown_hat,
 /obj/structure/closet/secure_closet/personal,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/wood,
 /area/aegis/mining)
 "vvz" = (
@@ -41483,14 +41763,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vwz" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/turf/open/floor/stone,
+/area/aegis/surface)
 "vwZ" = (
 /obj/structure/sign/cec/deck/research{
 	pixel_y = -32
@@ -41644,12 +41923,13 @@
 /obj/machinery/autolathe,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/port/lesser)
-"vAC" = (
+"vAq" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock/cafeteria)
 "vAI" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
@@ -41739,6 +42019,14 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
+"vCR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/mono,
+/area/station/cargo/sorting)
 "vCY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -41930,17 +42218,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "vIQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "vIY" = (
 /obj/machinery/pdapainter,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "vJc" = (
@@ -42037,6 +42332,13 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"vKJ" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "vKM" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/chair/office{
@@ -42084,6 +42386,19 @@
 /obj/effect/spawner/random/contraband/armory,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"vMc" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "vMm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -42100,12 +42415,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"vMn" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "vMp" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -42173,18 +42482,6 @@
 "vNo" = (
 /turf/open/floor/deadspace/grater,
 /area/mine/hydroponics)
-"vNq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "vNC" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/light/small/directional/north,
@@ -42193,18 +42490,6 @@
 "vNP" = (
 /turf/closed/wall/r_wall,
 /area/mine/lobby)
-"vOt" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "vOD" = (
 /obj/machinery/door/airlock/freezer{
 	name = "Cold Storage";
@@ -42424,6 +42709,9 @@
 "vTH" = (
 /obj/machinery/keycard_auth,
 /obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "vTK" = (
@@ -42509,10 +42797,6 @@
 	dir = 6
 	},
 /area/station/hallway/primary/central)
-"vUH" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/slides,
-/area/station/cargo/warehouse)
 "vUL" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -42554,7 +42838,9 @@
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
 	},
@@ -42577,6 +42863,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/hallway/primary/aft)
+"vWE" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "vXO" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
@@ -42596,8 +42888,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
 "vYt" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "vYA" = (
@@ -42698,12 +42992,6 @@
 "wbK" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/pharmacy)
-"wbT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
-	},
-/area/station/cargo/warehouse)
 "wbX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42929,12 +43217,6 @@
 /obj/effect/spawner/random/clothing/gloves,
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
-"whZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "wie" = (
 /obj/structure/closet{
 	name = "Evidence Closet 2"
@@ -43051,6 +43333,20 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
+"wmf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/medbay/aft)
 "wmg" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -43113,6 +43409,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
+"woq" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/service/janitor)
 "wot" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -43179,16 +43482,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpg" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/bot_white,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
@@ -43277,9 +43575,9 @@
 /area/station/cargo/drone_bay)
 "wrl" = (
 /obj/structure/cable/yellow{
-	icon_state = "132"
+	icon_state = "24"
 	},
-/turf/open/misc/asteroid,
+/turf/open/floor/plating,
 /area/aegis/surface)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
@@ -43366,13 +43664,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain)
@@ -43390,14 +43690,6 @@
 	dir = 4
 	},
 /area/aegis/mining)
-"wur" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/mono,
-/area/station/cargo/sorting)
 "wuy" = (
 /turf/closed/indestructible/rock,
 /area/aegis/surface)
@@ -43445,10 +43737,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "wwj" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/primary/central/aft)
 "wwt" = (
@@ -43497,7 +43791,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
@@ -43793,11 +44087,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
-"wFV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/slides,
-/area/station/cargo/warehouse)
 "wFX" = (
 /obj/machinery/jukebox,
 /turf/open/floor/wood,
@@ -43902,20 +44191,6 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
-"wHt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/maint_center{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
 "wHC" = (
 /obj/structure/rack/shelf,
 /obj/effect/turf_decal/bot_white,
@@ -43943,6 +44218,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/starboard)
+"wHU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/cargo/warehouse)
 "wIb" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -44007,7 +44288,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/central)
 "wKq" = (
@@ -44073,6 +44356,16 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
+"wNp" = (
+/obj/machinery/light/directional/north,
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "wNz" = (
 /obj/structure/table,
 /obj/effect/spawner/random/bureaucracy/briefcase,
@@ -44096,6 +44389,20 @@
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
+"wNW" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/clothing/costume,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "wNX" = (
 /obj/structure/railing{
 	dir = 8
@@ -44159,6 +44466,14 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
+"wQS" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/wood,
+/area/station/cargo/qm)
 "wRj" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 1
@@ -44255,6 +44570,16 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/deadspace/bathroom,
 /area/mine/production)
+"wUd" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/male)
 "wUk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -44454,12 +44779,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
-"wYn" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "wYs" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/stripes/line{
@@ -44609,10 +44928,12 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
 "xcO" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/hallway/primary/central/aft)
 "xdu" = (
@@ -44706,14 +45027,6 @@
 /obj/effect/spawner/random/deadspace/ammo,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
-"xeG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
 "xeQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -45139,12 +45452,14 @@
 /turf/open/floor/deadspace/mono,
 /area/station/service/kitchen/coldroom)
 "xpF" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "xpH" = (
@@ -45234,13 +45549,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "xsj" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/breakroom)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "xsl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -45268,7 +45579,10 @@
 "xsQ" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
@@ -45380,10 +45694,8 @@
 /area/station/cargo/drone_bay)
 "xvI" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "xvN" = (
@@ -45440,13 +45752,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/mine/lobby)
+/turf/open/floor/plating,
+/area/station/commons/dorms/cryo)
 "xwY" = (
 /obj/effect/landmark/pestspawn,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -45657,10 +45967,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
-"xDb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/commons/dorms/barracks/male)
 "xDc" = (
 /obj/machinery/light/small/maintenance/directional/east,
 /obj/structure/table/wood,
@@ -45715,9 +46021,19 @@
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/eva)
+"xEU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "xFb" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
 "xFe" = (
@@ -45826,6 +46142,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/central)
+"xIi" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/command/bridge)
 "xIA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -45844,13 +46169,6 @@
 /obj/effect/landmark/start/botanist,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
-"xIL" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "xIM" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/deadspace/random/slides{
@@ -45926,6 +46244,17 @@
 "xKp" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/break_room)
+"xKt" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Cargo Privacy";
+	name = "Cargo Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "xKG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -45944,12 +46273,6 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"xLd" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "xLh" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/surface)
@@ -45978,7 +46301,7 @@
 	name = "privacy shutter"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "2"
 	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/science)
@@ -45989,7 +46312,7 @@
 "xLY" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/security/warden)
@@ -46148,6 +46471,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
+"xRa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/hardwood,
+/area/station/command/heads_quarters/captain)
 "xRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -46173,6 +46501,14 @@
 "xRH" = (
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
+"xSa" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/command/bridge)
 "xSd" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
@@ -46280,7 +46616,6 @@
 /area/station/science/lab)
 "xWV" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/aft)
@@ -46442,6 +46777,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
+"yci" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "ycm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -46465,14 +46806,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
-"ycY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/mono,
-/area/station/cargo/sorting)
 "ycZ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -46489,7 +46822,9 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "19"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "yey" = (
@@ -46510,6 +46845,14 @@
 /obj/machinery/door/poddoor/preopen,
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
+"yeQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/norn,
+/area/station/hallway/primary/starboard)
 "yfc" = (
 /obj/machinery/computer/mecha{
 	dir = 8
@@ -46525,6 +46868,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
+"yfg" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "yfn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -46564,12 +46913,11 @@
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "ygs" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "5"
 	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/command/bridge)
 "ygt" = (
 /obj/structure/rack/shelf,
 /obj/item/plate_shard/marker_shard,
@@ -46633,14 +46981,17 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/obj/structure/cable/white{
-	icon_state = "132"
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/station/service/chapel/monastery)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
@@ -46665,15 +47016,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/aft)
-"yit" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "yiz" = (
 /obj/item/clothing/suit/xenos,
 /obj/item/clothing/head/xenos,
@@ -46730,12 +47072,6 @@
 "yjV" = (
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
-"yjX" = (
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "ykc" = (
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 4
@@ -55038,7 +55374,7 @@ uoP
 trm
 mNO
 mNO
-yhZ
+cUc
 trm
 ssE
 jxc
@@ -57611,8 +57947,8 @@ hgU
 qkb
 mNS
 vQc
+mAN
 aXf
-qAC
 qli
 qli
 qli
@@ -57764,12 +58100,12 @@ qAj
 boH
 lAb
 gGN
-epK
+uCR
 gpV
 qWI
 buK
 ovu
-rTT
+jTf
 cgY
 qWI
 eoV
@@ -57926,7 +58262,7 @@ bGQ
 qWI
 utT
 cSl
-rTT
+jTf
 cSl
 jpm
 eoV
@@ -58078,12 +58414,12 @@ eAl
 bXp
 yjT
 dAN
-uCR
+wmf
 gGN
 qWI
 utT
 mob
-rTT
+jTf
 mob
 jpm
 eoV
@@ -58235,12 +58571,12 @@ tik
 bXp
 yjT
 gGN
-epK
+uCR
 cXW
 qWI
 utT
 hTB
-rTT
+jTf
 mob
 jpm
 eoV
@@ -58388,7 +58724,7 @@ lAb
 qgO
 dfD
 ibV
-tIJ
+gZP
 xDY
 mBz
 isc
@@ -58397,7 +58733,7 @@ gGN
 qWI
 ofx
 eoV
-jTf
+iJI
 pbI
 ktX
 aaa
@@ -65299,8 +65635,8 @@ qVP
 erk
 erk
 iVy
-iFY
-rfU
+nMn
+uuS
 jiS
 jiS
 gRg
@@ -65614,7 +65950,7 @@ erk
 tmo
 ebG
 tDQ
-guQ
+jPn
 wEX
 hBa
 ebG
@@ -65771,8 +66107,8 @@ erk
 erk
 ebG
 ebG
-cUc
-iwD
+feD
+mIv
 ebG
 ebG
 erk
@@ -66242,7 +66578,7 @@ erk
 erk
 ebG
 ebG
-cUc
+feD
 ebG
 ebG
 ebG
@@ -66713,7 +67049,7 @@ erk
 erk
 xUZ
 ebG
-cUc
+feD
 ebG
 ebG
 uyM
@@ -66869,8 +67205,8 @@ vAm
 erk
 jiS
 ebG
-sdz
-cUc
+xsj
+feD
 jiS
 jiS
 aIS
@@ -67025,10 +67361,10 @@ etJ
 ulq
 erk
 fkx
-vAC
 ilS
-cUc
-rMh
+ucc
+feD
+rEc
 erk
 erk
 erk
@@ -67184,8 +67520,8 @@ erk
 jiS
 jiS
 rfJ
-cUc
-dzp
+feD
+eMX
 erk
 qVP
 qVP
@@ -67341,7 +67677,7 @@ erk
 eUJ
 erk
 uBz
-rfU
+uuS
 jiS
 erk
 qVP
@@ -75159,7 +75495,7 @@ sCv
 epE
 sCv
 lVh
-nDn
+urC
 sCv
 kWK
 sCv
@@ -75309,29 +75645,29 @@ qVP
 qVP
 kWK
 sCv
-whZ
+gCH
 sCv
 sCv
 sCv
 sCv
 sCv
 sCv
-trK
+dUe
 sCv
 kWK
 sCv
 sCv
-sCc
-gqh
-gqh
-gqh
-gqh
-rQA
-trK
-trK
-trK
-trK
-fvx
+arS
+uHY
+uHY
+uHY
+uHY
+qhR
+dUe
+dUe
+dUe
+dUe
+pMO
 gHW
 tbB
 gHW
@@ -75466,14 +75802,14 @@ qVP
 qVP
 kWK
 goN
-iCe
+wHU
 goN
 goN
 goN
 goN
 goN
 goN
-wbT
+iwD
 goN
 kWK
 mgm
@@ -75483,7 +75819,7 @@ goN
 goN
 goN
 goN
-mVx
+jpV
 goN
 goN
 goN
@@ -75623,14 +75959,14 @@ qVP
 qVP
 kWK
 lDu
-qHk
+rXD
 lDu
 nOn
 lDu
 lDu
 nOn
 lDu
-awP
+kBf
 lDu
 lTv
 lDu
@@ -75640,7 +75976,7 @@ lDu
 lDu
 lDu
 nOn
-uSZ
+rCI
 lDu
 nOn
 lDu
@@ -75780,14 +76116,14 @@ qVP
 qVP
 uYj
 mPy
-vUH
+dxV
 mPy
 uYj
 mPy
 mPy
 uYj
 mPy
-nll
+efO
 mPy
 uYj
 mPy
@@ -75797,7 +76133,7 @@ mPy
 mPy
 mPy
 uYj
-wFV
+kpk
 mPy
 uYj
 mPy
@@ -75937,14 +76273,14 @@ rqy
 qVP
 lxi
 mvU
-fCB
+dWU
 wwS
 wwS
 sCv
 sCv
 wwS
 wwS
-gBn
+qHk
 wwS
 wwS
 wwS
@@ -75954,7 +76290,7 @@ wwS
 wwS
 wwS
 wwS
-rQA
+qhR
 sCv
 wwS
 wwS
@@ -76094,24 +76430,24 @@ ozq
 pFl
 mUC
 wnU
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
-uQN
+flr
+flr
+flr
+flr
+flr
+flr
+flr
+flr
+flr
+flr
+flr
+flr
+flr
+flr
+flr
+flr
+flr
+flr
 bmx
 bmx
 bmx
@@ -76251,14 +76587,14 @@ rqy
 qVP
 lxi
 wUu
-nSo
+tIj
 gvZ
 gvZ
 sCv
 sCv
 gvZ
 gvZ
-dUm
+cXH
 gvZ
 gvZ
 gvZ
@@ -76268,7 +76604,7 @@ gvZ
 gvZ
 gvZ
 gvZ
-rQA
+qhR
 sCv
 gvZ
 gvZ
@@ -76408,14 +76744,14 @@ qVP
 qVP
 uYj
 goN
-wbT
+iwD
 goN
 uYj
 goN
 goN
 uYj
 goN
-iCe
+wHU
 goN
 uYj
 goN
@@ -76425,7 +76761,7 @@ goN
 goN
 goN
 uYj
-mVx
+jpV
 goN
 uYj
 goN
@@ -76565,14 +76901,14 @@ qVP
 qVP
 kWK
 lDu
-awP
+kBf
 lDu
 asE
 lDu
 lDu
 asE
 lDu
-qHk
+rXD
 lDu
 lTv
 lDu
@@ -76582,7 +76918,7 @@ lDu
 lDu
 lDu
 asE
-uSZ
+rCI
 lDu
 asE
 lDu
@@ -76722,14 +77058,14 @@ qVP
 qVP
 kWK
 mPy
-nll
+efO
 mPy
 mPy
 mPy
 mPy
 mPy
 mPy
-vUH
+dxV
 mPy
 kWK
 aPO
@@ -76739,7 +77075,7 @@ mPy
 mPy
 mPy
 mPy
-wFV
+kpk
 mPy
 mPy
 mPy
@@ -76879,30 +77215,30 @@ qVP
 qVP
 kWK
 sCv
-trK
+dUe
 sCv
 sCv
 sCv
 sCv
 sCv
 sCv
-gqh
+uHY
 sCv
 kWK
 sCv
-oEC
-trK
-trK
-trK
-trK
-trK
-rQA
-gqh
-gqh
-gqh
-gqh
-gqh
-tmB
+cOG
+dUe
+dUe
+dUe
+dUe
+dUe
+qhR
+uHY
+uHY
+uHY
+uHY
+uHY
+oLh
 sCv
 sCv
 kWK
@@ -77036,14 +77372,14 @@ qVP
 qVP
 kWK
 sCv
-but
+pfQ
 sCv
 sCv
 sCv
 sCv
 sCv
 sCv
-mBv
+nDH
 sCv
 kWK
 sCv
@@ -77053,7 +77389,7 @@ cQh
 cQh
 cQh
 sCv
-rQA
+qhR
 sCv
 sCv
 sCv
@@ -77209,8 +77545,8 @@ sCv
 sCv
 dqU
 tCy
-fzJ
-fzJ
+okh
+okh
 cSt
 cSt
 cSt
@@ -77220,7 +77556,7 @@ cSt
 cSt
 cSt
 aqr
-ptq
+hPy
 sCv
 mHX
 ljF
@@ -79723,7 +80059,7 @@ xVM
 xVM
 xVM
 fQc
-cKw
+urz
 pMt
 gRy
 rwp
@@ -79795,7 +80131,7 @@ qVP
 wSH
 hNO
 iCG
-hvU
+iCG
 iCG
 bnu
 wSH
@@ -80161,10 +80497,10 @@ anE
 nOX
 ijC
 rwR
-azW
+aJv
 hbH
 fXy
-bVH
+wUd
 iYH
 iYH
 iYH
@@ -80422,8 +80758,8 @@ qVP
 qVP
 wSH
 hNO
-hvU
-hvU
+iCG
+iCG
 iCG
 bnu
 wSH
@@ -80496,7 +80832,7 @@ mwV
 eDu
 mwV
 mwV
-xDb
+eTi
 qwb
 alr
 jJc
@@ -81034,17 +81370,17 @@ qVP
 qVP
 qVP
 wSH
-kis
-rpe
-rpe
-rpe
+fLI
+wIC
+wIC
+wIC
 wSH
 aUt
 eHv
 coK
-gpu
-rpe
-rpe
+xkM
+wIC
+wIC
 umN
 wSH
 qVP
@@ -81102,7 +81438,7 @@ qVP
 anE
 gRv
 gRv
-cUw
+xwJ
 sxL
 cYy
 anE
@@ -81194,15 +81530,15 @@ wSH
 osQ
 fLI
 wIC
-rpe
+wIC
 wSH
 cym
-rCI
+rQK
 rQK
 xkM
 xkM
 xkM
-gpu
+xkM
 wSH
 qVP
 wSH
@@ -81259,7 +81595,7 @@ qVP
 anE
 sxe
 nAx
-cUw
+xwJ
 vqU
 bro
 anE
@@ -81416,7 +81752,7 @@ qVP
 anE
 fDg
 mbe
-ror
+cUw
 wSD
 aqS
 anE
@@ -81429,8 +81765,8 @@ veo
 veo
 sFi
 nAH
-uDI
-pwG
+wtM
+wNW
 sNO
 dIR
 sFi
@@ -81508,7 +81844,7 @@ wSH
 gpz
 dEr
 gpz
-gpu
+xkM
 uwB
 jFR
 jFR
@@ -81516,11 +81852,11 @@ tBM
 uwB
 uwB
 uwB
-gpu
+xkM
 wSH
 kZN
 paC
-hUi
+niy
 vfL
 dSg
 qLV
@@ -81573,7 +81909,7 @@ qVP
 anE
 hTF
 tXB
-cUw
+xwJ
 vqU
 oJf
 anE
@@ -81665,7 +82001,7 @@ wSH
 wIC
 wIC
 wIC
-hUi
+niy
 niy
 xwY
 niy
@@ -81673,7 +82009,7 @@ niy
 niy
 niy
 niy
-wwt
+eVg
 vld
 pXo
 niy
@@ -81822,7 +82158,7 @@ wSH
 gpz
 gpz
 gpz
-hUi
+niy
 niy
 niy
 niy
@@ -81830,7 +82166,7 @@ niy
 niy
 nww
 niy
-wwt
+eVg
 vld
 niy
 niy
@@ -81979,7 +82315,7 @@ wSH
 wIC
 wIC
 wIC
-hUi
+niy
 niy
 niy
 niy
@@ -81987,7 +82323,7 @@ niy
 niy
 nww
 niy
-wwt
+eVg
 vld
 fMZ
 niy
@@ -82136,7 +82472,7 @@ wSH
 gpz
 gpz
 gpz
-hUi
+niy
 wSH
 dnI
 dnI
@@ -82144,7 +82480,7 @@ wSH
 niy
 nww
 niy
-wwt
+eVg
 vld
 bYP
 vhM
@@ -82450,7 +82786,7 @@ wSH
 hPU
 hvp
 jvP
-hUi
+niy
 wSH
 uqi
 uqi
@@ -82673,10 +83009,10 @@ anE
 nOX
 ijC
 nHL
-azW
+aJv
 hbH
 dVP
-tKm
+mou
 jKk
 jKk
 jKk
@@ -82932,11 +83268,11 @@ niy
 oQQ
 wSH
 xkM
-gpu
+xkM
 xkM
 wSH
-ePf
-qLV
+oGx
+bIn
 qzZ
 wSH
 qVP
@@ -83088,7 +83424,7 @@ niy
 niy
 oQQ
 wSH
-dSI
+xbM
 exj
 xbM
 wSH
@@ -83184,7 +83520,7 @@ tyr
 dmW
 hEO
 mui
-obj
+aLT
 vHE
 eEt
 qYZ
@@ -83646,7 +83982,7 @@ bYo
 kBk
 ruP
 bwu
-bgl
+gBa
 jaQ
 nAc
 wVk
@@ -83793,7 +84129,7 @@ fnR
 jfz
 hnk
 tQS
-bfq
+woq
 lqv
 rCd
 npi
@@ -84222,11 +84558,11 @@ qVP
 qVP
 wuy
 wuy
-dSu
-dSu
-dSu
-dSu
-dSu
+chP
+chP
+chP
+chP
+chP
 wuy
 wuy
 wuy
@@ -84298,7 +84634,7 @@ reE
 khL
 qbh
 qbh
-uyg
+mWE
 akB
 qyr
 qVP
@@ -84378,24 +84714,24 @@ wuy
 wuy
 wuy
 wuy
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+chP
+chP
 wuy
 wuy
 vRZ
@@ -84450,11 +84786,11 @@ vky
 vky
 vky
 vky
-fMx
+hyt
 vky
 tCw
 aQM
-kpP
+mfG
 nqY
 daa
 qyr
@@ -84531,29 +84867,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-dSu
-nBX
-nBX
-nBX
-nBX
-nBX
-nBX
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
+chP
+chP
+nOQ
+nOQ
+nOQ
+nOQ
+nOQ
+nOQ
+chP
+chP
+chP
+chP
+chP
+chP
+chP
 qnp
-nBX
-nBX
-nBX
-nBX
-nBX
-dSu
-dSu
+nOQ
+nOQ
+nOQ
+nOQ
+nOQ
+chP
+chP
 wuy
 vRZ
 bzI
@@ -84601,7 +84937,7 @@ uej
 bNV
 bNV
 bNV
-uyg
+mWE
 bNV
 bNV
 bNV
@@ -84609,7 +84945,7 @@ bNV
 bNV
 bNV
 bNV
-uyg
+mWE
 bNV
 bNV
 bNV
@@ -84688,29 +85024,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-nBX
+chP
+nOQ
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-dSu
-dSu
-dSu
+chP
+chP
+chP
 dsu
-dSu
-dSu
-dSu
+chP
+chP
+chP
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-nBX
-dSu
+nOQ
+chP
 wuy
 vRZ
 uho
@@ -84758,7 +85094,7 @@ vHk
 mct
 vmQ
 bHR
-uyg
+mWE
 qWQ
 qyr
 qyr
@@ -84766,7 +85102,7 @@ qyr
 qyr
 qyr
 uck
-uyg
+mWE
 daa
 qyr
 qyr
@@ -84845,29 +85181,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-nBX
-swY
-swY
-swY
-swY
-swY
-swY
-dSu
-dSu
-dSu
+chP
+nOQ
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+chP
+chP
+chP
 nGf
-dSu
-dSu
-dSu
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
-dSu
+chP
+chP
+chP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+nOQ
+chP
 wuy
 vRZ
 ham
@@ -84915,15 +85251,15 @@ qyr
 qyr
 qyr
 bHR
-eTF
-gwR
+hph
+fWl
 tWq
-diA
+ltp
 cVO
 weY
 qyr
 bHR
-uyg
+mWE
 daa
 qSo
 qSo
@@ -85002,14 +85338,14 @@ qVP
 qVP
 qVP
 wuy
-dSu
-nBX
-swY
-swY
-swY
-swY
-swY
-swY
+chP
+nOQ
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 gbS
 gbS
 gbS
@@ -85017,14 +85353,14 @@ dsu
 gbS
 gbS
 gbS
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
-dSu
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+nOQ
+chP
 wuy
 vRZ
 vRZ
@@ -85072,7 +85408,7 @@ kGp
 dSB
 aSO
 bHR
-uyg
+mWE
 qpF
 trI
 iee
@@ -85080,7 +85416,7 @@ qam
 fGV
 qyr
 bHR
-uyg
+mWE
 daa
 qKU
 qKU
@@ -85159,29 +85495,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-dSu
-swY
-swY
-swY
-swY
-swY
-swY
-dSu
-dSu
-dSu
+chP
+chP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+chP
+chP
+chP
 nGf
-dSu
-dSu
-dSu
-swY
-swY
-swY
-swY
-swY
-swY
-dSu
-dSu
+chP
+chP
+chP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+chP
+chP
 wuy
 qVP
 qVP
@@ -85224,12 +85560,12 @@ bJz
 wqD
 bJz
 bJz
-eOp
+kBg
 oqy
 oqy
-oab
+lMs
 bHR
-uyg
+mWE
 jYt
 qyr
 qyr
@@ -85237,7 +85573,7 @@ qyr
 qyr
 qyr
 tfu
-mWE
+fwp
 igw
 fpu
 fpu
@@ -85316,29 +85652,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-nBX
-swY
-swY
-swY
-swY
-swY
-swY
-dSu
-dSu
-dSu
+chP
+nOQ
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+chP
+chP
+chP
 nGf
-dSu
-dSu
-dSu
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
-dSu
+chP
+chP
+chP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+nOQ
+chP
 wuy
 qVP
 qVP
@@ -85374,27 +85710,27 @@ ohU
 wEZ
 wEZ
 lWL
-pfG
-pfG
+qUM
+qUM
 xPJ
-pfG
-pfG
-pfG
-pfG
-kVf
+qUM
+qUM
+qUM
+qUM
+mJG
 uSt
 kVO
-idt
+kVf
 sXZ
 bHX
-gwR
+fWl
 tWq
-diA
+ltp
 dHZ
 weY
 qyr
 bHR
-uyg
+mWE
 daa
 qKU
 qKU
@@ -85473,14 +85809,14 @@ qVP
 qVP
 qVP
 wuy
-dSu
-nBX
-swY
-swY
-swY
-swY
-swY
-swY
+chP
+nOQ
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 gbS
 gbS
 gbS
@@ -85488,13 +85824,13 @@ dsu
 gbS
 gbS
 gbS
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+nOQ
 gbS
 wuy
 qVP
@@ -85543,7 +85879,7 @@ qyr
 qyr
 qyr
 bHR
-uyg
+mWE
 lQE
 bqe
 iee
@@ -85551,7 +85887,7 @@ qam
 wYH
 qyr
 bHR
-uyg
+mWE
 daa
 jNW
 jNW
@@ -85630,28 +85966,28 @@ qVP
 qVP
 qVP
 wuy
-dSu
-nBX
-swY
-swY
-swY
-swY
-swY
-swY
-dSu
-dSu
-dSu
+chP
+nOQ
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+chP
+chP
+chP
 nGf
-dSu
-dSu
-dSu
-swY
-swY
-swY
-swY
-swY
-swY
-nBX
+chP
+chP
+chP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+nOQ
 dsu
 wuy
 qVP
@@ -85691,7 +86027,7 @@ rcl
 wUC
 aTw
 crJ
-xLY
+lxT
 svE
 crJ
 crJ
@@ -85708,7 +86044,7 @@ qyr
 qyr
 qyr
 uck
-odO
+fOb
 xIM
 pfC
 pXF
@@ -85787,28 +86123,28 @@ qVP
 qVP
 qVP
 wuy
-dSu
-dSu
-swY
-swY
-swY
-swY
-swY
-swY
-dSu
-dSu
-dSu
+chP
+chP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+chP
+chP
+chP
 nGf
-dSu
-dSu
-dSu
-swY
-swY
-swY
-swY
-swY
-swY
-dSu
+chP
+chP
+chP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+chP
 gbS
 wuy
 qVP
@@ -85852,20 +86188,20 @@ veP
 esC
 tdg
 dAi
-xLY
+lxT
 gPB
 qbh
 qbh
 bHR
-mWE
-gwR
+fwp
+fWl
 tWq
-diA
+ltp
 aTa
 weY
 qyr
 bHR
-uyg
+mWE
 daa
 qyr
 qyr
@@ -85944,14 +86280,14 @@ qVP
 qVP
 qVP
 wuy
-dSu
-lCi
-swY
-swY
-swY
-swY
-swY
-swY
+chP
+abd
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 gbS
 gbS
 gbS
@@ -85959,13 +86295,13 @@ dsu
 gbS
 gbS
 gbS
-swY
-swY
-swY
-swY
-swY
-swY
-dSu
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+chP
 gbS
 wuy
 qVP
@@ -86014,7 +86350,7 @@ vky
 vky
 vky
 vky
-dJM
+oDC
 lQE
 aII
 iee
@@ -86022,7 +86358,7 @@ qam
 hHl
 qyr
 bHR
-uyg
+mWE
 daa
 qbh
 qbh
@@ -86101,27 +86437,27 @@ qVP
 qVP
 qVP
 wuy
-dSu
-lCi
-fwp
+chP
+abd
 jeU
-unh
+qMP
+mCd
+qMP
+mCd
 jeU
-unh
-fwp
-dSu
-dSu
-dSu
+chP
+chP
+chP
 nGf
-dSu
-dSu
-dSu
-fwp
+chP
+chP
+chP
 jeU
-unh
+qMP
+mCd
+qMP
+mCd
 jeU
-unh
-fwp
 gbS
 gbS
 wuy
@@ -86158,7 +86494,7 @@ thc
 pJb
 pJb
 pJb
-pJb
+rep
 mpA
 wUC
 crJ
@@ -86166,12 +86502,12 @@ psI
 pnG
 bpE
 faw
-hgB
+xLY
 uej
 bNV
 bNV
 bHR
-uyg
+mWE
 hor
 qyr
 qyr
@@ -86179,12 +86515,12 @@ qyr
 qyr
 qyr
 uck
-dvw
-iix
-iix
-iix
-iix
-iix
+odO
+oHX
+oHX
+oHX
+oHX
+oHX
 cah
 ioB
 nPD
@@ -86261,10 +86597,10 @@ wuy
 wuy
 qQP
 lhT
-cIz
-cIz
-cIz
-cIz
+eHR
+eHR
+eHR
+eHR
 vTc
 qQP
 qQP
@@ -86274,10 +86610,10 @@ qQP
 qQP
 qQP
 pXJ
-drk
-drk
-drk
-drk
+jdI
+jdI
+jdI
+jdI
 rgW
 qQP
 wuy
@@ -86328,15 +86664,15 @@ qyr
 qyr
 qyr
 bHR
-mWE
-gwR
+fwp
+fWl
 tWq
-diA
+ltp
 fwd
 weY
 qyr
 bHR
-uyg
+mWE
 daa
 qnh
 qyr
@@ -86485,7 +86821,7 @@ vMZ
 gmr
 cPb
 oYf
-uyg
+mWE
 lQE
 tmp
 iee
@@ -86493,7 +86829,7 @@ qam
 kIo
 qyr
 bHR
-uyg
+mWE
 daa
 wAU
 sBj
@@ -86592,7 +86928,7 @@ isV
 tXh
 uzD
 bAy
-lzz
+rjT
 ogk
 qVP
 qVP
@@ -86642,7 +86978,7 @@ wie
 mny
 qyr
 bHR
-uyg
+mWE
 ebi
 qyr
 qyr
@@ -86650,7 +86986,7 @@ qyr
 qyr
 qyr
 uck
-uyg
+mWE
 daa
 mdl
 qyr
@@ -86749,7 +87085,7 @@ nzy
 sjI
 bIh
 lyZ
-dAF
+iBT
 rUa
 qVP
 qVP
@@ -86768,7 +87104,7 @@ dyb
 aUy
 vQq
 riy
-pmS
+inN
 ayu
 dUo
 bPG
@@ -86787,11 +87123,11 @@ hKc
 xZb
 wce
 fPN
-cPX
+rDy
 wce
 bbh
 hTw
-dLH
+fBC
 tml
 rCl
 ifc
@@ -86799,7 +87135,7 @@ efK
 bwU
 qyr
 bHR
-uyg
+mWE
 qbh
 gPB
 qbh
@@ -86807,7 +87143,7 @@ qbh
 qbh
 qbh
 qbh
-uyg
+mWE
 qbh
 qbh
 kFF
@@ -86907,7 +87243,7 @@ eIK
 kit
 edO
 hCO
-dUe
+pmS
 qVP
 qVP
 qVP
@@ -86957,17 +87293,17 @@ nGw
 qyr
 nDq
 xLA
-iix
+oHX
 ejX
-kpP
-cPn
-kpP
-kpP
-kpP
-pqx
-kpP
-kpP
 mfG
+cPn
+mfG
+mfG
+mfG
+pqx
+mfG
+mfG
+uCr
 wmg
 ust
 qyr
@@ -87064,7 +87400,7 @@ jiK
 iMZ
 blO
 cTo
-dUe
+pmS
 qVP
 qVP
 qVP
@@ -87124,7 +87460,7 @@ bNV
 vrG
 bNV
 bNV
-gTX
+uSr
 bNV
 bNV
 qyr
@@ -87219,8 +87555,8 @@ qMD
 gGE
 sVe
 yim
-jCN
-rnQ
+gqh
+dAF
 dOf
 qVP
 qVP
@@ -87752,7 +88088,7 @@ dTg
 dTg
 dTg
 cmX
-azf
+iiX
 isb
 tsI
 wCo
@@ -87880,7 +88216,7 @@ dUo
 dUo
 dUo
 vVQ
-uYo
+hIo
 iGp
 dUo
 onl
@@ -87901,7 +88237,7 @@ lJw
 cFv
 syO
 pgS
-abd
+cOq
 joj
 woI
 eZS
@@ -88332,9 +88668,9 @@ uxc
 wCJ
 vVb
 vVb
-bYx
-bYx
-bYx
+hjz
+hjz
+hjz
 mUn
 mUn
 mUn
@@ -88467,11 +88803,11 @@ xth
 xth
 xth
 xth
-xIL
+uVg
+azW
+azW
+gzn
 eIL
-eIL
-upb
-ygs
 xth
 fdA
 uOG
@@ -88487,12 +88823,12 @@ aNP
 aAq
 aGd
 aGd
-tQQ
+trK
 kPt
 oyt
 egd
 kNZ
-yjX
+khU
 mUn
 mUn
 mUn
@@ -88627,7 +88963,7 @@ cNx
 aJZ
 llM
 gMP
-tkh
+hff
 tEB
 xth
 rRW
@@ -88639,17 +88975,17 @@ xdT
 sun
 ajy
 gWu
-dEQ
+dJx
 ghX
 ojj
 qAi
 vVb
-qly
+tQQ
 pWI
-ldv
-ldv
-ldv
-aBf
+bYx
+bYx
+bYx
+guQ
 mUn
 dpz
 mUn
@@ -88673,22 +89009,22 @@ uME
 nLC
 qyR
 lzq
-cOX
+ldv
 cBm
 xki
-flr
-flr
-flr
-hyS
-mUx
-flr
-flr
+tcX
+tcX
+tcX
+rcj
+cOX
+tcX
+tcX
 tcQ
 dLA
-flr
 tcX
-flr
-flr
+rpe
+tcX
+tcX
 vwt
 tup
 vmf
@@ -88784,7 +89120,7 @@ bUh
 oRx
 tYl
 hpF
-vOt
+bkE
 iVk
 xth
 nCJ
@@ -88796,7 +89132,7 @@ lSF
 gOY
 mHD
 nPN
-tNh
+uXf
 icl
 ojj
 tit
@@ -88806,7 +89142,7 @@ iqB
 gvY
 pkg
 cqi
-aBf
+guQ
 jDd
 dxU
 tsG
@@ -88831,7 +89167,7 @@ ngP
 oYw
 rPR
 kCq
-ffw
+iix
 kCq
 jpQ
 kCq
@@ -88963,7 +89299,7 @@ smA
 gvY
 mUn
 mUn
-aBf
+guQ
 lch
 gvY
 gvY
@@ -89110,7 +89446,7 @@ cLU
 cLU
 ojj
 hFY
-dEQ
+dJx
 dJK
 ojj
 gFX
@@ -89119,8 +89455,8 @@ gFX
 gFX
 gFX
 kih
-ija
-bPf
+tmU
+aBf
 fsT
 gvY
 qVP
@@ -89136,7 +89472,7 @@ pLY
 ccd
 jML
 cwa
-wHt
+mAD
 jlM
 uwQ
 gqi
@@ -89175,8 +89511,8 @@ qtY
 eet
 vEb
 val
+jDZ
 jRe
-imS
 bfm
 xKp
 qVP
@@ -89267,7 +89603,7 @@ fpO
 gsG
 tuG
 xbE
-dEQ
+dJx
 eFo
 iNX
 pIx
@@ -89407,16 +89743,16 @@ kDP
 kDP
 kDP
 kDP
-kpk
-kpk
 eCA
-kpk
-kpk
+eCA
+yhZ
+eCA
+eCA
 pAx
 gbr
 pSi
 ukz
-cOO
+rxm
 tfP
 hPr
 jgb
@@ -89424,7 +89760,7 @@ fBA
 tfj
 eFj
 mcE
-koP
+dEQ
 avK
 uiB
 pIx
@@ -89633,18 +89969,18 @@ xCy
 wbK
 oEA
 vmh
-flr
+tcX
 qcz
 nOt
-flr
+tcX
 aur
-flr
-flr
-flr
-flr
-flr
-flr
-flr
+tcX
+tcX
+tcX
+tcX
+tcX
+tcX
+tcX
 kCT
 pWM
 cON
@@ -89715,7 +90051,7 @@ gsG
 jIe
 kxC
 ccb
-aPX
+xEU
 ccb
 rib
 hmJ
@@ -89738,7 +90074,7 @@ djs
 djs
 ojj
 hFY
-dEQ
+dJx
 dJK
 ojj
 pIx
@@ -89794,7 +90130,7 @@ izF
 sPc
 kCq
 kCq
-ffw
+iix
 kCq
 fqY
 kCq
@@ -89871,9 +90207,9 @@ qVP
 gsG
 gsG
 gsG
-efO
+oTJ
 adK
-izE
+sPk
 gsG
 gsG
 pMH
@@ -89892,7 +90228,7 @@ sSt
 pmf
 jto
 xtH
-jdI
+upb
 fRQ
 xbE
 wmL
@@ -90021,7 +90357,7 @@ rqy
 rqy
 rqy
 rqy
-qhR
+uGU
 rqy
 qVP
 qVP
@@ -90040,7 +90376,7 @@ gsG
 gsG
 oBx
 ccb
-oqg
+aPX
 ccb
 ubN
 xnC
@@ -90049,7 +90385,7 @@ nJs
 jSE
 kPV
 mXQ
-jdI
+upb
 ktu
 xbE
 wmL
@@ -90178,7 +90514,7 @@ qVP
 rqy
 eSR
 rqy
-sEX
+wrl
 jnM
 qVP
 qVP
@@ -90489,8 +90825,8 @@ rqy
 rqy
 rqy
 rqy
-jIq
-wYn
+tvi
+yci
 rqy
 wyu
 qVP
@@ -90520,10 +90856,10 @@ huG
 aYV
 mrm
 upl
-jdI
+upb
 mKE
 jqC
-dEQ
+dJx
 jzk
 uiB
 pIx
@@ -90643,9 +90979,9 @@ qVP
 rqy
 rqy
 rqy
-gQj
-nMG
-xLd
+kHh
+ocO
+gKK
 rqy
 rqy
 rqy
@@ -90677,10 +91013,10 @@ rDV
 iAC
 fRC
 bmS
-jdI
+upb
 pIG
 kNf
-ezg
+imS
 lwr
 hPz
 xwH
@@ -90989,10 +91325,10 @@ cMl
 oaV
 vBz
 pee
-bhY
+bAk
 jgI
 cAY
-sDh
+ugs
 oTl
 sRF
 sRF
@@ -91111,7 +91447,7 @@ qVP
 rqy
 rqy
 tuc
-wrl
+oDD
 qVP
 qVP
 qVP
@@ -91145,11 +91481,11 @@ vPr
 ebH
 fjl
 hfM
-utg
-dhS
+oQo
+sWD
 tKf
 jYX
-urW
+dzP
 qoR
 sRF
 keh
@@ -91184,11 +91520,11 @@ qgi
 uMo
 epq
 djC
-tIj
-tIj
-tIj
-tIj
-tIj
+mBv
+mBv
+mBv
+mBv
+mBv
 djC
 maK
 fpH
@@ -91201,7 +91537,7 @@ lrx
 xxC
 xxC
 rlA
-tIj
+mBv
 xxC
 uKh
 lhm
@@ -91268,7 +91604,7 @@ qVP
 rqy
 rqy
 tuc
-qhR
+uGU
 qVP
 qVP
 qVP
@@ -91317,7 +91653,7 @@ wDy
 rkU
 vQi
 rkU
-gGD
+suG
 pZv
 sxj
 wDV
@@ -91425,7 +91761,7 @@ qVP
 rqy
 rqy
 tuc
-ocO
+iol
 qVP
 qVP
 qVP
@@ -91455,7 +91791,7 @@ mpT
 eGf
 gkJ
 jZb
-aJA
+gLi
 kEE
 ebH
 kRQ
@@ -91474,7 +91810,7 @@ fDt
 rbK
 rbK
 rbK
-vNq
+mtB
 pZv
 sxj
 eLJ
@@ -91583,7 +91919,7 @@ qVP
 qVP
 rqy
 rqy
-ebu
+rOt
 qVP
 qVP
 qVP
@@ -91612,8 +91948,8 @@ anZ
 eGf
 eAg
 sxb
-ouq
-rlW
+cyz
+nEm
 gkJ
 eAg
 feG
@@ -91740,7 +92076,7 @@ qVP
 qVP
 qVP
 rqy
-lWk
+mzA
 rqy
 rqy
 rqy
@@ -91770,7 +92106,7 @@ exz
 hFC
 gQv
 tfU
-vrp
+lqp
 ohb
 ebH
 mbT
@@ -91898,7 +92234,7 @@ rqy
 qVP
 qVP
 rqy
-ebu
+rOt
 rqy
 rqy
 rqy
@@ -92374,7 +92710,7 @@ qVP
 qVP
 rqy
 rHU
-qhR
+uGU
 rqy
 rqy
 rqy
@@ -92531,7 +92867,7 @@ qVP
 qVP
 qVP
 rHU
-qhR
+uGU
 rqy
 rqy
 rqy
@@ -92688,7 +93024,7 @@ qVP
 qVP
 iHy
 ruE
-yit
+cPN
 rqy
 rqy
 rqy
@@ -92730,7 +93066,7 @@ rkX
 bkg
 ieE
 ijk
-qHf
+sCc
 rkU
 sxj
 puN
@@ -92843,9 +93179,9 @@ rqy
 rqy
 rqy
 rqy
-qhR
+uGU
 rEA
-jrY
+quR
 rEA
 rEA
 sIt
@@ -92872,7 +93208,7 @@ naE
 mCH
 dvF
 hHs
-aEF
+pfG
 dwU
 blf
 blf
@@ -92881,7 +93217,7 @@ woN
 bDj
 bnW
 vwd
-haR
+tuw
 eDU
 rkX
 wzw
@@ -93000,9 +93336,9 @@ rqy
 rqy
 rqy
 rqy
-qhR
+uGU
 rek
-vMn
+yfg
 jJJ
 wAN
 sIt
@@ -93039,12 +93375,12 @@ mbT
 jpS
 vwd
 jaR
-aYP
+haR
 eYu
 eYu
 qXg
 cAk
-qHf
+sCc
 bvP
 sxj
 eaH
@@ -93087,7 +93423,7 @@ jhV
 bid
 bUP
 nLV
-snt
+dlp
 sAH
 edX
 xRl
@@ -93157,12 +93493,12 @@ qVP
 rqy
 rqy
 rqy
-aMR
+tih
 rEA
-nGv
-jBo
 oYE
-quR
+jBo
+afD
+uVx
 ruE
 ieM
 rqy
@@ -93228,11 +93564,11 @@ dHN
 dHN
 kXb
 sTl
-xsj
-iJI
-xsj
-xsj
 bcm
+sKj
+bcm
+bcm
+tkM
 cMP
 cMP
 mhi
@@ -93314,7 +93650,7 @@ qVP
 rqy
 tuc
 tuc
-qhR
+uGU
 rEA
 aQr
 oXp
@@ -93680,7 +94016,7 @@ yio
 yio
 yio
 yio
-fBE
+gAY
 rDZ
 fEk
 vDP
@@ -93846,7 +94182,7 @@ fVs
 sBp
 soj
 juy
-dka
+oEb
 iGp
 wZK
 snn
@@ -94295,12 +94631,12 @@ hHi
 hHi
 rTI
 rWq
-qSC
+kpP
 rWq
 fwj
 qIi
-hMH
-hMH
+nMG
+nMG
 cFk
 faY
 qVP
@@ -94607,14 +94943,14 @@ xJv
 hqp
 xTj
 qwA
-uGU
+juQ
 xNF
 eBq
 aKq
 faY
 pDD
 wgO
-hMH
+nMG
 pYw
 faY
 fPT
@@ -94764,7 +95100,7 @@ uaC
 hqp
 rSF
 kAv
-stk
+iCe
 hgV
 rlP
 mHv
@@ -94790,7 +95126,7 @@ kyw
 gNo
 rAl
 uXc
-sPk
+xLC
 fDQ
 riO
 pkp
@@ -94921,7 +95257,7 @@ uaC
 hqp
 xgO
 kAv
-dzg
+fdT
 wcV
 jSw
 rQc
@@ -94933,7 +95269,7 @@ olg
 faY
 otF
 rkU
-rDI
+pVC
 rkU
 rkU
 gmN
@@ -95079,9 +95415,9 @@ hqp
 kAg
 pug
 akZ
-eWy
-dCz
-fdT
+vKJ
+vMc
+rkA
 faY
 ktR
 bbF
@@ -95104,7 +95440,7 @@ kxK
 kgC
 iTo
 uXc
-vmK
+uQx
 pcA
 bVG
 qhu
@@ -95261,7 +95597,7 @@ kxK
 lcv
 rAl
 ayx
-xLC
+uxL
 tiS
 dVm
 rIm
@@ -95561,7 +95897,7 @@ iel
 iel
 iel
 iel
-mou
+dwN
 eCC
 njj
 wYA
@@ -95718,7 +96054,7 @@ odc
 odc
 odc
 odc
-qAY
+eyJ
 tXH
 njj
 ncl
@@ -95908,7 +96244,7 @@ fCw
 fUt
 trT
 aes
-iol
+qly
 swv
 qUq
 sCq
@@ -96032,7 +96368,7 @@ uxN
 uxN
 uxN
 uxN
-mou
+dwN
 eCC
 njj
 tNe
@@ -96065,7 +96401,7 @@ swv
 swv
 iUp
 swv
-iol
+qly
 swv
 tij
 pvL
@@ -96189,7 +96525,7 @@ iJv
 iJv
 iJv
 iJv
-qAY
+eyJ
 aWW
 jfn
 bev
@@ -96222,7 +96558,7 @@ icC
 icC
 itU
 icC
-tKq
+cPe
 swv
 tij
 pvL
@@ -96346,7 +96682,7 @@ iXU
 ivg
 iXU
 ueC
-ihP
+bNj
 hfD
 wHF
 cvC
@@ -96362,11 +96698,11 @@ dZO
 sAo
 sAo
 oZq
-ktN
+yeQ
 rrw
-oDX
+hfy
 vtr
-pwU
+evE
 lOB
 cgv
 wEk
@@ -96503,7 +96839,7 @@ iel
 iel
 iel
 iel
-mou
+dwN
 eCC
 jfn
 bev
@@ -96521,7 +96857,7 @@ sAo
 kYq
 cCP
 mBt
-jpV
+diA
 fzw
 xew
 eGW
@@ -96536,7 +96872,7 @@ swv
 swv
 swv
 swv
-iol
+qly
 swv
 tij
 pvL
@@ -96660,7 +96996,7 @@ odc
 odc
 odc
 odc
-qAY
+eyJ
 aWW
 njj
 tNe
@@ -96693,7 +97029,7 @@ lHv
 swv
 lty
 swv
-iol
+qly
 swv
 tij
 pvL
@@ -96835,7 +97171,7 @@ sej
 lmF
 aLW
 ayy
-phP
+wNp
 tVH
 tMP
 vrC
@@ -96850,7 +97186,7 @@ juz
 xNd
 trT
 aes
-iol
+qly
 swv
 gbi
 oFO
@@ -96974,7 +97310,7 @@ uxN
 uxN
 uxN
 uxN
-mou
+dwN
 xdQ
 njj
 ncl
@@ -97007,7 +97343,7 @@ swv
 swv
 swv
 swv
-iol
+qly
 swv
 swv
 swv
@@ -97131,7 +97467,7 @@ iJv
 iJv
 iJv
 iJv
-qAY
+eyJ
 aWW
 njj
 fjW
@@ -97164,14 +97500,14 @@ icC
 icC
 icC
 icC
-wpg
+tKq
 ngl
 ngl
 ngl
 ngl
 ngl
 ngl
-mYN
+jkF
 jpF
 shR
 oQR
@@ -97316,19 +97652,19 @@ lLU
 nyU
 nyU
 nyU
-pPq
-jtr
+xKt
+vqq
 qcm
 nyU
 eFY
-iol
+qly
 xFe
 ilB
 evb
 swv
 xFe
 ghq
-ewa
+wpg
 swv
 shR
 lXt
@@ -97441,24 +97777,24 @@ jfn
 iel
 hKR
 cpt
-wtM
+dSu
 qgU
-wtM
-wtM
-jOG
+dSu
+dSu
+vWE
 dtP
 njj
 qwK
+aSt
 kyb
-fdE
 pmL
 vNP
 rsD
 eHS
 cCT
-ifH
-ifH
-ldF
+cKw
+cKw
+qTm
 rKt
 hSX
 lVO
@@ -97478,14 +97814,14 @@ tuB
 peY
 nyU
 swv
-iol
+qly
 evb
 swv
 xFe
 swv
 xFe
 swv
-rXD
+qAY
 ngl
 qno
 qbt
@@ -97615,34 +97951,34 @@ rKt
 rKt
 rKt
 rKt
-xwJ
+ldF
 mNP
 mNP
 rUg
 cml
-rjR
+fKB
 lkQ
 lVO
 nHM
+vAq
 xsQ
-bcN
 jyy
 nyU
 brk
 syb
 pCw
 oUk
-qAU
+wQS
 tmW
 ngl
-aJv
+eOt
 xFe
 swv
 evb
 swv
 evb
 swv
-gAR
+mmH
 swv
 shR
 qIY
@@ -97782,7 +98118,7 @@ vkm
 lVO
 kiq
 jjG
-chP
+rDI
 uTS
 cHJ
 hpz
@@ -97939,7 +98275,7 @@ igF
 lVO
 vpw
 sVG
-chP
+rDI
 sIH
 uLy
 mCX
@@ -98096,9 +98432,9 @@ tXl
 lVO
 dsg
 imT
-chP
+rDI
 sIH
-amf
+uQN
 wGC
 fts
 lue
@@ -98253,12 +98589,12 @@ lVO
 lVO
 iaO
 iaO
-chP
+rDI
 sIH
-pvC
+swY
 sUB
 xMe
-uNE
+sZZ
 rIL
 kLy
 nyU
@@ -98410,7 +98746,7 @@ pzZ
 lVO
 fLK
 xzt
-chP
+rDI
 sIH
 nyU
 nyU
@@ -98566,7 +98902,7 @@ oqG
 vYd
 sfB
 vvK
-uuS
+oWK
 mUd
 hGw
 lLU
@@ -98896,8 +99232,8 @@ iQt
 qBi
 ijm
 txt
+vCR
 jpj
-wur
 piB
 piB
 txt
@@ -99033,7 +99369,7 @@ ney
 mRg
 cxq
 rAb
-lcL
+wxK
 xUf
 xOZ
 qpB
@@ -99053,7 +99389,7 @@ hvt
 owQ
 nZZ
 txt
-ycY
+gwR
 sQY
 gYJ
 gYJ
@@ -99973,9 +100309,9 @@ oQX
 hJT
 xkY
 lyW
-wxK
+nBX
 mQm
-qUM
+bge
 sNc
 oje
 bID
@@ -101074,7 +101410,7 @@ xlt
 tAk
 fDi
 ixd
-qMP
+cHQ
 xUf
 cpf
 bLY
@@ -101854,7 +102190,7 @@ xlt
 bum
 uhl
 qYJ
-uSu
+qXx
 xlt
 rcd
 uQt
@@ -102015,8 +102351,8 @@ drM
 xlt
 cxa
 eph
-xeG
-kjn
+pep
+pvO
 sxh
 cpf
 gTq
@@ -103585,8 +103921,8 @@ rqy
 rqy
 muO
 rfo
-mCd
-rFk
+qLd
+rlW
 muO
 rqy
 rfo
@@ -103742,7 +104078,7 @@ rqy
 rqy
 rqy
 rfo
-fBC
+gpu
 aQP
 rqy
 rqy
@@ -103899,7 +104235,7 @@ rqy
 rqy
 rqy
 rfo
-fBC
+gpu
 aQP
 rqy
 rqy
@@ -104056,7 +104392,7 @@ qVP
 rqy
 rqy
 rfo
-fBC
+gpu
 aQP
 rqy
 rqy
@@ -104213,7 +104549,7 @@ qVP
 qVP
 rqy
 rfo
-fBC
+gpu
 aQP
 rqy
 rqy
@@ -104370,7 +104706,7 @@ qVP
 rqy
 rqy
 rfo
-fBC
+gpu
 aQP
 rqy
 rqy
@@ -104527,7 +104863,7 @@ qVP
 rqy
 rqy
 rfo
-fBC
+gpu
 aQP
 rqy
 rqy
@@ -104684,7 +105020,7 @@ qVP
 qVP
 rqy
 rfo
-fBC
+gpu
 aQP
 bbq
 rqy
@@ -104841,7 +105177,7 @@ qVP
 rqy
 rqy
 rfo
-fBC
+gpu
 aQP
 bbq
 rqy
@@ -104998,7 +105334,7 @@ rqy
 jKh
 rqy
 rfo
-fBC
+gpu
 aQP
 bbq
 rqy
@@ -105155,7 +105491,7 @@ rqy
 rqy
 rqy
 rfo
-fBC
+gpu
 aQP
 rqy
 rqy
@@ -105313,7 +105649,7 @@ rqy
 rqy
 rfo
 xHF
-qME
+nwl
 rqy
 rqy
 rqy
@@ -105470,7 +105806,7 @@ rfo
 rfo
 rfo
 bPH
-nMR
+vwz
 rfo
 rfo
 rfo
@@ -105627,7 +105963,7 @@ rfo
 rfo
 rfo
 bPH
-nMR
+vwz
 rfo
 rfo
 rfo
@@ -105783,8 +106119,8 @@ bbq
 rqy
 rqy
 rfo
-flF
-rFk
+bnC
+rlW
 rqy
 rqy
 rqy
@@ -105940,7 +106276,7 @@ rqy
 rqy
 rqy
 rfo
-fBC
+gpu
 aQP
 rqy
 rqy
@@ -108288,14 +108624,14 @@ lxu
 iAy
 thU
 aiw
-feD
-feD
-feD
-feD
-feD
-feD
-feD
-bFI
+xvI
+xvI
+xvI
+xvI
+xvI
+xvI
+xvI
+kis
 lxu
 lxu
 lxu
@@ -108452,7 +108788,7 @@ oaR
 oaR
 lxu
 lxu
-xvI
+aaw
 lxu
 lxu
 qef
@@ -113945,7 +114281,7 @@ wuy
 kBk
 dlm
 fLk
-dJx
+leg
 uFg
 lse
 lse
@@ -114576,7 +114912,7 @@ wuy
 kBk
 avB
 pOx
-pVu
+mAh
 dRt
 bUr
 noU
@@ -115215,8 +115551,8 @@ tcx
 lMF
 gUT
 cPy
-sjv
-eIj
+xRa
+hvU
 sjv
 uAD
 aRk
@@ -115373,7 +115709,7 @@ lMF
 unu
 thP
 eIj
-cPy
+ffw
 wtN
 hwG
 lSo
@@ -115383,7 +115719,7 @@ hwG
 goF
 tgq
 fzN
-qfF
+ako
 pAc
 bOE
 vvm
@@ -115540,7 +115876,7 @@ pyk
 pvH
 pYv
 aLQ
-otp
+qfF
 pAc
 bOE
 nRK
@@ -115686,7 +116022,7 @@ dSG
 khV
 lRE
 eqx
-bHF
+xSa
 lGt
 uDQ
 fOy
@@ -115835,7 +116171,7 @@ ong
 ong
 ong
 ong
-nyo
+idt
 fIk
 xpQ
 iOi
@@ -115843,8 +116179,8 @@ qUK
 qUK
 qUK
 rsk
-rKO
-nPd
+ewa
+dQi
 dZB
 kGY
 kZg
@@ -115992,7 +116328,7 @@ ong
 ong
 ong
 ong
-nyo
+svP
 bqk
 sRj
 hQq
@@ -116001,8 +116337,8 @@ sRj
 gva
 dhn
 rKO
-dQi
-dZB
+pty
+rVD
 kGY
 kZg
 uSd
@@ -116012,7 +116348,7 @@ wuy
 wuy
 jfa
 vVU
-pKq
+hTT
 wuT
 wuT
 mkD
@@ -116149,9 +116485,9 @@ ong
 ong
 ong
 ong
-nyo
+tiD
 vTH
-sRj
+ygs
 qrX
 nDr
 sRj
@@ -116159,7 +116495,7 @@ gva
 aqO
 xpF
 dQi
-dZB
+vmK
 kGY
 kZg
 uSd
@@ -116306,9 +116642,9 @@ ong
 ong
 ong
 ong
-nyo
+kzg
 eHr
-sRj
+rTT
 dzm
 xtQ
 sRj
@@ -116465,7 +116801,7 @@ ozh
 ozh
 nyo
 dUU
-sRj
+rTT
 bPD
 bPD
 sRj
@@ -116630,7 +116966,7 @@ mYe
 gva
 gEz
 dQi
-dZB
+rFO
 kGY
 kZg
 uSd
@@ -116777,9 +117113,9 @@ wZN
 wZN
 wZN
 wZN
-nyo
+idt
 bgk
-qjg
+rTT
 hQq
 hQq
 sRj
@@ -116934,15 +117270,15 @@ ong
 ong
 ong
 ong
-nyo
+svP
 vCL
-qjg
+rTT
 nOI
 awd
 sRj
 gva
 dQi
-bHF
+xSa
 dQi
 uDQ
 iIN
@@ -117091,15 +117427,15 @@ ong
 ong
 ong
 ong
-nyo
+tiD
 vTH
-qjg
+tNh
 xmx
 iRu
 sRj
 gva
 dQi
-bHF
+xSa
 dQi
 dZB
 kGY
@@ -117248,17 +117584,17 @@ ong
 ong
 ong
 ong
-nyo
+kzg
 xYs
-qjg
+rTT
 bPD
 bPD
 sRj
 gva
 dwy
 bHF
-dQi
-dZB
+pty
+hHG
 kGY
 kZg
 aTj
@@ -117407,15 +117743,15 @@ ong
 ong
 nyo
 bfG
-qjg
+xIi
 bbp
 qjg
-qjg
+mxJ
 qjg
 ocJ
-bHF
-nPd
-dZB
+elN
+dQi
+vmK
 kGY
 kZg
 aTj
@@ -117570,7 +117906,7 @@ pyY
 eON
 rui
 kTe
-bHF
+xSa
 lHc
 uDQ
 kGY
@@ -117582,10 +117918,10 @@ kRE
 bmz
 bmz
 bmz
+cLC
 jbI
-vwz
-vwz
-vwz
+jbI
+jbI
 ikZ
 fyZ
 rKj
@@ -117745,7 +118081,7 @@ mpQ
 mpQ
 eJO
 mpQ
-nOQ
+eYM
 bCA
 qhL
 qhL
@@ -117901,8 +118237,8 @@ pyh
 ctS
 ctS
 pyh
-rOW
-gqG
+nID
+qtJ
 jfa
 czR
 ggl
@@ -118053,13 +118389,13 @@ prI
 pVm
 pyh
 oer
-qLI
+lAk
 uuA
 qGr
 qQy
 pyh
 mpQ
-nOQ
+eYM
 mpQ
 mpQ
 mpQ
@@ -118210,16 +118546,16 @@ aDi
 jlE
 pyh
 hyP
-lAk
+pmQ
 hch
 hch
 hQX
 pyh
 mpQ
-eYM
+mKV
 xbH
 eWW
-nmy
+iXR
 uUC
 mpQ
 jfa
@@ -118348,7 +118684,7 @@ bRD
 aFR
 tHh
 ydj
-fAI
+dSI
 bbC
 uDQ
 mos
@@ -118530,7 +118866,7 @@ sxJ
 jXz
 pyh
 mpQ
-sDX
+uyg
 cPJ
 tdy
 hFz
@@ -118690,7 +119026,7 @@ jjd
 xpH
 cPJ
 ncG
-rir
+jyb
 pzN
 cPJ
 wuy

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -158,16 +158,24 @@
 /area/station/engineering/atmos)
 "adK" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Storage";
 	req_access_txt = "10"
 	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "aes" = (
@@ -247,11 +255,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "ahD" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "ahQ" = (
@@ -982,11 +992,19 @@
 	},
 /obj/effect/landmark/navigate_destination/tcomms,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
+"aAT" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "aAU" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor,
@@ -1005,7 +1023,9 @@
 	},
 /area/station/hallway/primary/port)
 "aBf" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "aBg" = (
@@ -1135,11 +1155,13 @@
 	name = "Atmospherics Monitoring";
 	req_access_txt = "24"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "aEX" = (
@@ -1158,9 +1180,11 @@
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/starboard/upper)
 "aGd" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
 "aGC" = (
@@ -1379,9 +1403,11 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "aNP" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "aOh" = (
@@ -1440,7 +1466,6 @@
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse)
 "aPX" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -1455,7 +1480,9 @@
 /area/station/engineering/atmos)
 "aQr" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "aQw" = (
@@ -1841,7 +1868,6 @@
 	dir = 8
 	},
 /obj/machinery/fax_machine,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/machinery/power/data_terminal,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
@@ -2126,8 +2152,10 @@
 	pixel_x = 4
 	},
 /obj/machinery/telephone/engineering,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "bgk" = (
@@ -2278,7 +2306,9 @@
 /area/aegis/surface)
 "blf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "blr" = (
@@ -2355,8 +2385,9 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "bmY" = (
@@ -2400,7 +2431,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "boh" = (
@@ -2752,6 +2785,11 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
+"bxx" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "bxG" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/food_or_drink/refreshing_beverage,
@@ -2997,7 +3035,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "bDz" = (
@@ -3221,10 +3261,12 @@
 	},
 /area/station/hallway/primary/port)
 "bKN" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "bKS" = (
@@ -3767,6 +3809,9 @@
 /area/station/cargo/warehouse/upper)
 "bYx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
 "bYy" = (
@@ -4331,9 +4376,11 @@
 /area/station/tcommsat/server)
 "cql" = (
 /obj/structure/chair/office,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
@@ -4471,8 +4518,13 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "ctA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
 "ctS" = (
@@ -4498,7 +4550,9 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "cuM" = (
@@ -4742,8 +4796,11 @@
 "cAY" = (
 /obj/structure/table,
 /obj/machinery/telephone/engineering,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "cAZ" = (
@@ -4823,10 +4880,12 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "cDn" = (
@@ -4928,11 +4987,13 @@
 /turf/open/floor/deadspace/cable_start,
 /area/misc/testroom)
 "cGm" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "cGB" = (
@@ -5057,6 +5118,11 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
+"cIu" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "cIF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5826,15 +5892,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/area/station/engineering/atmos)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -6163,7 +6226,9 @@
 "dsu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
-/turf/open/misc/asteroid,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "dsJ" = (
 /turf/open/floor/deadspace/random/maint_center,
@@ -6265,7 +6330,9 @@
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "dxn" = (
@@ -6331,9 +6398,11 @@
 /area/station/engineering/atmos)
 "dyS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "dyV" = (
@@ -6520,7 +6589,9 @@
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/delivery,
 /obj/item/clothing/glasses/meson/engine,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "dEb" = (
@@ -6564,6 +6635,9 @@
 "dEQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "dFA" = (
@@ -6742,11 +6816,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "dJx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
@@ -6864,6 +6939,9 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
 "dOf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "dOx" = (
@@ -6959,8 +7037,10 @@
 	dir = 8;
 	network = "tcommsat"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
 "dRE" = (
@@ -7598,7 +7678,15 @@
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/engine_smes)
 "egd" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/server)
 "egf" = (
@@ -7704,7 +7792,6 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering - Desk"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
@@ -7849,6 +7936,10 @@
 "eoM" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/central)
+"eoO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "eoV" = (
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
@@ -8024,6 +8115,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"eva" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "evb" = (
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/deadspace/random/rectangles,
@@ -8235,10 +8333,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "eAV" = (
-/obj/machinery/light/floor/has_bulb,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "eBa" = (
 /obj/structure/railing{
 	dir = 8
@@ -8288,9 +8387,11 @@
 /area/station/maintenance/fore/lesser)
 "eCA" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "eCC" = (
@@ -8422,11 +8523,13 @@
 	id = "Engineering";
 	name = "Engineering Security Doors"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "eFm" = (
@@ -8494,9 +8597,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "eGt" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "eGC" = (
@@ -8606,7 +8711,6 @@
 /area/station/engineering/supermatter/room)
 "eIL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/engineering/monitoring)
 "eIZ" = (
@@ -9307,8 +9411,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
@@ -9461,8 +9563,8 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
 "fjl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 10
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
@@ -9555,7 +9657,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "fkY" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/misc/testroom)
 "flj" = (
@@ -9588,6 +9692,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"flF" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "flJ" = (
 /obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron/dark,
@@ -9644,6 +9757,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/miningoffice)
+"fnw" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "fnQ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/box,
@@ -10065,10 +10187,12 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "fBC" = (
@@ -10138,7 +10262,6 @@
 /area/station/maintenance/starboard/aft)
 "fDO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -10410,9 +10533,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
 "fNB" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/monitoring)
@@ -10587,12 +10715,13 @@
 /area/aegis/surface)
 "fRC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/firealarm/directional/east,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
@@ -10697,7 +10826,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
 "fUt" = (
@@ -10796,6 +10927,15 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
+"fXL" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "fXZ" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Cold Room";
@@ -10943,15 +11083,21 @@
 /area/station/medical/medbay/aft)
 "gbr" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "gbS" = (
-/obj/structure/lattice,
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "gcw" = (
 /obj/machinery/door/airlock/mining{
 	dir = 1;
@@ -11404,9 +11550,15 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/misc/asteroid,
-/area/station/solars/port/fore)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -11577,12 +11729,15 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "gxI" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_center,
@@ -11654,7 +11809,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "gzE" = (
@@ -11700,8 +11854,9 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
 "gAZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+	power_setting = 50
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "gBe" = (
@@ -11712,7 +11867,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/modular_computer/console/preset/engineering,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
@@ -11816,6 +11970,13 @@
 	},
 /turf/open/floor/engine/airless,
 /area/station/engineering/supermatter/room)
+"gEy" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "gEz" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
@@ -11948,9 +12109,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "gKI" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
@@ -12089,9 +12252,11 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
 "gPk" = (
@@ -12431,7 +12596,6 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "gWu" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
@@ -12455,7 +12619,10 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "gXh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
+	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "gXk" = (
@@ -12740,8 +12907,8 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hfM" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	initialize_directions = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Distro to Waste"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
@@ -13049,12 +13216,14 @@
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
 "hqb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "hqn" = (
@@ -13083,7 +13252,6 @@
 "hqS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "hqZ" = (
@@ -13168,8 +13336,10 @@
 /area/aegis/mining)
 "htp" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "hty" = (
@@ -13234,9 +13404,6 @@
 /obj/item/flashlight/lamp,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 6
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
@@ -13336,10 +13503,12 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/commons/storage/primary)
 "hwO" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/highcap/five_k/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
 "hwQ" = (
@@ -13371,7 +13540,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
 "hxB" = (
@@ -13465,7 +13636,6 @@
 /area/mine/production)
 "hAa" = (
 /obj/structure/disposalpipe/junction/flip,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "hAg" = (
@@ -13662,7 +13832,9 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "hGw" = (
@@ -13707,9 +13879,11 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "hGU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/directional/south,
 /obj/machinery/power/apc/highcap/ten_k/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/monitoring)
 "hGV" = (
@@ -13794,7 +13968,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "hJM" = (
@@ -13995,10 +14168,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hPr" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "hPv" = (
@@ -14967,6 +15145,13 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
+"ios" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15014,7 +15199,6 @@
 /area/station/hallway/primary/central/aft)
 "iqf" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -15025,6 +15209,12 @@
 	},
 /obj/machinery/light_switch/directional/west{
 	pixel_y = 32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
@@ -15240,11 +15430,13 @@
 /area/station/service/kitchen/coldroom)
 "iyS" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "Engineering Security Doors"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
@@ -15325,7 +15517,6 @@
 /area/station/cargo/warehouse/upper)
 "iAC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/button/door/directional/east{
 	pixel_y = -6;
 	name = "Engineering Lockdown";
@@ -15337,9 +15528,6 @@
 	id = "Secure Storage"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
@@ -15419,11 +15607,12 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
+/area/aegis/surface)
 "iCm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate/large/ds/green_horizontal,
@@ -15785,6 +15974,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/slides,
 /area/station/ai_monitored/security/armory)
+"iKi" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "iKJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -15799,7 +15994,6 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lesser)
 "iKX" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 8
 	},
@@ -15807,6 +16001,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
@@ -16276,9 +16473,11 @@
 /area/station/hallway/primary/central/aft)
 "iVk" = (
 /obj/structure/table,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/telephone/engineering,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/monitoring)
 "iVq" = (
@@ -16558,8 +16757,9 @@
 	id = "ceprivacy";
 	name = "privacy shutter"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
 "jdK" = (
@@ -16590,7 +16790,9 @@
 	dir = 8
 	},
 /obj/structure/lattice,
-/turf/open/misc/asteroid,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "jfa" = (
 /turf/closed/wall/r_wall,
@@ -16622,10 +16824,15 @@
 /area/station/command/heads_quarters/captain)
 "jgb" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "jgm" = (
@@ -16654,6 +16861,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "jgK" = (
@@ -17262,6 +17470,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/newscaster/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "jtu" = (
@@ -17330,11 +17544,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "juH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste to Filter";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "jvn" = (
@@ -17526,6 +17739,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "jBo" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "jBp" = (
@@ -17586,8 +17802,10 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "jDq" = (
@@ -18138,6 +18356,9 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/telephone/command,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
 "jSL" = (
@@ -18372,7 +18593,10 @@
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/checkpoint/customs)
 "jYX" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "jZb" = (
@@ -18493,7 +18717,9 @@
 	input_level = 60000;
 	output_level = 70000
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "kej" = (
@@ -18689,8 +18915,10 @@
 /turf/open/floor/deadspace/random/slides,
 /area/aegis/mining)
 "kih" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "kiq" = (
@@ -18956,12 +19184,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/area/aegis/surface)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -19092,6 +19318,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
+"ktD" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "ktI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -19160,12 +19392,17 @@
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
 "kvH" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "kvY" = (
@@ -19379,10 +19616,12 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
 "kDP" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "kEv" = (
@@ -19391,7 +19630,10 @@
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
 "kEE" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "kEF" = (
@@ -19502,6 +19744,13 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central/aft)
+"kHN" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "kHQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -19711,7 +19960,15 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/server)
 "kOf" = (
@@ -19756,7 +20013,9 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/fore/lesser)
 "kPt" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
 "kPv" = (
@@ -19794,6 +20053,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
 "kQi" = (
@@ -20329,11 +20594,16 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "ldv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 9
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
 	},
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/ce)
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -20913,6 +21183,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/hallway/primary/central)
+"lut" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "luv" = (
 /obj/machinery/door/poddoor/preopen,
 /obj/structure/disposalpipe/segment{
@@ -20974,6 +21250,9 @@
 /area/station/commons/dorms/cryo)
 "lwr" = (
 /obj/structure/chair/office,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "lwW" = (
@@ -21211,7 +21490,9 @@
 	dir = 5
 	},
 /obj/structure/lattice,
-/turf/open/misc/asteroid,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "lDu" = (
 /turf/open/floor/deadspace/random/golf_brown,
@@ -21500,6 +21781,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"lLB" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "lLJ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/box,
@@ -21743,9 +22030,11 @@
 "lSF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
 "lSG" = (
@@ -22020,7 +22309,6 @@
 /area/station/hallway/primary/central)
 "mbF" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -22028,6 +22316,9 @@
 /obj/structure/rack,
 /obj/item/storage/belt/utility,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
 "mbL" = (
@@ -22059,9 +22350,11 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "mcZ" = (
@@ -22172,9 +22465,11 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "mgv" = (
@@ -22416,6 +22711,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "mnQ" = (
@@ -22553,8 +22851,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
 "mrn" = (
@@ -23070,6 +23373,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
+"mFk" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "mFm" = (
 /obj/item/paper_bin,
 /obj/structure/table/wood/fancy/blue,
@@ -23102,9 +23414,11 @@
 /area/station/hallway/secondary/exit)
 "mHD" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "mHG" = (
@@ -23172,7 +23486,6 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "mKH" = (
@@ -23349,7 +23662,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/light/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "mOr" = (
@@ -23483,6 +23795,9 @@
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics - Desk"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "mTB" = (
@@ -23528,7 +23843,6 @@
 	},
 /area/station/hallway/primary/starboard)
 "mVI" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -23540,6 +23854,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "mVT" = (
@@ -23616,6 +23936,9 @@
 "mXQ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "mXV" = (
@@ -23701,9 +24024,11 @@
 	name = "Supermatter Engine Control Room";
 	req_access_txt = "10"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/monitoring)
 "mZF" = (
@@ -23756,10 +24081,15 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
 "nav" = (
@@ -23817,12 +24147,14 @@
 	},
 /area/station/security/lockers)
 "nck" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "ncl" = (
@@ -23985,7 +24317,6 @@
 	c_tag = "Chief Engineer's Office"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24586,7 +24917,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "nAU" = (
@@ -24637,14 +24967,17 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "nBX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/area/station/engineering/break_room)
 "nCk" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -24739,7 +25072,9 @@
 /area/station/commons/dorms/barracks/male)
 "nGf" = (
 /obj/structure/lattice/catwalk,
-/turf/open/misc/asteroid,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "nGk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24955,7 +25290,9 @@
 	dir = 6
 	},
 /obj/structure/lattice,
-/turf/open/misc/asteroid,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "nMt" = (
 /obj/machinery/light/directional/north,
@@ -25107,9 +25444,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "nPO" = (
@@ -25119,12 +25458,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
 "nQh" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "nQt" = (
@@ -25469,7 +25810,7 @@
 /area/station/cargo/warehouse/upper)
 "oaV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/meter/monitored/distro_loop,
 /turf/open/floor/deadspace/random/rectangles,
@@ -25659,11 +26000,10 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
 "ogk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
-	},
 /obj/machinery/light/directional/south,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible/layer2{
+	dir = 8
+	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "ogs" = (
@@ -25830,7 +26170,9 @@
 /area/station/security/checkpoint/science)
 "okQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "okR" = (
@@ -26064,7 +26406,6 @@
 /turf/open/floor/plating,
 /area/station/security/brig)
 "oqA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
@@ -26330,7 +26671,15 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/server)
 "oyz" = (
@@ -26565,6 +26914,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
 "oGx" = (
@@ -26631,12 +26983,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "oIM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "oIR" = (
@@ -26938,6 +27292,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "oRx" = (
@@ -27092,12 +27449,14 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
 "oVl" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "oVp" = (
@@ -27143,7 +27502,9 @@
 "oXp" = (
 /obj/machinery/light/small/directional/east,
 /obj/machinery/power/smes,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "oXu" = (
@@ -27200,7 +27561,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "oYE" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "oYR" = (
@@ -27379,8 +27742,7 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "pee" = (
-/obj/machinery/meter/monitored/waste_loop,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "pev" = (
@@ -27658,6 +28020,12 @@
 	pixel_x = -26
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "pml" = (
@@ -27702,9 +28070,14 @@
 /area/station/security/warden)
 "pnH" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "pnL" = (
@@ -28159,12 +28532,20 @@
 	},
 /area/station/security/checkpoint/science)
 "pAx" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "pAL" = (
@@ -28257,13 +28638,15 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
 "pDo" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "Engineering Security Doors"
 	},
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "pDD" = (
@@ -28391,6 +28774,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
+"pGU" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "pHp" = (
 /obj/structure/sign/cec/deck/medical{
 	pixel_y = 32
@@ -28458,7 +28847,6 @@
 /obj/item/trash/can{
 	pixel_x = -8
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "pIO" = (
@@ -28730,6 +29118,18 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"pOY" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "pOZ" = (
 /obj/structure/table,
 /obj/item/exodrone{
@@ -28843,10 +29243,15 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "pSn" = (
@@ -28915,7 +29320,9 @@
 /area/station/hallway/secondary/exit)
 "pWm" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/misc/testroom)
 "pWn" = (
@@ -29583,6 +29990,16 @@
 	dir = 4
 	},
 /area/station/security/checkpoint/customs)
+"qnL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "qnS" = (
 /obj/structure/sign/cec/deck/medical{
 	pixel_y = 32
@@ -29904,8 +30321,10 @@
 	name = "Solar Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "qvr" = (
@@ -30256,14 +30675,11 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qHk" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste to Filter";
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -30418,6 +30834,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
+"qMG" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "qMH" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/structure/crate,
@@ -30434,15 +30855,14 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "qMP" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/ce)
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "qMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -30547,6 +30967,12 @@
 /obj/structure/closet/secure_closet/ds/engineering_personal,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"qQf" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "qQg" = (
 /obj/item/kirbyplants,
 /turf/open/floor/iron/dark/side{
@@ -30657,7 +31083,9 @@
 /area/station/engineering/atmos)
 "qTj" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qTV" = (
@@ -30689,7 +31117,6 @@
 /area/station/cargo/storage)
 "qUr" = (
 /obj/structure/disposalpipe/junction/yjunction,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "qUA" = (
@@ -31869,6 +32296,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "rDp" = (
@@ -31913,11 +32343,7 @@
 /area/station/engineering/storage_shared)
 "rDV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring the engine.";
 	dir = 8;
@@ -32031,7 +32457,6 @@
 /area/station/cargo/storage)
 "rIu" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "rIL" = (
@@ -32342,12 +32767,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
 "rQA" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
 	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "rQK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/tool,
@@ -32439,8 +32863,8 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "rUa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 6
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -32524,7 +32948,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "rWC" = (
@@ -32763,8 +33189,10 @@
 /area/station/commons/dorms/barracks/male)
 "sga" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
 "sgo" = (
@@ -32924,6 +33352,9 @@
 "slG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
@@ -33105,10 +33536,12 @@
 	req_one_access_txt = "32;19"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "spQ" = (
@@ -33293,7 +33726,10 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/misc/asteroid,
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
@@ -33432,7 +33868,9 @@
 /area/station/science/server)
 "sAQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/misc/testroom)
 "sAS" = (
@@ -33461,11 +33899,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "sCc" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/misc/asteroid,
 /area/aegis/surface)
 "sCd" = (
 /obj/structure/closet/crate/large,
@@ -33528,10 +33965,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
@@ -33686,12 +34125,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse/upper)
 "sJD" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "sJI" = (
@@ -33784,11 +34225,13 @@
 /turf/open/floor/deadspace/random/slides,
 /area/aegis/hanger)
 "sMX" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "sMY" = (
@@ -33986,6 +34429,9 @@
 /obj/item/radio/intercom/directional/east,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "sSP" = (
@@ -34093,6 +34539,9 @@
 "sVe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "sVh" = (
@@ -34409,7 +34858,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
 	req_one_access_txt = "10;24"
@@ -34417,6 +34865,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "tfu" = (
@@ -34430,15 +34881,21 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "tfU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "tfW" = (
@@ -35046,12 +35503,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "tyE" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "tyN" = (
@@ -35229,7 +35688,6 @@
 /area/station/engineering/supermatter/room)
 "tEB" = (
 /obj/structure/table,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/monitoring)
 "tEL" = (
@@ -35321,6 +35779,7 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "tKq" = (
@@ -35516,8 +35975,10 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "tQQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
 "tQR" = (
@@ -35583,6 +36044,12 @@
 	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/medical/morgue)
+"tSk" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "tSv" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/bubbleplush,
@@ -35620,10 +36087,12 @@
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "tSY" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "tTd" = (
@@ -35797,7 +36266,6 @@
 "tYc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/keycard_auth/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -36153,7 +36621,6 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
 	req_one_access_txt = "10;24"
@@ -36161,6 +36628,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "ukB" = (
@@ -36350,7 +36820,6 @@
 	name = "Equipment Closet";
 	req_access_txt = "11"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
@@ -36377,21 +36846,23 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
 "upb" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/ce)
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "upl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
 /obj/item/mod/control/pre_equipped/ds/intermediate_engineer,
 /obj/item/mod/control/pre_equipped/ds/intermediate_engineer,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/item/disk/holodisk/ds13/ce,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "upr" = (
@@ -37018,9 +37489,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37223,7 +37694,6 @@
 	c_tag = "Engineering - Foyer - Shared Storage"
 	},
 /obj/structure/sign/poster/official/random/directional/west,
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
 "uOK" = (
@@ -37279,9 +37749,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
-/obj/structure/reagent_dispensers/fueltank/large,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -37637,6 +38110,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"uZG" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "uZP" = (
 /obj/effect/spawner/random/contraband,
 /turf/open/floor/plating,
@@ -37754,11 +38233,17 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos/storage/gas)
+"vbZ" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
 /area/station/engineering/atmos/storage/gas)
 "vcg" = (
 /obj/effect/landmark{
@@ -37832,9 +38317,11 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
 "vfu" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "vfL" = (
@@ -38171,12 +38658,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "vqr" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "vqw" = (
@@ -38559,10 +39048,8 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "vBz" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Distro to Waste"
-	},
 /obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "vBI" = (
@@ -39470,7 +39957,7 @@
 	icon_state = "12"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
@@ -39584,8 +40071,9 @@
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "weG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
+	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "weI" = (
@@ -39848,6 +40336,9 @@
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "wnd" = (
@@ -39925,9 +40416,11 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
@@ -40025,11 +40518,11 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "wrl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/ce)
+/area/station/engineering/supermatter/room)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -40306,9 +40799,14 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "wAY" = (
@@ -40538,7 +41036,6 @@
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse/upper)
 "wGU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Power Monitoring";
 	req_access_txt = "11"
@@ -40546,6 +41043,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/engine_smes)
 "wGW" = (
@@ -41336,10 +41836,12 @@
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xdT" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
@@ -41440,7 +41942,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "xhF" = (
@@ -41473,11 +41974,13 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "xhP" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "xhS" = (
@@ -41705,7 +42208,9 @@
 /area/station/hallway/primary/central/aft)
 "xnC" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
 "xnE" = (
@@ -41906,12 +42411,14 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "xtB" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "xtH" = (
@@ -41919,6 +42426,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/storage/secure/briefcase,
 /obj/machinery/airalarm/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "xtL" = (
@@ -42349,7 +42859,9 @@
 /area/aegis/surface)
 "xHG" = (
 /obj/machinery/light/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/misc/testroom)
 "xHS" = (
@@ -42624,6 +43136,9 @@
 "xPd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "xPq" = (
@@ -42790,7 +43305,9 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "xWB" = (
@@ -42965,7 +43482,9 @@
 /area/station/engineering/atmos/storage/gas)
 "ycm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "ycn" = (
@@ -43137,11 +43656,16 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/ce)
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
@@ -43156,6 +43680,9 @@
 	network = list("ss13","engine")
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "yio" = (
@@ -43241,7 +43768,9 @@
 	c_tag = "Engineering - Foyer"
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "ykX" = (
@@ -80705,11 +81234,11 @@ qVP
 qVP
 wuy
 wuy
-rqy
-rqy
-rqy
-rqy
-rqy
+kpP
+kpP
+kpP
+kpP
+kpP
 wuy
 wuy
 wuy
@@ -80861,24 +81390,24 @@ wuy
 wuy
 wuy
 wuy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
 wuy
 wuy
 vRZ
@@ -81014,29 +81543,29 @@ qVP
 qVP
 qVP
 wuy
-rqy
-rqy
+kpP
+kpP
+iCe
+iCe
+iCe
+iCe
+iCe
+iCe
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
+kpP
 qnp
-qnp
-qnp
-qnp
-qnp
-qnp
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-qnp
-qnp
-qnp
-qnp
-qnp
-qnp
-rqy
-rqy
+iCe
+iCe
+iCe
+iCe
+iCe
+kpP
+kpP
 wuy
 vRZ
 bzI
@@ -81171,29 +81700,29 @@ qVP
 qVP
 qVP
 wuy
-rqy
-qnp
+kpP
+iCe
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-rqy
-rqy
-rqy
+kpP
+kpP
+kpP
 dsu
-rqy
-rqy
-rqy
+kpP
+kpP
+kpP
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-qnp
-rqy
+iCe
+kpP
 wuy
 vRZ
 uho
@@ -81328,29 +81857,29 @@ qVP
 qVP
 qVP
 wuy
-rqy
-qnp
-rQA
+kpP
+iCe
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-rqy
-rqy
+swY
+swY
+swY
+swY
+kpP
+kpP
+kpP
 nGf
-rqy
-rqy
-rqy
-rQA
+kpP
+kpP
+kpP
 swY
-rQA
-rQA
 swY
-rQA
-qnp
-rqy
+swY
+swY
+swY
+swY
+iCe
+kpP
 wuy
 vRZ
 ham
@@ -81485,29 +82014,29 @@ qVP
 qVP
 qVP
 wuy
-rqy
-qnp
-rQA
+kpP
+iCe
 swY
-rQA
-rQA
 swY
-rQA
-gbS
-gbS
-gbS
+swY
+swY
+swY
+swY
+sCc
+sCc
+sCc
 dsu
-gbS
-gbS
-gbS
-rQA
+sCc
+sCc
+sCc
 swY
-rQA
-rQA
 swY
-rQA
-qnp
-rqy
+swY
+swY
+swY
+swY
+iCe
+kpP
 wuy
 vRZ
 vRZ
@@ -81642,29 +82171,29 @@ qVP
 qVP
 qVP
 wuy
-rqy
-rqy
-rQA
+kpP
+kpP
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-rqy
-rqy
+swY
+swY
+swY
+swY
+kpP
+kpP
+kpP
 nGf
-rqy
-rqy
-rqy
-rQA
+kpP
+kpP
+kpP
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-rqy
+swY
+swY
+swY
+swY
+kpP
+kpP
 wuy
 wuy
 wuy
@@ -81799,30 +82328,30 @@ qVP
 qVP
 qVP
 wuy
-rqy
-qnp
-rQA
+kpP
+iCe
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-rqy
-rqy
+swY
+swY
+swY
+swY
+kpP
+kpP
+kpP
 nGf
-rqy
-rqy
-rqy
-rQA
+kpP
+kpP
+kpP
 swY
-rQA
-rQA
 swY
-rQA
-qnp
-rqy
-rqy
+swY
+swY
+swY
+swY
+iCe
+kpP
+kpP
 wuy
 wuy
 vRZ
@@ -81956,30 +82485,30 @@ qVP
 qVP
 qVP
 wuy
-rqy
-qnp
-rQA
+kpP
+iCe
 swY
-rQA
-rQA
 swY
-rQA
-gbS
-gbS
-gbS
+swY
+swY
+swY
+swY
+sCc
+sCc
+sCc
 dsu
-gbS
-gbS
-gbS
-rQA
+sCc
+sCc
+sCc
 swY
-rQA
-rQA
 swY
-rQA
-qnp
-gbS
-rqy
+swY
+swY
+swY
+swY
+iCe
+sCc
+kpP
 wuy
 wuy
 kZJ
@@ -82113,30 +82642,30 @@ qVP
 qVP
 qVP
 wuy
-rqy
-qnp
-rQA
+kpP
+iCe
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-rqy
-rqy
+swY
+swY
+swY
+swY
+kpP
+kpP
+kpP
 nGf
-rqy
-rqy
-rqy
-rQA
+kpP
+kpP
+kpP
 swY
-rQA
-rQA
 swY
-rQA
-qnp
+swY
+swY
+swY
+swY
+iCe
 dsu
-rqy
+kpP
 wuy
 wuy
 kZJ
@@ -82270,30 +82799,30 @@ qVP
 qVP
 qVP
 wuy
-rqy
-rqy
-rQA
+kpP
+kpP
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-rqy
-rqy
+swY
+swY
+swY
+swY
+kpP
+kpP
+kpP
 nGf
-rqy
-rqy
-rqy
-rQA
+kpP
+kpP
+kpP
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-gbS
-rqy
+swY
+swY
+swY
+swY
+kpP
+sCc
+kpP
 wuy
 wuy
 kZJ
@@ -82427,30 +82956,30 @@ qVP
 qVP
 qVP
 wuy
-rqy
-rHU
-rQA
+kpP
+pGU
 swY
-rQA
-rQA
 swY
-rQA
-gbS
-gbS
-gbS
+swY
+swY
+swY
+swY
+sCc
+sCc
+sCc
 dsu
-gbS
-gbS
-gbS
-rQA
+sCc
+sCc
+sCc
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-gbS
-rqy
+swY
+swY
+swY
+swY
+kpP
+sCc
+kpP
 wuy
 kZJ
 kZJ
@@ -82584,30 +83113,30 @@ qVP
 qVP
 qVP
 wuy
-rqy
-rHU
+kpP
+pGU
 jeU
+upb
+qMP
+upb
+qMP
 jeU
-jeU
-jeU
-jeU
-jeU
-rqy
-rqy
-rqy
+kpP
+kpP
+kpP
 nGf
-rqy
-rqy
-rqy
+kpP
+kpP
+kpP
 jeU
-jeU
-jeU
-jeU
-jeU
+upb
+qMP
+upb
+qMP
 jeU
 sCc
-gbS
-rqy
+sCc
+kpP
 wuy
 kZJ
 xii
@@ -82741,13 +83270,13 @@ qVP
 qVP
 qVP
 wuy
-rqy
+wuy
 qQP
 lhT
-lhT
-lhT
-lhT
-lhT
+gwR
+gwR
+gwR
+gwR
 vTc
 qQP
 qQP
@@ -82757,12 +83286,12 @@ qQP
 qQP
 qQP
 pXJ
+gqh
+gqh
+gqh
+gqh
 rgW
-rgW
-rgW
-rgW
-rgW
-iCe
+qQP
 qQP
 wuy
 wuy
@@ -82897,14 +83426,14 @@ qVP
 qVP
 qVP
 qVP
-wuy
-wuy
+qVP
+qVP
 qQP
 hBo
-gXh
-dJx
-dJx
-dJx
+weG
+aIL
+aIL
+aIL
 nQP
 bwR
 auf
@@ -82914,13 +83443,13 @@ fnm
 geM
 bwR
 gFk
-gXh
-gXh
 weG
 gXh
+weG
+weG
 nJu
 rUa
-qQP
+rQA
 qVP
 qVP
 kZJ
@@ -83077,7 +83606,7 @@ uzD
 bAy
 dAF
 ogk
-qQP
+wrl
 qVP
 qVP
 eRR
@@ -83233,8 +83762,8 @@ sjI
 bIh
 lyZ
 dAF
-rUa
-qQP
+uQN
+wrl
 qVP
 qVP
 eRR
@@ -83391,7 +83920,7 @@ kit
 edO
 hCO
 dUe
-qQP
+wrl
 qVP
 qVP
 eRR
@@ -83548,7 +84077,7 @@ trK
 blO
 cTo
 pmS
-qQP
+wrl
 qVP
 qVP
 eRR
@@ -83702,10 +84231,10 @@ qMD
 gGE
 sVe
 yim
-iMZ
-dAF
+lLB
+mFk
 dOf
-qQP
+lut
 qVP
 qVP
 eRR
@@ -84964,18 +85493,18 @@ nLe
 mbF
 sun
 uUt
-uGU
+avK
 wAX
 aNP
 aAq
 aGd
 aGd
-tQQ
+qnL
 kPt
 oyt
 egd
 kNZ
-aBf
+tSk
 mUn
 mUn
 mUn
@@ -85129,9 +85658,9 @@ qAi
 vVb
 tQQ
 pWI
-bYx
-bYx
-bYx
+eva
+eva
+eva
 aBf
 mUn
 dpz
@@ -85267,7 +85796,7 @@ bUh
 oRx
 tYl
 hpF
-tYl
+fXL
 iVk
 xth
 nCJ
@@ -85279,7 +85808,7 @@ lSF
 gOY
 mHD
 nPN
-wmL
+nBX
 icl
 ojj
 tit
@@ -85592,7 +86121,7 @@ iyS
 cLU
 cLU
 ojj
-diA
+hFY
 dEQ
 dJK
 ojj
@@ -85602,8 +86131,8 @@ gFX
 gFX
 gFX
 kih
-aBf
-aBf
+qQf
+uZG
 fsT
 gvY
 qVP
@@ -85749,7 +86278,7 @@ slG
 fpO
 gsG
 tuG
-kpP
+xbE
 dEQ
 eFo
 iNX
@@ -85888,8 +86417,8 @@ kDP
 kDP
 kDP
 kDP
-gwR
-gwR
+kDP
+kDP
 eCA
 eCA
 eCA
@@ -85897,7 +86426,7 @@ eCA
 eCA
 pAx
 gbr
-pSi
+pOY
 ukz
 pSi
 tfP
@@ -85907,7 +86436,7 @@ fBA
 tfj
 eFj
 mcE
-dEQ
+yhZ
 avK
 uiB
 pIx
@@ -86049,7 +86578,7 @@ bXK
 ccb
 ccb
 ccb
-eAV
+bXK
 ccb
 bWA
 vqr
@@ -86198,7 +86727,7 @@ gsG
 jIe
 kxC
 ccb
-aPX
+gbS
 ccb
 rib
 hmJ
@@ -86354,9 +86883,9 @@ qVP
 gsG
 gsG
 gsG
-ahD
+gEy
 adK
-ahD
+kHN
 gsG
 gsG
 pMH
@@ -86375,7 +86904,7 @@ sSt
 pmf
 jto
 xtH
-upb
+jdI
 fRQ
 xbE
 wmL
@@ -86532,7 +87061,7 @@ nJs
 jSE
 kPV
 mXQ
-upb
+jdI
 ktu
 xbE
 wmL
@@ -87160,10 +87689,10 @@ rDV
 iAC
 fRC
 bmS
-qMP
+jdI
 pIG
 kNf
-avK
+aAT
 lwr
 hPz
 xwH
@@ -87312,9 +87841,9 @@ gsG
 gsG
 gsG
 djs
-yhZ
-ldv
-wrl
+djs
+djs
+djs
 djs
 djs
 djs
@@ -87472,10 +88001,10 @@ cMl
 oaV
 vBz
 pee
-sRF
+vbZ
 jgI
 cAY
-sRF
+eoO
 oTl
 sRF
 sRF
@@ -87624,15 +88153,15 @@ nBT
 iJV
 vtj
 uzW
-nBX
+vPr
 ebH
 fjl
 hfM
-gmn
-sEl
+ios
+bxx
 tKf
 jYX
-sRF
+uGU
 qoR
 sRF
 keh
@@ -87781,11 +88310,11 @@ qxW
 eBE
 gkJ
 vxP
-qJv
-qJv
+ebH
+ebH
+ebH
 gAZ
-gAZ
-qHk
+gmn
 sEl
 vah
 okQ
@@ -87938,9 +88467,9 @@ mpT
 eGf
 gkJ
 jZb
-ebH
+diA
 kEE
-uQN
+ebH
 kRQ
 juH
 sEl
@@ -88095,8 +88624,8 @@ anZ
 eGf
 eAg
 sxb
-gkJ
-gkJ
+cIu
+qMG
 gkJ
 eAg
 feG
@@ -88253,10 +88782,10 @@ exz
 hFC
 gQv
 tfU
-tfU
+iKi
 ohb
 ebH
-juH
+mbT
 sRF
 lav
 gzx
@@ -89014,7 +89543,7 @@ qVP
 qVP
 qVP
 rHU
-afp
+eAV
 rqy
 rqy
 rqy
@@ -89169,9 +89698,9 @@ tuc
 tuc
 qVP
 qVP
-afp
-afp
-afp
+iHy
+ruE
+fnw
 rqy
 rqy
 rqy
@@ -89326,7 +89855,7 @@ rqy
 rqy
 rqy
 rqy
-afp
+eAV
 rEA
 quR
 rEA
@@ -89355,7 +89884,7 @@ naE
 mCH
 dvF
 hHs
-blf
+dJx
 dwU
 blf
 blf
@@ -89483,9 +90012,9 @@ rqy
 rqy
 rqy
 rqy
-afp
+eAV
 rek
-oYE
+ktD
 jJJ
 wAN
 sIt
@@ -89640,14 +90169,14 @@ qVP
 rqy
 rqy
 rqy
-ocO
+qHk
 rEA
-oYE
+flF
 jBo
 oYE
-quR
-gqh
-gqh
+ldv
+ruE
+ieM
 rqy
 rqy
 rqy
@@ -89797,14 +90326,14 @@ qVP
 rqy
 tuc
 tuc
-afp
+eAV
 rEA
 aQr
 oXp
 cuI
 sIt
 rqy
-gqh
+rqy
 rqy
 rqy
 rqy
@@ -89961,7 +90490,7 @@ rEA
 rEA
 sIt
 rqy
-gqh
+rqy
 rqy
 rqy
 rqy

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -262,6 +262,9 @@
 /area/station/engineering/break_room)
 "ahD" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "ahQ" = (
@@ -1040,12 +1043,6 @@
 /obj/machinery/power/floodlight,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
-"aBZ" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "aCf" = (
 /obj/structure/ladder/invincible,
 /obj/structure/lattice,
@@ -1350,12 +1347,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
-"aLK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/brig)
 "aLQ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -1381,6 +1372,17 @@
 	dir = 4
 	},
 /area/station/hallway/primary/aft)
+"aNc" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "aNe" = (
 /obj/structure/railing{
 	dir = 10
@@ -1526,6 +1528,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/stone,
 /area/aegis/surface)
+"aRb" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "aRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2245,6 +2259,18 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"biA" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "biD" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line{
@@ -2301,6 +2327,13 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
+"bkq" = (
+/obj/structure/cable/multiz,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "bkr" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -2345,7 +2378,10 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "blO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "blQ" = (
@@ -2477,17 +2513,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"boD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "boH" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -2689,7 +2714,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "10"
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -2811,15 +2836,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"bwV" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "bxp" = (
 /obj/machinery/power/floodlight,
 /obj/effect/turf_decal/box,
@@ -2872,6 +2888,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
+"byz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/maintenance/fore/greater)
 "byB" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/closet/crate/coffin,
@@ -2950,12 +2973,6 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"bAp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "bAs" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/wood,
@@ -3024,7 +3041,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/central/aft)
+/area/station/security/brig/upper)
 "bBP" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/box,
@@ -3317,6 +3334,13 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
+"bKO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "bKS" = (
 /obj/effect/landmark{
 	name = "ShuttleRepairPart"
@@ -3858,7 +3882,7 @@
 "bYx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
@@ -3866,13 +3890,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
-"bYC" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "bYP" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
@@ -4099,13 +4116,6 @@
 /mob/living/simple_animal/slug,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
-"cfy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "cfz" = (
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/deadspace/grater,
@@ -4186,13 +4196,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
-"cgZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "chj" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/awakenedplushie,
@@ -4250,16 +4253,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
-"cjX" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "ckb" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/machinery/computer/atmos_control/oxygen_tank{
@@ -4608,6 +4601,14 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
+"ctC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "ctS" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced/grille,
@@ -4917,17 +4918,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"cBA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "cBD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -5169,13 +5159,6 @@
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"cHR" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "cHY" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap{
@@ -5280,13 +5263,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
-"cKA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
 "cKB" = (
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/misc/beach/sand/coastline_t,
@@ -5561,14 +5537,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
-"cSA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig/upper)
 "cSE" = (
 /obj/machinery/light,
 /obj/effect/spawner/random/vending/colavend,
@@ -5589,11 +5557,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cTo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/h2{
+	dir = 8
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -5736,6 +5704,13 @@
 /obj/machinery/light/directional/east,
 /turf/open/misc/asteroid,
 /area/station/maintenance/disposal)
+"cXc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "cXA" = (
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
@@ -6006,15 +5981,16 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "9"
 	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -6228,7 +6204,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/grater,
-/area/station/hallway/primary/central/aft)
+/area/station/security/brig/upper)
 "dpo" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/right{
@@ -6286,16 +6262,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
-"dqV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/computer)
 "dqX" = (
 /obj/machinery/mechpad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6624,6 +6590,10 @@
 "dAF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -6954,11 +6924,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "dJx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "5"
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
@@ -7077,9 +7049,9 @@
 /area/station/hallway/secondary/exit)
 "dOf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
+	dir = 9
 	},
-/turf/open/floor/iron/ported/techfloor,
+/turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "dOx" = (
 /obj/machinery/cryopod{
@@ -7211,8 +7183,15 @@
 	},
 /area/aegis/mining)
 "dSu" = (
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/central/aft)
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "dSB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -7327,11 +7306,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "dUe" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/h2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "dUl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -7490,18 +7471,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
-"dYw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "dYK" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/deadspace/random/rectangles,
@@ -8243,6 +8212,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
 	},
@@ -8466,12 +8438,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "eAV" = (
-/obj/structure/cable/multiz,
+/obj/machinery/light/floor/has_bulb,
 /obj/structure/cable/yellow{
-	icon_state = "2"
+	icon_state = "12"
 	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "eBa" = (
 /obj/structure/railing{
 	dir = 8
@@ -8851,6 +8823,9 @@
 /area/station/engineering/supermatter/room)
 "eIL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/plating,
 /area/station/engineering/monitoring)
 "eIZ" = (
@@ -9024,14 +8999,6 @@
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
-"eOC" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "eON" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -9370,9 +9337,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "eYU" = (
@@ -9445,16 +9409,6 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
-"eZU" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "eZW" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -10679,6 +10633,17 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
+"fNw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "fNB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -11229,12 +11194,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "gbS" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "8"
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
+/area/aegis/surface)
 "gcw" = (
 /obj/machinery/door/airlock/mining{
 	dir = 1;
@@ -11282,13 +11247,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics)
-"gdm" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "gdr" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -11645,17 +11603,6 @@
 	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
-"goW" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "gpj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/south,
@@ -11663,15 +11610,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
-"gpp" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "gpr" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
@@ -11718,12 +11656,13 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "5"
 	},
-/turf/open/floor/plating,
-/area/station/security/warden)
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -11894,12 +11833,11 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "gxI" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_center,
@@ -12017,7 +11955,7 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
 "gAZ" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
 	power_setting = 50
 	},
 /turf/open/floor/deadspace/random/rectangles,
@@ -12948,6 +12886,12 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/central)
+"hbF" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "hbH" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -12964,6 +12908,12 @@
 /obj/structure/bed/roller,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"hcc" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "hch" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -13874,12 +13824,13 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "hCO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "hCW" = (
@@ -13895,10 +13846,16 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "hDf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/red,
-/area/station/security/office)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "hDv" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/customs)
@@ -14614,6 +14571,20 @@
 /obj/effect/spawner/random/engineering/flashlight,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"hWp" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "hWr" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
@@ -14720,6 +14691,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/male)
+"iaa" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "iae" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -14802,16 +14779,12 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "1"
 	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "idy" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor{
@@ -14913,12 +14886,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
-"ifb" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "ifc" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/psychology)
@@ -15243,6 +15210,18 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
+"ilJ" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "ilN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
@@ -15333,33 +15312,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "iol" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "5"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
-"iot" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15820,14 +15777,16 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
-/area/aegis/surface)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "iCm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate/large/ds/green_horizontal,
@@ -15852,12 +15811,6 @@
 "iCG" = (
 /turf/open/floor/wood,
 /area/aegis/mining)
-"iCH" = (
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "iCL" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/deadspace/random/slides{
@@ -15991,6 +15944,17 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
+"iFU" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "iGf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -16244,7 +16208,7 @@
 "iLi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/fore/greater)
@@ -16755,12 +16719,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
-"iWc" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "iWf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/random/maint_center,
@@ -16986,16 +16944,15 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jdI" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1"
+/obj/structure/cable/red{
+	icon_state = "2"
 	},
 /turf/open/floor/plating,
-/area/station/command/heads_quarters/ce)
+/area/station/engineering/supermatter/room)
 "jdK" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -17885,11 +17842,6 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"jxU" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "jyl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
@@ -18863,15 +18815,6 @@
 "jZu" = (
 /turf/closed/wall/r_wall,
 /area/aegis/telecomms/high)
-"jZK" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "kap" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/misc/asteroid,
@@ -18929,11 +18872,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
-"kcE" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
 "kcG" = (
 /obj/machinery/door_timer{
 	id = "Cell 3";
@@ -19301,6 +19239,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"kkt" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "kky" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -19311,10 +19256,6 @@
 /obj/machinery/door/airlock/mining,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse/upper)
-"kkZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "klu" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/machinery/camera/autoname/directional/south,
@@ -19426,6 +19367,14 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
+"koC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "koO" = (
 /obj/machinery/light/directional/north,
 /turf/open/misc/asteroid,
@@ -19451,11 +19400,15 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -20007,15 +19960,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central/aft)
-"kHK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "kHQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -20481,6 +20425,12 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"kTS" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "kTT" = (
 /obj/machinery/newscaster/directional/west,
 /obj/structure/table/wood,
@@ -20866,14 +20816,14 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "ldv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "5"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -21570,6 +21520,12 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/service/chapel)
+"lyQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "lyS" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -22334,6 +22290,14 @@
 	},
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/female)
+"lTu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "lTv" = (
 /obj/machinery/door/airlock/mining,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -22424,6 +22388,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/central)
 "lXb" = (
@@ -22453,6 +22420,13 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
+"lXX" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "lYG" = (
 /obj/structure/railing,
 /turf/open/openspace,
@@ -23298,18 +23272,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/port)
-"mvI" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
 "mvL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -23374,10 +23336,6 @@
 /obj/structure/chair,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
-"mxG" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "mxH" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -23686,12 +23644,6 @@
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"mHr" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
 "mHv" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/deadspace/random/slides{
@@ -24211,17 +24163,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
-"mWW" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
-	dir = 4
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "mXc" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/machinery/computer{
@@ -24411,7 +24356,7 @@
 "naA" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/central/aft)
+/area/station/security/brig/upper)
 "naE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -24991,14 +24936,6 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
-"nuD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "nuK" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -25282,14 +25219,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "nBX" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "nCk" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -25487,12 +25424,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/aft)
-"nIU" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "nIX" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/deadspace/grater,
@@ -25919,6 +25850,20 @@
 	},
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/male)
+"nUa" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "nUc" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
@@ -26325,11 +26270,10 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
 "ogk" = (
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 5
 	},
-/turf/open/floor/iron/ported/techfloor,
+/turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "ogs" = (
 /obj/item/folder/blue,
@@ -26438,14 +26382,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
-"ojo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
 "ojB" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -26537,6 +26473,10 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore/lesser)
+"olt" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "olT" = (
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -26547,6 +26487,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningdock/oresilo)
+"omf" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "omq" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 4;
@@ -26738,12 +26684,18 @@
 "oqy" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "2"
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/plating,
 /area/station/security/brig)
 "oqA" = (
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "oqG" = (
@@ -27319,6 +27271,24 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"oIA" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "oIM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -27905,6 +27875,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "oYR" = (
@@ -28013,6 +27986,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/hallway/primary/central)
+"pcr" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "pcv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -28395,10 +28374,10 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "pmS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/ported/techfloor,
+/turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "pnj" = (
 /obj/structure/railing{
@@ -28603,6 +28582,13 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/mine/hydroponics)
+"psT" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/security/warden)
 "psW" = (
 /turf/open/floor/carpet/red,
 /area/aegis/hanger)
@@ -28687,6 +28673,10 @@
 /obj/structure/railing/corner,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
+"pvp" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "pvH" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/button/door/directional/north{
@@ -29153,6 +29143,15 @@
 /obj/structure/railing,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
+"pIj" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "pIk" = (
 /obj/item/wallframe/apc,
 /turf/open/floor/plating,
@@ -29579,9 +29578,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "pSn" = (
@@ -29770,6 +29766,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
+"pYn" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "pYv" = (
 /obj/effect/landmark/start/detective,
 /obj/structure/chair/office,
@@ -30646,7 +30647,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -31003,15 +31004,11 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qHk" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
-	},
-/obj/structure/cable/red{
-	icon_state = "2"
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/area/station/maintenance/solars/port/fore)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -31135,12 +31132,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"qLv" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "qLV" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -31190,10 +31181,16 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "qMP" = (
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "ceprivacy";
+	name = "privacy shutter"
 	},
-/area/aegis/surface)
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/command/heads_quarters/ce)
 "qMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -31373,6 +31370,13 @@
 /obj/item/book/manual/wiki/robotics_cyborgs,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
+"qRY" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "qSh" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible{
 	dir = 9
@@ -31416,10 +31420,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"qTs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "qTV" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -31931,24 +31931,6 @@
 /obj/structure/ore_box,
 /turf/open/misc/asteroid,
 /area/station/hallway/primary/fore)
-"riv" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "P-Sec Brig";
-	req_access_txt = "63";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig)
 "riy" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 8
@@ -32738,17 +32720,6 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
-"rFn" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "rFp" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -33201,13 +33172,6 @@
 /obj/effect/spawner/random/deadspace/ammo,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
-"rSM" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/maintenance/fore/greater)
 "rSR" = (
 /obj/effect/spawner/random/deadspace/rig/scaf,
 /turf/open/floor/deadspace/mono,
@@ -33250,10 +33214,10 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "rUa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 6
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/iron/ported/techfloor,
+/turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "rUg" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
@@ -33264,6 +33228,18 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
+"rUG" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "rUK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -33320,6 +33296,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"rVJ" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "rVX" = (
 /obj/effect/turf_decal/siding/white,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -33472,6 +33458,15 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"scS" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "sdl" = (
 /obj/machinery/vending/assist,
 /obj/effect/turf_decal/bot,
@@ -34118,12 +34113,8 @@
 /area/station/engineering/atmos)
 "swY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -34547,6 +34538,13 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
+"sKg" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "sKh" = (
 /obj/structure/table,
 /turf/open/floor/stone,
@@ -35617,12 +35615,10 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "trK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/machinery/meter,
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
+/area/aegis/surface)
 "trL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -35978,6 +35974,15 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
+"tAR" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "tBf" = (
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -36063,6 +36068,10 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
+"tDb" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "tDg" = (
 /turf/open/floor/iron,
 /area/station/maintenance/fore/lesser)
@@ -36145,6 +36154,16 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/starboard/upper)
+"tHs" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "tHX" = (
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/male)
@@ -36386,7 +36405,10 @@
 "tQQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
@@ -36720,6 +36742,13 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/aft)
+"tZl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "tZt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37254,15 +37283,11 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
 "upb" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
-/obj/structure/cable/red{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "upl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -37325,15 +37350,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/aegis/surface)
-"uqJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "uqU" = (
 /obj/structure/rack/shelf,
 /obj/item/mod/control/pre_equipped/ds/pcsi,
@@ -37396,12 +37412,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/customs)
-"uso" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "ust" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37479,14 +37489,6 @@
 "utU" = (
 /turf/closed/wall/r_wall,
 /area/station/service/bar)
-"uua" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "uum" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -37928,11 +37930,20 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/effect/turf_decal/bot{
+	dir = 1
 	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38190,13 +38201,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/slides{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/area/station/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -38864,6 +38878,12 @@
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
+"vkv" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "vky" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39290,12 +39310,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
-"vvP" = (
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "vwd" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage/tech)
@@ -39560,6 +39574,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
+"vDc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "vDM" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -40317,7 +40340,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
@@ -40626,6 +40649,19 @@
 /obj/machinery/holopad,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/customs)
+"wgV" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "wgZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -40795,9 +40831,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "wnd" = (
@@ -40889,11 +40922,13 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpg" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
+	},
+/area/station/security/brig)
 "wpl" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
@@ -40976,19 +41011,17 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "wrl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41063,16 +41096,10 @@
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "wtM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41965,7 +41992,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
@@ -42094,6 +42121,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
+"wYf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "wYj" = (
 /obj/structure/railing{
 	dir = 10
@@ -42325,6 +42366,13 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
+"xdW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "xew" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -42795,6 +42843,11 @@
 /obj/structure/grille/broken,
 /turf/open/floor/plating,
 /area/aegis/surface)
+"xrd" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "xrA" = (
 /obj/structure/railing{
 	dir = 1
@@ -43520,7 +43573,7 @@
 "xLY" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/security/warden)
@@ -43591,12 +43644,6 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
-"xOq" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
 "xOz" = (
 /obj/machinery/light/small/maintenance/directional/north,
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -43688,9 +43735,6 @@
 "xRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "xRl" = (
@@ -43858,8 +43902,8 @@
 /area/station/hallway/primary/starboard)
 "xYm" = (
 /obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "xYs" = (
@@ -44156,19 +44200,20 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
 /turf/open/misc/asteroid,
 /area/station/hallway/primary/fore)
 "yim" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Engine Room South";
 	network = list("ss13","engine")
@@ -44177,6 +44222,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "yio" = (
@@ -81728,11 +81774,11 @@ qVP
 qVP
 wuy
 wuy
-qMP
-qMP
-qMP
-qMP
-qMP
+trK
+trK
+trK
+trK
+trK
 wuy
 wuy
 wuy
@@ -81804,7 +81850,7 @@ reE
 khL
 qbh
 qbh
-wtM
+mWE
 akB
 qyr
 qVP
@@ -81884,24 +81930,24 @@ wuy
 wuy
 wuy
 wuy
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
+trK
+trK
+trK
+trK
+trK
+trK
+trK
+trK
+trK
+trK
+trK
+trK
+trK
+trK
+trK
+trK
+trK
+trK
 wuy
 wuy
 vRZ
@@ -81944,7 +81990,7 @@ mwp
 yfI
 cZh
 uEm
-xRk
+dUe
 xfD
 vky
 dAe
@@ -81956,7 +82002,7 @@ vky
 vky
 vky
 vky
-cBA
+iCe
 vky
 tCw
 aQM
@@ -82037,29 +82083,29 @@ qVP
 qVP
 qVP
 wuy
-qMP
-qMP
-gwR
-gwR
-gwR
-gwR
-gwR
-gwR
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
-qMP
+trK
+trK
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+trK
+trK
+trK
+trK
+trK
+trK
+trK
 qnp
-gwR
-gwR
-gwR
-gwR
-gwR
-qMP
-qMP
+gbS
+gbS
+gbS
+gbS
+gbS
+trK
+trK
 wuy
 vRZ
 bzI
@@ -82100,14 +82146,14 @@ elo
 mwp
 tTg
 blQ
-hDf
-hDf
+xRk
+xRk
 mwp
 uej
 bNV
 bNV
 bNV
-wtM
+mWE
 bNV
 bNV
 bNV
@@ -82115,7 +82161,7 @@ bNV
 bNV
 bNV
 bNV
-wtM
+mWE
 bNV
 bNV
 bNV
@@ -82194,29 +82240,29 @@ qVP
 qVP
 qVP
 wuy
-qMP
-gwR
+trK
+gbS
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-qMP
-qMP
-qMP
+trK
+trK
+trK
 dsu
-qMP
-qMP
-qMP
+trK
+trK
+trK
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-gwR
-qMP
+gbS
+trK
 wuy
 vRZ
 uho
@@ -82264,7 +82310,7 @@ vHk
 mct
 vmQ
 bHR
-wtM
+mWE
 qWQ
 qyr
 qyr
@@ -82272,7 +82318,7 @@ qyr
 qyr
 qyr
 uck
-wtM
+mWE
 daa
 qyr
 qyr
@@ -82351,29 +82397,29 @@ qVP
 qVP
 qVP
 wuy
-qMP
-gwR
+trK
+gbS
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-qMP
-qMP
-qMP
+trK
+trK
+trK
 nGf
-qMP
-qMP
-qMP
+trK
+trK
+trK
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-gwR
-qMP
+gbS
+trK
 wuy
 vRZ
 ham
@@ -82421,15 +82467,15 @@ qyr
 qyr
 qyr
 bHR
-iot
-uQN
+wYf
+wpg
 tWq
-aLK
+gwR
 cVO
 weY
 qyr
 bHR
-wtM
+mWE
 daa
 qSo
 qSo
@@ -82508,8 +82554,8 @@ qVP
 qVP
 qVP
 wuy
-qMP
-gwR
+trK
+gbS
 rQA
 rQA
 rQA
@@ -82529,8 +82575,8 @@ rQA
 rQA
 rQA
 rQA
-gwR
-qMP
+gbS
+trK
 wuy
 vRZ
 vRZ
@@ -82578,7 +82624,7 @@ kGp
 dSB
 aSO
 bHR
-wtM
+mWE
 qpF
 trI
 iee
@@ -82586,7 +82632,7 @@ qam
 fGV
 qyr
 bHR
-wtM
+mWE
 daa
 qKU
 qKU
@@ -82665,32 +82711,32 @@ qVP
 qVP
 qVP
 wuy
-qMP
-qMP
+trK
+trK
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-qMP
-qMP
-qMP
+trK
+trK
+trK
 nGf
-qMP
-qMP
-qMP
+trK
+trK
+trK
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-qMP
-qMP
+trK
+trK
 wuy
-wuy
-wuy
+qVP
+qVP
 vRZ
 cxr
 vRZ
@@ -82730,12 +82776,12 @@ bJz
 wqD
 bJz
 bJz
+lXX
+kpP
+kpP
 oqy
-cjX
-cjX
-eZU
 bHR
-wtM
+mWE
 jYt
 qyr
 qyr
@@ -82822,32 +82868,32 @@ qVP
 qVP
 qVP
 wuy
-qMP
-gwR
+trK
+gbS
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-qMP
-qMP
-qMP
+trK
+trK
+trK
 nGf
-qMP
-qMP
-qMP
+trK
+trK
+trK
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-gwR
-qMP
-qMP
+gbS
+trK
 wuy
-wuy
+qVP
+qVP
 vRZ
 gzi
 vRZ
@@ -82887,20 +82933,20 @@ pfG
 pfG
 pfG
 pfG
-riv
+oIA
 uSt
 kVO
 kVf
 sXZ
 bHX
-uQN
+wpg
 tWq
-aLK
+gwR
 dHZ
 weY
 qyr
 bHR
-wtM
+mWE
 daa
 qKU
 qKU
@@ -82979,8 +83025,8 @@ qVP
 qVP
 qVP
 wuy
-qMP
-gwR
+trK
+gbS
 rQA
 rQA
 rQA
@@ -83000,11 +83046,11 @@ rQA
 rQA
 rQA
 rQA
-gwR
+gbS
 sCc
-qMP
 wuy
-wuy
+qVP
+qVP
 kZJ
 cJh
 kZJ
@@ -83049,7 +83095,7 @@ qyr
 qyr
 qyr
 bHR
-wtM
+mWE
 lQE
 bqe
 iee
@@ -83057,7 +83103,7 @@ qam
 wYH
 qyr
 bHR
-wtM
+mWE
 daa
 jNW
 jNW
@@ -83136,32 +83182,32 @@ qVP
 qVP
 qVP
 wuy
-qMP
-gwR
+trK
+gbS
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-qMP
-qMP
-qMP
+trK
+trK
+trK
 nGf
-qMP
-qMP
-qMP
+trK
+trK
+trK
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-gwR
+gbS
 dsu
-qMP
 wuy
-wuy
+qVP
+qVP
 kZJ
 srA
 kZJ
@@ -83197,7 +83243,7 @@ rcl
 wUC
 aTw
 crJ
-xLY
+psT
 svE
 crJ
 crJ
@@ -83214,7 +83260,7 @@ qyr
 qyr
 qyr
 uck
-rFn
+iFU
 xIM
 pfC
 pXF
@@ -83293,32 +83339,32 @@ qVP
 qVP
 qVP
 wuy
-qMP
-qMP
+trK
+trK
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-qMP
-qMP
-qMP
+trK
+trK
+trK
 nGf
-qMP
-qMP
-qMP
+trK
+trK
+trK
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-qMP
+trK
 sCc
-qMP
 wuy
-wuy
+qVP
+qVP
 kZJ
 aWO
 uZr
@@ -83358,20 +83404,20 @@ veP
 esC
 tdg
 dAi
-xLY
+psT
 gPB
 qbh
 qbh
 bHR
 qUM
-uQN
+wpg
 tWq
-aLK
+gwR
 aTa
 weY
 qyr
 bHR
-wtM
+mWE
 daa
 qyr
 qyr
@@ -83450,8 +83496,8 @@ qVP
 qVP
 qVP
 wuy
-qMP
-nIU
+trK
+vkv
 rQA
 rQA
 rQA
@@ -83471,10 +83517,10 @@ rQA
 rQA
 rQA
 rQA
-qMP
+trK
 sCc
-qMP
 wuy
+qVP
 kZJ
 kZJ
 kZJ
@@ -83520,7 +83566,7 @@ vky
 vky
 vky
 vky
-wrl
+nUa
 lQE
 aII
 iee
@@ -83528,7 +83574,7 @@ qam
 hHl
 qyr
 bHR
-wtM
+mWE
 daa
 qbh
 qbh
@@ -83607,31 +83653,31 @@ qVP
 qVP
 qVP
 wuy
-qMP
-nIU
-gpp
+trK
+vkv
+tAR
 jeU
-iCe
+nBX
 jeU
-iCe
-gpp
-qMP
-qMP
-qMP
+nBX
+tAR
+trK
+trK
+trK
 nGf
-qMP
-qMP
-qMP
-gpp
+trK
+trK
+trK
+tAR
 jeU
-iCe
+nBX
 jeU
-iCe
-gpp
+nBX
+tAR
 sCc
 sCc
-qMP
 wuy
+qVP
 kZJ
 xii
 lUG
@@ -83672,12 +83718,12 @@ psI
 pnG
 bpE
 faw
-gqh
+xLY
 uej
 bNV
 bNV
 bHR
-wtM
+mWE
 hor
 qyr
 qyr
@@ -83686,11 +83732,11 @@ qyr
 qyr
 uck
 odO
-mWE
-mWE
-mWE
-mWE
-mWE
+hDf
+hDf
+hDf
+hDf
+hDf
 cah
 ioB
 nPD
@@ -83767,10 +83813,10 @@ wuy
 wuy
 qQP
 lhT
-qHk
-qHk
-qHk
-qHk
+jdI
+jdI
+jdI
+jdI
 vTc
 qQP
 qQP
@@ -83780,15 +83826,15 @@ qQP
 qQP
 qQP
 pXJ
-upb
-upb
-upb
-upb
+tHs
+tHs
+tHs
+tHs
 rgW
 qQP
-qQP
 wuy
 wuy
+qVP
 kZJ
 tTm
 vhO
@@ -83835,14 +83881,14 @@ qyr
 qyr
 bHR
 qUM
-uQN
+wpg
 tWq
-aLK
+gwR
 fwd
 weY
 qyr
 bHR
-wtM
+mWE
 daa
 qnh
 qyr
@@ -83942,8 +83988,8 @@ gXh
 weG
 weG
 nJu
-rUa
-mHr
+qQP
+qVP
 qVP
 qVP
 kZJ
@@ -83991,7 +84037,7 @@ vMZ
 gmr
 cPb
 oYf
-wtM
+mWE
 lQE
 tmp
 iee
@@ -83999,7 +84045,7 @@ qam
 kIo
 qyr
 bHR
-wtM
+mWE
 daa
 wAU
 sBj
@@ -84100,7 +84146,7 @@ uzD
 bAy
 dAF
 ogk
-uGU
+qVP
 qVP
 qVP
 eRR
@@ -84148,7 +84194,7 @@ wie
 mny
 qyr
 bHR
-wtM
+mWE
 ebi
 qyr
 qyr
@@ -84156,7 +84202,7 @@ qyr
 qyr
 qyr
 uck
-wtM
+mWE
 daa
 mdl
 qyr
@@ -84255,9 +84301,9 @@ nzy
 sjI
 bIh
 lyZ
-dAF
-mWW
-uGU
+vDc
+rUa
+qVP
 qVP
 qVP
 eRR
@@ -84305,7 +84351,7 @@ efK
 bwU
 qyr
 bHR
-wtM
+mWE
 qbh
 gPB
 qbh
@@ -84313,7 +84359,7 @@ qbh
 qbh
 qbh
 qbh
-wtM
+mWE
 qbh
 qbh
 kFF
@@ -84413,8 +84459,8 @@ eIK
 kit
 edO
 hCO
-dUe
-uGU
+pmS
+qVP
 qVP
 qVP
 eRR
@@ -84463,7 +84509,7 @@ nGw
 qyr
 nDq
 xLA
-mWE
+hDf
 ejX
 mfG
 cPn
@@ -84473,7 +84519,7 @@ mfG
 pqx
 mfG
 mfG
-kHK
+ldv
 wmg
 ust
 qyr
@@ -84567,11 +84613,11 @@ fYJ
 bAy
 bVz
 jiK
-trK
+iMZ
 blO
 cTo
 pmS
-uGU
+qVP
 qVP
 qVP
 eRR
@@ -84630,7 +84676,7 @@ bNV
 vrG
 bNV
 bNV
-eOC
+ctC
 bNV
 bNV
 qyr
@@ -84725,10 +84771,10 @@ qMD
 gGE
 sVe
 yim
-wpg
-uqJ
+yhZ
+wrl
 dOf
-xOq
+qVP
 qVP
 qVP
 eRR
@@ -84885,7 +84931,7 @@ qQP
 qQP
 qQP
 qQP
-qQP
+qVP
 qVP
 qVP
 qVP
@@ -85101,7 +85147,7 @@ qVP
 qVP
 wCo
 gvH
-bul
+dSu
 olT
 jdO
 wCo
@@ -85258,7 +85304,7 @@ dTg
 dTg
 dTg
 cmX
-diA
+bul
 isb
 tsI
 wCo
@@ -85407,7 +85453,7 @@ lJw
 cFv
 syO
 pgS
-uso
+xYm
 joj
 woI
 eZS
@@ -85564,7 +85610,7 @@ dmE
 cFv
 crs
 fLg
-xYm
+hbF
 dYv
 woI
 qZi
@@ -85838,9 +85884,9 @@ uxc
 wCJ
 vVb
 vVb
-bYx
-bYx
-bYx
+sKg
+sKg
+sKg
 mUn
 mUn
 mUn
@@ -85974,10 +86020,10 @@ xth
 xth
 xth
 eIL
-eIL
-eIL
-eIL
-eIL
+rVJ
+rVJ
+wgV
+idt
 xth
 fdA
 uOG
@@ -85993,12 +86039,12 @@ aNP
 aAq
 aGd
 aGd
-dqV
+tQQ
 kPt
 oyt
 egd
 kNZ
-iCH
+iol
 mUn
 mUn
 mUn
@@ -86133,7 +86179,7 @@ cNx
 aJZ
 llM
 gMP
-llM
+scS
 tEB
 xth
 rRW
@@ -86150,11 +86196,11 @@ ghX
 ojj
 qAi
 vVb
-tQQ
+bKO
 pWI
-gbS
-gbS
-gbS
+bYx
+bYx
+bYx
 aBf
 mUn
 dpz
@@ -86290,7 +86336,7 @@ bUh
 oRx
 tYl
 hpF
-jZK
+rUG
 iVk
 xth
 nCJ
@@ -86302,7 +86348,7 @@ lSF
 gOY
 mHD
 nPN
-wmL
+biA
 icl
 ojj
 tit
@@ -86459,7 +86505,7 @@ eQw
 sun
 dJK
 hJJ
-nBX
+wmL
 dCM
 ojj
 aVq
@@ -86625,8 +86671,8 @@ gFX
 gFX
 gFX
 kih
-ifb
-qLv
+pcr
+lyQ
 fsT
 gvY
 qVP
@@ -86915,14 +86961,14 @@ kDP
 kDP
 eCA
 eCA
-eCA
+ilJ
 eCA
 eCA
 pAx
 gbr
-mvI
-ukz
 pSi
+ukz
+uGU
 tfP
 hPr
 jgb
@@ -86930,7 +86976,7 @@ fBA
 tfj
 eFj
 mcE
-boD
+diA
 avK
 uiB
 pIx
@@ -87072,7 +87118,7 @@ bXK
 ccb
 ccb
 ccb
-bXK
+eAV
 ccb
 bWA
 vqr
@@ -87221,7 +87267,7 @@ gsG
 jIe
 kxC
 ccb
-uua
+koC
 ccb
 rib
 hmJ
@@ -87377,9 +87423,9 @@ qVP
 gsG
 gsG
 gsG
-bYC
+qRY
 adK
-gdm
+ahD
 gsG
 gsG
 pMH
@@ -87398,10 +87444,10 @@ sSt
 pmf
 jto
 xtH
-jdI
+qMP
 fRQ
 xbE
-nBX
+wmL
 bZM
 ojj
 pIx
@@ -87555,10 +87601,10 @@ nJs
 jSE
 kPV
 mXQ
-jdI
+qMP
 ktu
 xbE
-nBX
+wmL
 nAU
 ojj
 von
@@ -87701,10 +87747,10 @@ qey
 qey
 fhe
 gsG
-ahD
-ahD
+tDb
+tDb
 uop
-ahD
+tDb
 gsG
 djs
 nhz
@@ -88026,7 +88072,7 @@ huG
 aYV
 mrm
 upl
-jdI
+qMP
 mKE
 jqC
 dEQ
@@ -88183,10 +88229,10 @@ rDV
 iAC
 fRC
 bmS
-jdI
+qMP
 pIG
 kNf
-vvP
+upb
 lwr
 hPz
 xwH
@@ -88495,10 +88541,10 @@ cMl
 oaV
 vBz
 pee
-mxG
+pvp
 jgI
 cAY
-qTs
+swY
 oTl
 sRF
 sRF
@@ -88651,11 +88697,11 @@ vPr
 ebH
 fjl
 hfM
-cgZ
-kcE
+tZl
+xrd
 tKf
 jYX
-kkZ
+olt
 qoR
 sRF
 keh
@@ -88961,7 +89007,7 @@ mpT
 eGf
 gkJ
 jZb
-cfy
+cXc
 kEE
 ebH
 kRQ
@@ -89118,8 +89164,8 @@ anZ
 eGf
 eAg
 sxb
-yhZ
-jxU
+pYn
+wtM
 gkJ
 eAg
 feG
@@ -89276,7 +89322,7 @@ exz
 hFC
 gQv
 tfU
-bAp
+omf
 ohb
 ebH
 mbT
@@ -90037,7 +90083,7 @@ qVP
 qVP
 qVP
 rHU
-kpP
+hcc
 rqy
 rqy
 rqy
@@ -90194,7 +90240,7 @@ qVP
 qVP
 iHy
 ruE
-bwV
+pIj
 rqy
 rqy
 rqy
@@ -90349,9 +90395,9 @@ rqy
 rqy
 rqy
 rqy
-kpP
+hcc
 rEA
-goW
+quR
 rEA
 rEA
 sIt
@@ -90378,7 +90424,7 @@ naE
 mCH
 dvF
 hHs
-cHR
+kkt
 dwU
 blf
 blf
@@ -90506,9 +90552,9 @@ rqy
 rqy
 rqy
 rqy
-kpP
+hcc
 rek
-oYE
+iaa
 jJJ
 wAN
 sIt
@@ -90663,12 +90709,12 @@ qVP
 rqy
 rqy
 rqy
-aBZ
+kTS
 rEA
-ldv
+oYE
 jBo
-dJx
-quR
+qHk
+aNc
 ruE
 ieM
 rqy
@@ -90820,7 +90866,7 @@ qVP
 rqy
 tuc
 tuc
-kpP
+hcc
 rEA
 aQr
 oXp
@@ -112889,7 +112935,7 @@ hwG
 goF
 tgq
 fzN
-cKA
+xdW
 pAc
 bOE
 vvm
@@ -113517,8 +113563,8 @@ pyk
 wuy
 wuy
 jfa
-cSA
-wVE
+vVU
+gqh
 wuT
 wuT
 mkD
@@ -113675,7 +113721,7 @@ wuy
 wuy
 jfa
 xQj
-vVU
+wVE
 xQj
 grS
 grS
@@ -113832,7 +113878,7 @@ wuy
 wuy
 jfa
 eDR
-vVU
+wVE
 xQj
 ePu
 mLH
@@ -113989,7 +114035,7 @@ jfa
 jfa
 jfa
 nrV
-vVU
+wVE
 xQj
 vCp
 vCp
@@ -114146,7 +114192,7 @@ kqI
 maF
 ubl
 foK
-vVU
+wVE
 xQj
 grS
 txW
@@ -114303,7 +114349,7 @@ vfS
 xQj
 xQj
 xQj
-vVU
+wVE
 xQj
 qHm
 fJj
@@ -114460,7 +114506,7 @@ kQI
 xQj
 xQj
 xQj
-vVU
+wVE
 xQj
 vCp
 vCp
@@ -114617,7 +114663,7 @@ sEi
 grS
 xQj
 grS
-vVU
+wVE
 xQj
 xQj
 qgZ
@@ -115088,7 +115134,7 @@ kRE
 bmz
 bmz
 bmz
-dYw
+aRb
 jbI
 jbI
 jbI
@@ -115251,7 +115297,7 @@ mpQ
 mpQ
 eJO
 mpQ
-idt
+fNw
 bCA
 qhL
 qhL
@@ -115407,8 +115453,8 @@ pyh
 ctS
 ctS
 pyh
-eAV
-iol
+bkq
+hWp
 jfa
 czR
 ggl
@@ -115565,7 +115611,7 @@ qGr
 qQy
 pyh
 mpQ
-idt
+fNw
 mpQ
 mpQ
 mpQ
@@ -115716,16 +115762,16 @@ aDi
 jlE
 pyh
 hyP
-ojo
+lTu
 hch
 hch
 hQX
 pyh
 mpQ
-eYM
+uQN
 xbH
 eWW
-swY
+dJx
 uUC
 mpQ
 jfa
@@ -116036,7 +116082,7 @@ sxJ
 jXz
 pyh
 mpQ
-nuD
+eYM
 cPJ
 tdy
 hFz
@@ -116187,8 +116233,8 @@ qMo
 qMo
 qMo
 qMo
-qMo
-qMo
+pyh
+pyh
 pyh
 pyh
 pyh
@@ -116196,7 +116242,7 @@ jjd
 xpH
 cPJ
 ncG
-iLi
+byz
 pzN
 cPJ
 wuy
@@ -116344,7 +116390,7 @@ iIS
 oxZ
 iIS
 krr
-dSu
+mpQ
 naA
 mpQ
 mpQ
@@ -116353,7 +116399,7 @@ mpQ
 xpH
 cPJ
 vsE
-rSM
+iLi
 bmZ
 cPJ
 wuy
@@ -116503,10 +116549,10 @@ bvM
 rJS
 dpc
 dpc
-iWc
-iWc
-iWc
-iWc
+dpc
+dpc
+dpc
+dpc
 ivq
 cPJ
 evB
@@ -116658,7 +116704,7 @@ oKi
 xsP
 xRH
 krr
-dSu
+mpQ
 bBI
 mpQ
 mpQ
@@ -116815,8 +116861,8 @@ qMo
 qMo
 qMo
 qMo
-qMo
-qMo
+jfa
+jfa
 jfa
 jfa
 jfa

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -4,7 +4,6 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "aaf" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "aak" = (
@@ -211,7 +210,10 @@
 /area/station/hallway/primary/central)
 "afp" = (
 /obj/structure/cable/yellow{
-	icon_state = "144"
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
@@ -421,6 +423,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "alr" = (
@@ -469,20 +477,16 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "amN" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"anC" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
 "anE" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/dorms/cryo)
@@ -698,7 +702,6 @@
 /area/station/security/medical)
 "asn" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/engine,
 /area/station/science/misc_lab/range)
 "asw" = (
@@ -776,10 +779,18 @@
 /area/station/commons/dorms/barracks/male)
 "aur" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "auw" = (
@@ -788,7 +799,9 @@
 /area/station/cargo/storage)
 "auB" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "auT" = (
@@ -916,7 +929,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -985,20 +1000,21 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "azW" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms/cryo)
 "aAj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "aAn" = (
@@ -1041,7 +1057,7 @@
 /area/station/hallway/primary/port)
 "aBf" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
@@ -1070,10 +1086,12 @@
 /area/station/commons/storage/primary)
 "aCy" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "aCE" = (
@@ -1156,12 +1174,14 @@
 /area/station/hallway/primary/central/aft)
 "aEu" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aEw" = (
@@ -1207,9 +1227,17 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
+"aGi" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "aGC" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
@@ -1230,13 +1258,6 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse/upper)
-"aHo" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "aHO" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
@@ -1311,13 +1332,11 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
 "aJv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms/cryo)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "aJH" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -1421,9 +1440,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "aNG" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aNI" = (
@@ -1465,12 +1486,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "aOS" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aPd" = (
@@ -1524,6 +1547,18 @@
 /obj/effect/spawner/random/engineering/material,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"aQJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "aQL" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -1579,6 +1614,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
@@ -1659,17 +1697,6 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
-"aSP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "aSR" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1773,8 +1800,10 @@
 "aUq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "aUt" = (
@@ -1831,11 +1860,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "aWM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "aWO" = (
@@ -1853,7 +1884,9 @@
 "aXf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "aXp" = (
@@ -1908,7 +1941,6 @@
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "aYU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -1955,8 +1987,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "bat" = (
@@ -2044,8 +2078,10 @@
 /area/station/security/brig)
 "bcm" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "bct" = (
@@ -2118,9 +2154,11 @@
 /area/station/science/research)
 "beN" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -2271,7 +2309,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "bir" = (
@@ -2356,6 +2393,19 @@
 /obj/structure/water_source/puddle,
 /turf/open/floor/grass,
 /area/station/service/library)
+"bkG" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "bkR" = (
 /obj/structure/table,
 /obj/effect/spawner/random/deadspace/ammo,
@@ -2411,9 +2461,11 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "bmx" = (
@@ -2553,7 +2605,7 @@
 "bqd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
@@ -2635,16 +2687,6 @@
 /obj/item/gun/ballistic/automatic/pistol/rivet,
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
-"brs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/computer)
 "brD" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 5
@@ -2709,6 +2751,18 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central/aft)
+"bsJ" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "bsW" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/machinery/computer/atmos_control/plasma_tank{
@@ -2741,7 +2795,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -2865,13 +2919,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"bxn" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "bxp" = (
 /obj/machinery/power/floodlight,
 /obj/effect/turf_decal/box,
@@ -2969,6 +3016,15 @@
 /obj/structure/railing,
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
+"bzz" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "bzD" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/item/bikehorn/airhorn,
@@ -3045,9 +3101,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"bAY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/commons/dorms/barracks/male)
 "bBh" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/closet/secure_closet/personal,
@@ -3155,7 +3217,9 @@
 /obj/structure/table/glass,
 /obj/item/disk/holodisk/ds13/cryo,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "bEf" = (
@@ -3254,8 +3318,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "bGQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "bHy" = (
@@ -3344,6 +3410,14 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
+"bJn" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/break_room)
 "bJz" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/central)
@@ -3376,13 +3450,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
-"bLq" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "bLS" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -3536,12 +3603,14 @@
 	},
 /area/station/hallway/primary/starboard)
 "bPk" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bPs" = (
@@ -3690,6 +3759,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/maint_center{
 	dir = 8
 	},
@@ -3729,6 +3801,16 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
+"bTS" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/male)
 "bTT" = (
 /obj/structure/janitorialcart,
 /obj/effect/turf_decal/box,
@@ -3861,6 +3943,12 @@
 /obj/machinery/light/small/maintenance/directional/west,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"bWQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "bWY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 4
@@ -3970,13 +4058,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/camera/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bZM" = (
@@ -4094,11 +4184,12 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "ccB" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -4257,10 +4348,28 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
+"chz" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "chP" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
+"chW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "ciq" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
@@ -4340,6 +4449,11 @@
 	},
 /turf/closed/wall/r_wall,
 /area/station/cargo/storage)
+"clx" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "clD" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 1
@@ -4560,9 +4674,11 @@
 /obj/structure/table,
 /obj/machinery/telephone/research,
 /obj/machinery/light/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/item/folder,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "crE" = (
@@ -4570,7 +4686,6 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "crF" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/command{
 	name = "Medical Director's Office";
 	req_one_access_txt = "40";
@@ -4580,6 +4695,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "crJ" = (
@@ -4691,8 +4809,10 @@
 "cuM" = (
 /obj/structure/table,
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/telephone/command,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "cuN" = (
@@ -4735,20 +4855,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/starboard)
-"cvG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "cvS" = (
 /turf/open/floor/deadspace/cable{
 	dir = 8
@@ -4787,12 +4893,6 @@
 	dir = 8
 	},
 /area/mine/production)
-"cxh" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "cxq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -4988,12 +5088,17 @@
 /area/station/medical/chemistry)
 "cBm" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cBD" = (
@@ -5060,9 +5165,17 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "cDr" = (
@@ -5286,6 +5399,12 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
+"cIs" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/checkpoint/customs)
 "cIF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5334,14 +5453,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "cKw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/maint_right{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "68"
 	},
-/area/station/hallway/primary/fore)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "cKy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -5457,12 +5573,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/monitoring)
-"cNY" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "cOf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -5490,12 +5600,17 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cPb" = (
@@ -5592,6 +5707,14 @@
 /obj/item/clothing/mask/bandana/blue,
 /turf/open/floor/deadspace/hardwood,
 /area/station/maintenance/fore/lesser)
+"cQO" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "cQY" = (
 /turf/open/floor/deadspace/mono,
 /area/station/security/lockers)
@@ -5681,12 +5804,13 @@
 /turf/open/water,
 /area/station/maintenance/port/lesser)
 "cUc" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "cUs" = (
 /obj/machinery/disposal/bin,
 /obj/effect/floor_decal/ds/spline/fancy/wood{
@@ -5749,9 +5873,11 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "cVS" = (
@@ -5898,6 +6024,12 @@
 	dir = 4
 	},
 /area/station/security/brig)
+"dag" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "daK" = (
 /obj/structure/chair/office,
 /obj/effect/landmark/start/chief_medical_officer,
@@ -6000,8 +6132,10 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/telephone/research,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
 "dfh" = (
@@ -6076,13 +6210,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 4
-	},
-/area/station/security/brig)
+/turf/open/floor/iron/white,
+/area/station/service/kitchen)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -6097,6 +6233,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/maint_center{
 	dir = 8
 	},
@@ -6114,6 +6253,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "djT" = (
@@ -6135,6 +6277,14 @@
 /obj/item/plate_shard/marker_shard,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
+"dkf" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "dki" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/norn,
@@ -6215,10 +6365,15 @@
 	},
 /area/station/hallway/primary/port)
 "dmq" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "dmE" = (
@@ -6314,10 +6469,12 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/rd)
 "dpv" = (
@@ -6415,18 +6572,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
-"dsr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/commons/dorms/cryo)
 "dsu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
@@ -6695,9 +6840,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
+	dir = 8
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -6706,10 +6850,12 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/cable/multiz,
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
@@ -6780,11 +6926,21 @@
 	name = "Cryogenics Bay";
 	req_access_txt = "5"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"dDl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "dDu" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/side{
@@ -6833,12 +6989,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dEQ" = (
@@ -6850,10 +7008,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "dFA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/multitool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "dFK" = (
@@ -6926,17 +7086,6 @@
 /obj/structure/chair/sofa/corp/right,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"dHB" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "dHH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -6967,12 +7116,14 @@
 	name = "Break Room";
 	req_access_txt = "5"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "dHZ" = (
@@ -7039,10 +7190,10 @@
 /area/station/cargo/drone_bay)
 "dJx" = (
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "40"
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
@@ -7108,9 +7259,14 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dLK" = (
@@ -7124,7 +7280,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "dMf" = (
@@ -7150,8 +7311,13 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "dOa" = (
@@ -7211,20 +7377,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
-"dQc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "dQh" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -7295,9 +7447,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "dSg" = (
@@ -7310,10 +7464,16 @@
 	},
 /area/aegis/mining)
 "dSu" = (
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/area/aegis/surface)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "dSB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -7421,24 +7581,22 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "dUe" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
 	},
-/turf/open/floor/iron/white,
-/area/station/service/kitchen)
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "dUl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -7472,6 +7630,25 @@
 	dir = 4
 	},
 /area/mine/production)
+"dUu" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
+"dUL" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "dUU" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -7490,6 +7667,16 @@
 /obj/structure/reagent_dispensers/wall/peppertank/directional/east,
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/checkpoint/science)
+"dVu" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "dVv" = (
 /obj/structure/ore_box,
 /obj/effect/turf_decal/box,
@@ -7513,6 +7700,18 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/dorms/cryo)
+"dWl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "dWo" = (
 /obj/structure/rack{
 	icon = 'icons/obj/stationobjs.dmi';
@@ -7764,7 +7963,9 @@
 "edm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "edr" = (
@@ -7794,7 +7995,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "edX" = (
@@ -7809,7 +8009,9 @@
 /area/station/commons/dorms/barracks/male)
 "eem" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
 "eer" = (
@@ -7864,9 +8066,9 @@
 /area/station/security/brig)
 "efO" = (
 /obj/structure/cable/yellow{
-	icon_state = "68"
+	icon_state = "40"
 	},
-/turf/open/misc/asteroid,
+/turf/open/misc/ironsand,
 /area/aegis/surface)
 "efQ" = (
 /obj/effect/turf_decal/tile/purple,
@@ -8015,9 +8217,11 @@
 /area/station/cargo/warehouse/upper)
 "eiv" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "eiy" = (
@@ -8204,6 +8408,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "epA" = (
@@ -8240,7 +8447,6 @@
 /area/station/hallway/primary/port)
 "eqm" = (
 /obj/structure/table,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/controller,
 /obj/item/compact_remote,
 /obj/item/compact_remote,
@@ -8274,24 +8480,6 @@
 "erk" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo)
-"ern" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
-"erN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "esc" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/machinery/light/small/maintenance/directional/north,
@@ -8313,26 +8501,10 @@
 	},
 /turf/open/floor/eighties/red,
 /area/aegis/surface)
-"esY" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
 "etp" = (
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"etu" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "etC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -8391,8 +8563,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "evb" = (
@@ -8787,6 +8961,16 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
+"eEL" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/female)
 "eET" = (
 /obj/machinery/computer/security,
 /obj/machinery/computer/security/telescreen{
@@ -8861,7 +9045,6 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "eGb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -9002,10 +9185,7 @@
 "eIL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "1"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/monitoring)
@@ -9118,6 +9298,9 @@
 /obj/machinery/telephone/security,
 /obj/machinery/power/data_terminal,
 /obj/machinery/door/window/brigdoor/left/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "eMN" = (
@@ -9301,7 +9484,9 @@
 "eRL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/machinery/meter,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "eRR" = (
@@ -9348,8 +9533,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
 "eTw" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
 "eTK" = (
@@ -9390,7 +9577,6 @@
 /area/station/security/brig)
 "eVb" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/plating,
 /area/station/science/server)
@@ -9467,7 +9653,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "3"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
@@ -9702,13 +9888,13 @@
 "fdT" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "2"
+	icon_state = "9"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "10"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
@@ -9719,15 +9905,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/starboard)
-"fex" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "feD" = (
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
@@ -9759,18 +9936,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ffw" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "ffz" = (
@@ -9875,17 +10056,6 @@
 /obj/item/toy/figure/scientist,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
-"fir" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "miningsecprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/science)
 "fiB" = (
 /obj/structure/closet/crate/large/ds/green_horizontal,
 /obj/effect/spawner/random/medical/minor_healing,
@@ -10032,14 +10202,15 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/misc_lab)
 "flr" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "flJ" = (
@@ -10131,11 +10302,13 @@
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/male)
 "foI" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "foK" = (
@@ -10173,23 +10346,33 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/light_switch/directional{
 	pixel_x = -24;
 	pixel_y = -8
 	},
 /obj/machinery/vending/medical,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fpH" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "fpO" = (
@@ -10211,11 +10394,13 @@
 	req_access_txt = "33";
 	stripe_paint = "#ff9900"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "fqc" = (
@@ -10294,6 +10479,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right{
 	dir = 8
 	},
@@ -10450,13 +10638,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lesser)
-"fxU" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "fxZ" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/plating,
@@ -10542,9 +10723,17 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "fBC" = (
-/obj/structure/disposalpipe/trunk/multiz,
-/turf/closed/wall/r_wall,
-/area/station/medical/medbay/aft)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "fCw" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -10938,6 +11127,14 @@
 /obj/item/radio/intercom/directional/south,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"fOK" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "fOP" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
@@ -11000,11 +11197,13 @@
 /area/station/security/brig)
 "fQf" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/camera/directional/south{
 	c_tag = "Science Hallway - South"
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "fQu" = (
@@ -11062,6 +11261,14 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
+"fRr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "fRC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/firealarm/directional/east,
@@ -11437,7 +11644,6 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "gbS" = (
-/obj/structure/lattice,
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -11512,7 +11718,9 @@
 "gew" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "geM" = (
@@ -11645,9 +11853,11 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "gjc" = (
@@ -11669,6 +11879,13 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"gjU" = (
+/obj/structure/cable/multiz,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "gka" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -11751,12 +11968,17 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "glT" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/yjunction{
 	icon_state = "pipe-y";
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
@@ -11898,20 +12120,15 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
 	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
+/obj/structure/cable/red{
+	icon_state = "1"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -12031,14 +12248,13 @@
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/captain)
 "guQ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/rack,
+/obj/effect/spawner/random/clothing/costume,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "gva" = (
 /obj/structure/railing,
 /turf/open/floor/deadspace/random/rectangles,
@@ -12088,13 +12304,14 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/area/station/engineering/main)
 "gxI" = (
 /obj/structure/cable/yellow{
 	icon_state = "3"
@@ -12105,12 +12322,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gxZ" = (
@@ -12123,14 +12342,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/aft)
-"gyh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "gyv" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
@@ -12323,12 +12534,14 @@
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "gEb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gEj" = (
@@ -12583,12 +12796,20 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
 "gOz" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "gOA" = (
@@ -12733,9 +12954,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -12798,6 +13021,17 @@
 /obj/machinery/vending/games,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/security/courtroom)
+"gSl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "gSA" = (
 /obj/structure/rack,
 /obj/item/tank/internals/emergency_oxygen/double,
@@ -12991,9 +13225,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
@@ -13140,31 +13376,15 @@
 	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/service/chapel/office)
-"hat" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "P-Sec Brig";
-	req_access_txt = "63";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig)
 "hay" = (
 /obj/machinery/holopad,
 /obj/effect/landmark/start/scientist,
 /obj/effect/turf_decal/box/white,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "haz" = (
@@ -13219,16 +13439,6 @@
 /obj/structure/bed/roller,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"hbZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/male)
 "hch" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -13324,7 +13534,6 @@
 	name = "Aegis Science"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -13374,9 +13583,11 @@
 "hgU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
@@ -13744,7 +13955,9 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "hsj" = (
@@ -13781,6 +13994,16 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/deadspace/mono,
 /area/aegis/mining)
+"htm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "htp" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -13792,8 +14015,10 @@
 "hty" = (
 /obj/structure/table,
 /obj/machinery/telephone/research,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "htA" = (
@@ -13983,9 +14208,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "hxA" = (
@@ -14006,12 +14233,14 @@
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "hxF" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "hxG" = (
@@ -14030,8 +14259,10 @@
 /area/station/medical/medbay/central)
 "hyK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "hyN" = (
@@ -14069,6 +14300,12 @@
 	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/security/courtroom)
+"hzt" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "hzL" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -14179,10 +14416,15 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "hDf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/red,
-/area/station/security/office)
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "hDv" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/customs)
@@ -14252,7 +14494,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "hFC" = (
@@ -14405,7 +14649,9 @@
 "hJs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "hJv" = (
@@ -14423,17 +14669,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
-"hJF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "hJJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 4
@@ -14623,8 +14858,10 @@
 /area/station/command/heads_quarters/ce)
 "hOT" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/cold/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "hOX" = (
@@ -14851,13 +15088,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
-"hUd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/commons/dorms/barracks/male)
 "hUi" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -15005,15 +15235,6 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"hYP" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
 "hYZ" = (
 /turf/open/floor/engine/airless,
 /area/station/engineering/supermatter/room)
@@ -15094,9 +15315,11 @@
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "ibV" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
 "icl" = (
@@ -15126,16 +15349,13 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "miningsecprivacy";
-	name = "privacy shutter"
-	},
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "3"
 	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/science)
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
+	},
+/area/station/security/brig)
 "idy" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor{
@@ -15375,14 +15595,12 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lesser)
 "iix" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/plating,
+/area/station/security/warden)
 "iiK" = (
 /obj/structure/closet,
 /turf/open/floor/plating,
@@ -15626,15 +15844,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "imS" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/red{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "imT" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -15671,13 +15888,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "iol" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "18"
 	},
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
+/turf/open/misc/ironsand,
 /area/aegis/surface)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
@@ -15789,10 +16003,12 @@
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "isc" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "isj" = (
@@ -15831,6 +16047,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
+"iuc" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "iup" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/cmo)
@@ -15865,6 +16087,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
+"ivr" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "ivz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -15927,7 +16156,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/maint_center,
+/turf/open/floor/deadspace/grille_spare3,
 /area/station/security/checkpoint/customs)
 "iwK" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -16107,8 +16336,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "iAS" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "iAV" = (
@@ -16144,12 +16375,11 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/turf/open/floor/plating,
+/area/aegis/surface)
 "iCm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate/large/ds/green_horizontal,
@@ -16248,7 +16478,6 @@
 /area/aegis/hanger)
 "iEJ" = (
 /obj/structure/chair/office,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -16336,9 +16565,11 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "iGV" = (
@@ -16447,9 +16678,11 @@
 	req_access_txt = "69;5";
 	stripe_paint = "#ff9900"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "iIq" = (
@@ -16506,13 +16739,9 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "iJI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/white,
-/area/station/science/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "iJV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 4
@@ -16523,20 +16752,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/slides,
 /area/station/ai_monitored/security/armory)
-"iKl" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/security/warden)
 "iKJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "iKK" = (
@@ -16577,7 +16807,7 @@
 "iLi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/fore/greater)
@@ -16657,11 +16887,6 @@
 /obj/effect/spawner/random/food_or_drink/booze,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
-"iMw" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "iMy" = (
 /obj/machinery/light/small/directional/west,
 /obj/machinery/camera/directional/west{
@@ -16815,9 +17040,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "iPr" = (
@@ -16879,12 +17106,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "iQt" = (
@@ -16950,14 +17179,6 @@
 "iSV" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
-"iSX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
 "iSY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -17060,7 +17281,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -17209,6 +17429,13 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/aegis/surface)
+"iZx" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "iZD" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -17280,7 +17507,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
@@ -17368,10 +17598,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "jeU" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -17586,7 +17816,9 @@
 	color = "#9FED58"
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "jjF" = (
@@ -17605,8 +17837,10 @@
 /area/station/cargo/miningdock/cafeteria)
 "jjN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "jjQ" = (
@@ -17700,15 +17934,6 @@
 /mob/living/simple_animal/slug,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
-"jmm" = (
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/hallway/secondary/exit/departure_lounge)
 "jmr" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood,
 /obj/effect/floor_decal/ds/spline/fancy/wood/corner{
@@ -17776,7 +18001,6 @@
 /area/station/tcommsat/computer)
 "jnA" = (
 /obj/effect/landmark/navigate_destination/research,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -17924,11 +18148,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "jpQ" = (
@@ -17970,7 +18196,6 @@
 /area/station/engineering/atmos)
 "jqx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/science/research)
 "jqC" = (
@@ -18159,6 +18384,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"juJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "jvn" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/air_input{
 	dir = 8
@@ -18301,6 +18532,12 @@
 	dir = 1
 	},
 /area/aegis/hanger)
+"jzK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
+/area/station/commons/lounge)
 "jAf" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8;
@@ -18339,7 +18576,6 @@
 /area/aegis/hanger)
 "jAQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/science/server)
 "jAT" = (
@@ -18390,14 +18626,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
-"jCd" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "jCn" = (
 /obj/machinery/door/airlock/mining{
 	name = "Cargo Bay";
@@ -18485,18 +18713,6 @@
 /obj/machinery/light/cold/directional/east,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"jEU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "jFJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -18505,18 +18721,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/checkpoint/science)
-"jFO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "jFR" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/grater,
@@ -18655,7 +18859,6 @@
 	c_tag = "Science Firing Range";
 	network = list("ss13","rd")
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/engine,
 /area/station/science/misc_lab/range)
 "jIT" = (
@@ -18968,8 +19171,10 @@
 /area/station/maintenance/fore/lesser)
 "jRe" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "jRg" = (
@@ -19015,16 +19220,6 @@
 	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit)
-"jSD" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/female)
 "jSE" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
@@ -19056,7 +19251,9 @@
 "jTf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "jTp" = (
@@ -19310,12 +19507,6 @@
 /obj/machinery/vending/assist,
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
-"kbb" = (
-/obj/structure/cable/yellow{
-	icon_state = "132"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "kbh" = (
 /obj/effect/landmark{
 	name = "ShuttleRepairPart"
@@ -19421,6 +19612,9 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "kew" = (
@@ -19443,7 +19637,6 @@
 	placard_name = "Medical PBX"
 	},
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -19640,8 +19833,10 @@
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "kiA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "kiC" = (
@@ -19808,6 +20003,16 @@
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
+"knc" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "knr" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/sunglasses,
@@ -19831,6 +20036,14 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
+"knH" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "knS" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -19850,7 +20063,6 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
@@ -19860,12 +20072,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
-"koA" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
 "koO" = (
 /obj/machinery/light/directional/north,
 /turf/open/misc/asteroid,
@@ -19876,12 +20082,33 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "kpk" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/aegis/surface)
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
+"kpq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "kpy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -19894,12 +20121,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "3"
 	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -20052,7 +20278,9 @@
 /area/station/security/checkpoint/customs)
 "ktX" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "ktY" = (
@@ -20150,7 +20378,7 @@
 /area/station/commons/dorms/laundry)
 "kyb" = (
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "10"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
@@ -20235,6 +20463,14 @@
 /obj/machinery/pdapainter/research,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"kBA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "kBD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -20249,6 +20485,19 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
+"kBE" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "kBN" = (
 /obj/effect/landmark/pestspawn,
 /turf/open/floor/deadspace/random/maint_left{
@@ -20299,17 +20548,24 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "kDx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "med_md_privacy";
 	name = "privacy shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/cmo)
@@ -20334,14 +20590,11 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
 "kDP" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "144"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "kEv" = (
 /obj/item/megaphone,
 /obj/structure/table/wood,
@@ -20434,12 +20687,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "kGp" = (
@@ -20464,12 +20722,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central/aft)
-"kHw" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "kHQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -20760,7 +21012,9 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
 "kPU" = (
@@ -20804,15 +21058,6 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
-"kQW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "kRf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21010,9 +21255,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
 "kVj" = (
@@ -21073,7 +21315,9 @@
 "kXb" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "kXe" = (
@@ -21110,8 +21354,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "kYb" = (
@@ -21190,7 +21436,9 @@
 "lao" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "lav" = (
@@ -21309,8 +21557,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "lcV" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/newscaster/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "ldn" = (
@@ -21332,16 +21582,19 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "ldv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "6"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -21491,7 +21744,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "lhq" = (
@@ -21533,7 +21788,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -21574,8 +21828,10 @@
 /turf/open/floor/stone,
 /area/aegis/surface)
 "liE" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/medical/exam_room)
 "liT" = (
@@ -21635,14 +21891,22 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
+"lkZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "lli" = (
 /obj/machinery/power/floodlight,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "llp" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
 "llB" = (
@@ -21868,10 +22132,12 @@
 /area/station/hallway/primary/starboard)
 "lrx" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "lrH" = (
@@ -21923,12 +22189,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
-"ltj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/station/commons/lounge)
 "lty" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
@@ -21956,6 +22216,9 @@
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -22008,6 +22271,20 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
+"lwU" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/medbay/aft)
 "lwW" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -22100,13 +22377,15 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "lzq" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "lzS" = (
@@ -22160,7 +22439,9 @@
 /obj/item/bot_assembly/janibot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "lAY" = (
@@ -22339,6 +22620,14 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/wood,
 /area/station/service/bar)
+"lGU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/morgue)
 "lHc" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -22807,7 +23096,9 @@
 "lSG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "lSI" = (
@@ -22847,6 +23138,9 @@
 /area/station/service/library)
 "lTz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/male)
 "lTI" = (
@@ -22855,6 +23149,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "lUG" = (
@@ -22968,9 +23265,11 @@
 /obj/structure/table/glass,
 /obj/machinery/telephone/medical,
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/window/reinforced/spawner/north,
 /obj/item/folder/white,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "lZc" = (
@@ -23049,6 +23348,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "maU" = (
@@ -23355,16 +23657,17 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"mjx" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "mjG" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
+"mka" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/service/janitor)
 "mkp" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/deadspace/grater,
@@ -23386,6 +23689,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
+"mlo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "mlt" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -23410,13 +23721,6 @@
 	},
 /turf/open/floor/deadspace/roller,
 /area/aegis/surface)
-"mlO" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "mlU" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/effect/spawner/random/vending/snackvend,
@@ -23574,7 +23878,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -23671,20 +23974,6 @@
 /obj/machinery/newscaster/directional/south,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"mro" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "mry" = (
 /obj/structure/fluff/broken_flooring{
 	icon_state = "singular"
@@ -23908,9 +24197,11 @@
 /area/station/medical/surgery/theatre)
 "mxH" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "mxM" = (
@@ -23989,10 +24280,11 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "mBd" = (
@@ -24017,12 +24309,11 @@
 /turf/open/floor/engine,
 /area/station/command/heads_quarters/rd)
 "mBv" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "mBz" = (
 /obj/machinery/door/airlock/medical{
 	name = "Bioprosthetics Lab";
@@ -24030,10 +24321,12 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
 "mCb" = (
@@ -24046,9 +24339,17 @@
 	},
 /area/mine/production)
 "mCd" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/commons/dorms/cryo)
 "mCl" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/east,
@@ -24057,10 +24358,12 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "mCy" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light_switch/directional{
 	pixel_x = -24;
 	pixel_y = -24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -24123,7 +24426,9 @@
 /area/station/cargo/qm)
 "mCZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "mDg" = (
@@ -24254,8 +24559,10 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/filingcabinet/chestdrawer,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "mIY" = (
@@ -24280,6 +24587,17 @@
 	},
 /turf/open/water,
 /area/station/hallway/primary/aft)
+"mJT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "mJY" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/iron/ten,
@@ -24317,10 +24635,15 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "mLl" = (
@@ -24442,10 +24765,12 @@
 	req_access_txt = "6"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "mNX" = (
@@ -24628,13 +24953,6 @@
 /obj/machinery/cryopod,
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/storage)
-"mUb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "mUd" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment,
@@ -24714,6 +25032,9 @@
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/structure/cable/yellow{
 	icon_state = "8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
@@ -24923,6 +25244,9 @@
 /area/station/command/heads_quarters/ce)
 "nav" = (
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "naz" = (
@@ -25024,7 +25348,7 @@
 /area/station/maintenance/fore/lesser)
 "ncO" = (
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
@@ -25247,11 +25571,6 @@
 	dir = 1
 	},
 /area/station/security/checkpoint/customs)
-"njI" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "njM" = (
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/vitals_monitor,
@@ -25277,9 +25596,11 @@
 /area/aegis/surface)
 "nkV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "nlg" = (
@@ -25499,6 +25820,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"nsG" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "nth" = (
 /obj/machinery/light,
 /turf/open/misc/asteroid,
@@ -25542,6 +25870,13 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"nvs" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "nvH" = (
 /obj/structure/rack,
 /obj/item/plant_analyzer,
@@ -25552,7 +25887,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/corner,
 /area/station/science/lab)
 "nvP" = (
@@ -25569,9 +25906,11 @@
 	},
 /area/aegis/mining)
 "nwv" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "nww" = (
@@ -25618,9 +25957,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
@@ -25633,13 +25974,6 @@
 "nyU" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/qm)
-"nzd" = (
-/obj/structure/cable/multiz,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "nzi" = (
 /obj/structure/railing,
 /turf/open/openspace,
@@ -25667,8 +26001,10 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/machinery/telephone/research,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "nzy" = (
@@ -25726,11 +26062,6 @@
 /obj/item/clothing/head/beret/sec,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"nAn" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
 "nAs" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/lizard_plushie/green,
@@ -25781,11 +26112,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
-"nAV" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "nBo" = (
 /obj/structure/rack,
 /obj/item/chainsaw/plasma_industrial,
@@ -25831,10 +26157,12 @@
 /area/station/engineering/atmos)
 "nBX" = (
 /obj/structure/cable/yellow{
-	icon_state = "40"
+	icon_state = "12"
 	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "nCk" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -25889,9 +26217,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "nDm" = (
@@ -26058,9 +26388,11 @@
 	dir = 4
 	},
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/trunk/multiz/down{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -26141,14 +26473,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "nLV" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -26239,11 +26572,16 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse)
 "nOt" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -26263,11 +26601,14 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "nOQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "10"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/obj/structure/cable/white{
+	icon_state = "132"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/service/chapel/monastery)
 "nOX" = (
 /obj/machinery/cryopod,
 /obj/effect/landmark/latejoin,
@@ -26488,7 +26829,6 @@
 /area/station/maintenance/fore/lesser)
 "nUW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "nUX" = (
@@ -26511,9 +26851,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "nVr" = (
@@ -26737,7 +27079,7 @@
 /area/station/command/bridge)
 "ocO" = (
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/misc/ironsand,
 /area/aegis/surface)
@@ -26792,6 +27134,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "odU" = (
@@ -26807,7 +27152,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "oed" = (
@@ -26935,9 +27282,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "ohT" = (
@@ -26957,7 +27306,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "oie" = (
@@ -27056,8 +27407,10 @@
 /area/station/engineering/atmos/storage/gas)
 "okR" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/airalarm/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/medical/exam_room)
 "olc" = (
@@ -27291,11 +27644,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"oqx" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "oqy" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2"
 	},
@@ -27473,6 +27834,16 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
+"ovS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "ovV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -27615,9 +27986,11 @@
 /area/station/command/bridge)
 "ozj" = (
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "ozm" = (
@@ -27769,6 +28142,9 @@
 	c_tag = "Medbay Main Hallway- Surgical Junction"
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "oET" = (
@@ -27912,7 +28288,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
 "oJa" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
 "oJf" = (
@@ -27942,7 +28320,6 @@
 /obj/item/stock_parts/cell,
 /obj/item/stack/cable_coil,
 /obj/item/assembly/igniter,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "oJI" = (
@@ -28011,12 +28388,17 @@
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/port/lesser)
 "oMj" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "oMn" = (
@@ -28074,13 +28456,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "oOD" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Receptionist Room";
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "oOK" = (
@@ -28381,18 +28765,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
-"oVs" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "oWg" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable/yellow{
@@ -28410,7 +28782,6 @@
 /area/station/engineering/atmos)
 "oXb" = (
 /obj/structure/table,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/camera{
 	c_tag = "Medical Director's Office";
 	dir = 6;
@@ -28420,6 +28791,9 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "oXc" = (
@@ -28439,6 +28813,20 @@
 /obj/effect/landmark/start/medical_doctor,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"oXx" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "oXC" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder{
@@ -28473,16 +28861,6 @@
 	dir = 8
 	},
 /area/station/security/brig)
-"oYi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
 "oYm" = (
 /obj/machinery/shower{
 	dir = 4
@@ -28500,10 +28878,7 @@
 /area/station/medical/medbay/central)
 "oYE" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "6"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -28594,13 +28969,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
-"pbo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/service/janitor)
 "pbp" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plating,
@@ -28613,7 +28981,9 @@
 /turf/open/floor/deadspace/mono,
 /area/station/cargo)
 "pbI" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "pbN" = (
@@ -28755,16 +29125,14 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "pfG" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/hallway/primary/central)
 "pfH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -28796,9 +29164,11 @@
 "pgI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "pgS" = (
@@ -28832,6 +29202,27 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"phJ" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "piB" = (
 /obj/structure/railing{
 	dir = 8
@@ -28936,9 +29327,11 @@
 	req_access_txt = "70";
 	stripe_paint = "#D381C9"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "plM" = (
@@ -29015,11 +29408,15 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "pmS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+/obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/station/service/library)
 "pnj" = (
 /obj/structure/railing{
 	dir = 6
@@ -29204,16 +29601,6 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo)
-"psG" = (
-/obj/effect/floor_decal/ds/spline/fancy/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/carpet/royalblue,
-/area/station/service/library)
 "psI" = (
 /obj/machinery/computer/prisoner/management,
 /obj/machinery/power/apc/auto_name/directional/north,
@@ -29378,8 +29765,10 @@
 	req_access_txt = "5";
 	stripe_paint = "#52B4E9"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pxS" = (
@@ -29430,7 +29819,6 @@
 /area/station/cargo/storage)
 "pyY" = (
 /obj/machinery/computer/communications,
-/obj/item/storage/secure/safe/caps_spare/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "pzk" = (
@@ -29454,6 +29842,13 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
+"pzM" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "pzN" = (
 /obj/item/storage/toolbox/mechanical,
 /obj/item/storage/toolbox/electrical,
@@ -29497,13 +29892,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
-"pAp" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "pAu" = (
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -29582,6 +29970,12 @@
 	dir = 1
 	},
 /area/aegis/hanger)
+"pBG" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "pCh" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
@@ -29699,8 +30093,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "pFl" = (
@@ -30139,12 +30535,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/fore)
-"pPz" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "pPG" = (
 /obj/machinery/door/airlock/external,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -30238,6 +30628,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "pSn" = (
@@ -30269,7 +30662,9 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "pUq" = (
@@ -30575,9 +30970,11 @@
 "qcz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qcO" = (
@@ -30687,9 +31084,11 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "qgt" = (
@@ -30742,7 +31141,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "qho" = (
@@ -30761,6 +31162,11 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
+"qhC" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "qhK" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -30833,10 +31239,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "qkb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "qki" = (
@@ -30859,7 +31267,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/medical{
 	name = "Port Operating Room";
 	req_access_txt = "45";
@@ -30868,6 +31275,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "qlb" = (
@@ -31066,12 +31476,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"qpo" = (
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "qpp" = (
 /obj/effect/turf_decal/siding/white,
 /turf/open/floor/iron/white,
@@ -31156,9 +31560,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "qrQ" = (
@@ -31226,13 +31632,22 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse/upper)
+"qtx" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "qtB" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -31329,16 +31744,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
-"qve" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "qvr" = (
 /obj/structure/table/wood,
 /obj/item/clothing/gloves/ring,
@@ -31384,13 +31789,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"qwv" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "qwA" = (
 /obj/structure/railing{
 	dir = 8
@@ -31454,12 +31852,6 @@
 "qyr" = (
 /turf/closed/wall/r_wall,
 /area/station/security/brig)
-"qyQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
 "qyR" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Medbay Clinic"
@@ -31467,16 +31859,20 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qyX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qzA" = (
@@ -31522,12 +31918,14 @@
 /turf/open/floor/iron/norn,
 /area/station/medical/office)
 "qAY" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 10
-	},
 /obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/science/lab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/hallway/primary/port)
 "qBi" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
@@ -31648,6 +32046,14 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
+"qES" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/exam_room)
 "qEV" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/effect/landmark/pestspawn,
@@ -31686,6 +32092,10 @@
 /obj/item/bedsheet/random,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"qGh" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "qGi" = (
 /obj/structure/sign/cec/deck/security{
 	pixel_y = -32
@@ -31705,11 +32115,19 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qHk" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -31796,6 +32214,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"qJF" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "qJH" = (
 /obj/structure/chair{
 	dir = 4
@@ -31886,11 +32318,9 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "qMP" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/brig)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "qMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -31967,6 +32397,12 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
+"qON" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "qOQ" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/grater,
@@ -32044,8 +32480,10 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "qRz" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "qRI" = (
@@ -32171,14 +32609,16 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "qUM" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/hallway/primary/central)
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "qVj" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
@@ -32381,18 +32821,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
+"raj" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "ran" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 4
 	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
-"rbb" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "rbg" = (
 /obj/machinery/camera/autoname/directional/north,
 /obj/structure/noticeboard/directional/north,
@@ -32407,6 +32851,15 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
+"rbA" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/hallway/secondary/exit/departure_lounge)
 "rbD" = (
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
@@ -32496,7 +32949,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/side,
 /area/station/science/lab)
 "rdS" = (
@@ -32516,8 +32971,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
 "reC" = (
@@ -32761,10 +33218,12 @@
 /area/station/cargo/warehouse/upper)
 "rlA" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rlC" = (
@@ -32861,12 +33320,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
 /area/station/hallway/primary/port)
-"rnV" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "rop" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock/pile/icy,
@@ -32967,6 +33420,13 @@
 "rqy" = (
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"rqC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "rqH" = (
 /obj/machinery/light/small/directional/north,
 /obj/structure/table,
@@ -33095,6 +33555,7 @@
 /obj/structure/closet/secure_closet/psychology,
 /obj/item/clothing/neck/necklace/marker,
 /obj/item/clothing/neck/necklace/marker,
+/obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "ruE" = (
@@ -33237,9 +33698,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "rzw" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "rzy" = (
@@ -33278,6 +33741,17 @@
 /obj/effect/spawner/random/deadspace/ammo/mining,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
+"rAp" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "rAt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/deadspace/mono,
@@ -33415,9 +33889,13 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "rDI" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "rDN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -33498,15 +33976,6 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"rGQ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "rHx" = (
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
@@ -33596,12 +34065,6 @@
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
-"rJq" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/aegis/surface)
 "rJs" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/right/directional/west{
@@ -34035,10 +34498,11 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/mechbay)
 "rVF" = (
@@ -34090,11 +34554,11 @@
 /turf/open/floor/plating,
 /area/station/medical/surgery/theatre)
 "rXD" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/maint_right{
-	dir = 8
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/area/station/hallway/primary/fore)
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "rXE" = (
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
@@ -34151,7 +34615,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "saC" = (
@@ -34196,12 +34659,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
-"scu" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "scx" = (
 /obj/structure/cable/yellow{
 	icon_state = "6"
@@ -34482,18 +34939,6 @@
 	},
 /turf/open/misc/asteroid,
 /area/station/solars/port/fore)
-"slg" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "slG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -34531,9 +34976,11 @@
 /area/station/maintenance/port/lesser)
 "smg" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
@@ -34561,6 +35008,16 @@
 /obj/item/stack/ore/diamond,
 /turf/open/misc/asteroid,
 /area/station/hallway/primary/fore)
+"snm" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "snn" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/medical/medkit_rare,
@@ -34635,13 +35092,6 @@
 	dir = 8
 	},
 /area/aegis/mining)
-"soz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
 "soA" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4;
@@ -34768,9 +35218,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "ssE" = (
@@ -34889,9 +35341,12 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "swY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -34966,6 +35421,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
+"syh" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "syO" = (
 /obj/structure/table/glass,
 /obj/machinery/light/cold/directional/north,
@@ -35020,15 +35482,25 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
 "sAF" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "sAH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"sAI" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "sAQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
@@ -35063,21 +35535,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
-"sBv" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "sCc" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/hallway/primary/port)
+/area/aegis/surface)
 "sCd" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/random/maintenance/two,
@@ -35088,9 +35551,11 @@
 "sCh" = (
 /obj/structure/table,
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/fax_machine,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "sCq" = (
@@ -35148,6 +35613,12 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
+"sDR" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "sDZ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/engineering/flashlight,
@@ -35173,7 +35644,9 @@
 "sEx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "sEz" = (
@@ -35374,10 +35847,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lesser)
-"sLK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "sLV" = (
 /obj/effect/decal/cleanable/blood,
 /turf/open/misc/asteroid,
@@ -35396,6 +35865,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
+"sMz" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "sMK" = (
 /obj/machinery/light/directional/east,
 /obj/effect/decal/cleanable/blood/splatter,
@@ -35511,26 +35989,16 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sPk" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "rdoffice";
-	name = "Research Director's Shutters"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/rd)
-"sPD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "sPH" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/bot,
@@ -35644,8 +36112,10 @@
 /area/station/hallway/primary/central)
 "sTl" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "sTR" = (
@@ -35736,9 +36206,11 @@
 "sVh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/storage/toolbox/electrical,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
 "sVq" = (
@@ -35927,27 +36399,18 @@
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
 "tak" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "taJ" = (
 /turf/closed/wall/mineral/titanium,
 /area/aegis/hanger)
-"taM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "tbq" = (
 /obj/machinery/conveyor{
 	id = "Lower Marker Conveyor";
@@ -35959,10 +36422,12 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "tbB" = (
@@ -35984,18 +36449,25 @@
 /area/station/cargo/warehouse)
 "tcQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tcX" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tda" = (
@@ -36233,7 +36705,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "tjm" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
 "tjo" = (
@@ -36281,6 +36755,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
+"tlV" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "tmd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -36301,16 +36784,11 @@
 /obj/item/paper_bin,
 /obj/item/folder/white,
 /obj/item/pen/blue,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
-"tmm" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "tmo" = (
 /obj/structure/rack/shelf,
 /obj/effect/turf_decal/bot_white,
@@ -36432,11 +36910,14 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "trK" = (
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
 /obj/structure/cable/yellow{
 	icon_state = "6"
 	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "trL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -36520,9 +37001,11 @@
 	icon_state = "pipe-y";
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tuv" = (
@@ -36752,11 +37235,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -36966,6 +37451,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "tIu" = (
@@ -36986,7 +37474,6 @@
 	},
 /obj/machinery/telephone/research,
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/misc_lab)
 "tJM" = (
@@ -37018,6 +37505,12 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"tKz" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "tKA" = (
 /obj/item/restraints/legcuffs/beartrap,
 /obj/item/restraints/legcuffs/beartrap,
@@ -37087,7 +37580,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "tMP" = (
@@ -37122,12 +37617,11 @@
 	},
 /area/station/hallway/primary/starboard)
 "tNh" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "tNI" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4;
@@ -37182,7 +37676,9 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/rd)
 "tQv" = (
@@ -37291,9 +37787,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "tSR" = (
@@ -37338,12 +37836,14 @@
 /turf/open/openspace,
 /area/station/service/chapel)
 "tTv" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "tTR" = (
@@ -37501,6 +38001,13 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
+"tYh" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "tYl" = (
 /obj/structure/chair/office{
 	dir = 8
@@ -37693,7 +38200,6 @@
 /area/station/engineering/main)
 "ueG" = (
 /obj/structure/table,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/multitool/circuit{
 	pixel_x = 7
 	},
@@ -37790,13 +38296,6 @@
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
 /area/station/engineering/break_room)
-"uiU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/maintenance/fore/greater)
 "uiV" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/deadspace/mono,
@@ -37872,6 +38371,9 @@
 /area/station/cargo/drone_bay)
 "ukH" = (
 /obj/machinery/light_switch/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "ukL" = (
@@ -38082,15 +38584,16 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
 "upb" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/red{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "upl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -38249,9 +38752,11 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "uta" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "utw" = (
@@ -38345,15 +38850,23 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "uvA" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "uvC" = (
@@ -38416,11 +38929,14 @@
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation)
 "uyg" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "129"
+	icon_state = "12"
 	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "uyk" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/vending/hydroseeds,
@@ -38569,6 +39085,24 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
+"uBu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
+"uBx" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "uBz" = (
 /obj/structure/cable/multiz,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -38637,12 +39171,14 @@
 /turf/open/floor/deadspace/grille_spare2,
 /area/aegis/surface)
 "uCR" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "uDn" = (
@@ -38689,9 +39225,14 @@
 "uFs" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "uFY" = (
@@ -38730,9 +39271,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "uGP" = (
@@ -38740,11 +39283,16 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -38772,13 +39320,15 @@
 /area/station/commons/dorms/barracks/female)
 "uIr" = (
 /obj/structure/table/glass,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/telephone/service{
 	friendly_name = "Chemistry";
 	placard_name = "Medical PBX"
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "uIw" = (
@@ -38806,6 +39356,15 @@
 /obj/machinery/light/small/maintenance/directional/east,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"uJP" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "uKg" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -38817,10 +39376,15 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "uKm" = (
@@ -38859,9 +39423,11 @@
 /area/station/cargo/qm)
 "uLE" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
@@ -38874,6 +39440,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "uME" = (
@@ -38881,12 +39450,14 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -39001,19 +39572,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "2"
 	},
-/turf/open/floor/deadspace/random/maint_center{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -39152,14 +39716,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/port)
-"uTC" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit/departure_lounge)
 "uTH" = (
 /obj/item/radio/intercom/directional/north,
 /obj/machinery/camera/directional/north{
@@ -39395,12 +39951,14 @@
 /area/station/engineering/atmos/storage/gas)
 "val" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "vap" = (
@@ -39488,6 +40046,12 @@
 "vbN" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
@@ -39751,10 +40315,12 @@
 	name = "Surgery Observation";
 	stripe_paint = "#DE3A3A"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/medical/surgery/theatre)
 "vld" = (
@@ -39827,9 +40393,17 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vmk" = (
@@ -39889,6 +40463,12 @@
 	dir = 4
 	},
 /area/station/hallway/primary/aft)
+"vpn" = (
+/obj/structure/cable/yellow{
+	icon_state = "132"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "vpw" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
@@ -39914,8 +40494,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/siding/blue,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "vqm" = (
@@ -39970,6 +40552,14 @@
 "vri" = (
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
+"vrr" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "vrv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -39983,13 +40573,27 @@
 /obj/machinery/camera/motion/directional/east,
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/brig)
+"vrH" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "vrN" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "vsj" = (
@@ -39999,10 +40603,18 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "vsp" = (
@@ -40110,9 +40722,11 @@
 /area/aegis/mining)
 "vvz" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/table,
 /obj/item/stack/splint,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "vvK" = (
@@ -40136,8 +40750,10 @@
 "vwt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vwz" = (
@@ -40310,13 +40926,6 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"vBi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "vBq" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/cee{
 	dir = 4
@@ -40495,6 +41104,16 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
+"vGe" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "vGr" = (
 /obj/effect/spawner/structure/window/reinforced/plasma/prepainted/daedalus,
 /obj/machinery/atmospherics/pipe/smart/simple/purple/visible{
@@ -40549,26 +41168,18 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
+"vHR" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "vHV" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 10
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"vIc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/maint_center{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
 "vIf" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -40583,9 +41194,26 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
+"vII" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "vIJ" = (
 /obj/structure/closet/emcloset,
 /turf/open/floor/plating,
@@ -40632,12 +41260,14 @@
 	stripe_paint = "#52B4E9"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "vJE" = (
@@ -40830,7 +41460,6 @@
 "vNC" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/light/small/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/engine,
 /area/station/science/misc_lab/range)
 "vNP" = (
@@ -40841,8 +41470,10 @@
 	name = "Cold Storage";
 	req_access_txt = "45"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/kitchen_coldroom,
 /area/station/medical/coldroom)
 "vPr" = (
@@ -40874,9 +41505,11 @@
 "vQc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
@@ -40945,17 +41578,18 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "vRc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "vRx" = (
@@ -41122,7 +41756,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "vUD" = (
@@ -41373,19 +42009,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/security/courtroom)
-"weg" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "weo" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -41459,14 +42082,6 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/bar)
-"wft" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
 "wfv" = (
 /obj/machinery/telecomms/broadcaster/preset_right,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -41761,12 +42376,17 @@
 /turf/open/floor/plating,
 /area/station/medical/medbay/central)
 "woJ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "woN" = (
@@ -41788,15 +42408,11 @@
 /area/station/science/research)
 "wpg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/area/station/maintenance/fore/greater)
 "wpl" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
@@ -41849,13 +42465,6 @@
 /obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig/upper)
-"wqu" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "wqC" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/chair/office{
@@ -41888,22 +42497,19 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "wrl" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/clothing/costume,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
+/area/aegis/surface)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "wry" = (
@@ -41918,7 +42524,9 @@
 /obj/machinery/light_switch/directional/north{
 	pixel_x = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
 "wrD" = (
@@ -41975,17 +42583,13 @@
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "wtM" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "10"
 	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/turf/open/floor/deadspace/medical,
+/area/station/medical/morgue)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -42050,12 +42654,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/female)
-"wvS" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/grille_spare3,
-/area/station/security/checkpoint/customs)
 "wvY" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
@@ -42109,15 +42707,6 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
-"wxA" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "wxK" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -42397,26 +42986,15 @@
 	},
 /turf/open/floor/deadspace/random/slides,
 /area/aegis/hanger)
-"wFp" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "wFz" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/security/courtroom)
 "wFK" = (
 /obj/machinery/light/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
 "wFX" = (
@@ -42700,7 +43278,6 @@
 /area/station/service/hydroponics)
 "wNG" = (
 /obj/effect/turf_decal/siding/purple,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "wNX" = (
@@ -43123,8 +43700,13 @@
 "xbh" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "xbk" = (
@@ -43235,9 +43817,11 @@
 /turf/open/misc/asteroid,
 /area/station/solars/port/fore)
 "xdJ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
 "xdL" = (
@@ -43508,13 +44092,18 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "xkM" = (
@@ -43533,7 +44122,9 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "xkQ" = (
@@ -43661,6 +44252,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -43793,13 +44387,19 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "xsj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "5"
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig/upper)
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "xsl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -43943,10 +44543,12 @@
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "xvX" = (
@@ -43988,10 +44590,12 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "xwJ" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "xwY" = (
 /obj/effect/landmark/pestspawn,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -44009,9 +44613,11 @@
 /area/station/service/chapel/storage)
 "xxC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "xxI" = (
@@ -44227,12 +44833,14 @@
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
 "xDY" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
 "xEs" = (
@@ -44427,9 +45035,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "xKg" = (
@@ -44493,9 +45103,6 @@
 	name = "privacy shutter"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "2"
 	},
 /turf/open/floor/plating,
@@ -44504,6 +45111,11 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/hanger)
+"xLM" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "xLY" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
@@ -44669,9 +45281,6 @@
 "xRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "xRl" = (
@@ -44838,9 +45447,11 @@
 	},
 /area/station/hallway/primary/starboard)
 "xYm" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "xYs" = (
@@ -44991,20 +45602,6 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
-"ydc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "ydh" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/deadspace/grater,
@@ -45017,14 +45614,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
-"yeq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "yey" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/grater,
@@ -45142,23 +45731,16 @@
 "ygU" = (
 /turf/open/water,
 /area/station/maintenance/fore/lesser)
-"ygZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "132"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/station/service/chapel/monastery)
 "yhf" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "yhy" = (
@@ -45173,11 +45755,16 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
@@ -53560,7 +54147,7 @@ uoP
 trm
 mNO
 mNO
-ygZ
+nOQ
 trm
 ssE
 jxc
@@ -55655,7 +56242,7 @@ qVP
 qVP
 qVP
 qVP
-fBC
+cRu
 xUe
 gHU
 ors
@@ -56134,7 +56721,7 @@ qkb
 mNS
 vQc
 aXf
-aXf
+lGU
 qli
 qli
 qli
@@ -56600,7 +57187,7 @@ eAl
 bXp
 yjT
 dAN
-uCR
+lwU
 gGN
 qWI
 utT
@@ -56909,7 +57496,7 @@ qVP
 lAb
 qgO
 dfD
-ibV
+qES
 ibV
 xDY
 mBz
@@ -56919,7 +57506,7 @@ gGN
 qWI
 ofx
 eoV
-jTf
+wtM
 pbI
 ktX
 aaa
@@ -78245,7 +78832,7 @@ xVM
 xVM
 xVM
 fQc
-sCc
+qAY
 pMt
 gRy
 rwp
@@ -78683,10 +79270,10 @@ anE
 nOX
 ijC
 rwR
-aJv
+azW
 hbH
 fXy
-hbZ
+bTS
 iYH
 iYH
 iYH
@@ -79010,7 +79597,7 @@ mwV
 hfO
 mwV
 mwV
-hUd
+lTz
 mwV
 mwV
 hfO
@@ -79018,7 +79605,7 @@ mwV
 eDu
 mwV
 mwV
-lTz
+bAY
 qwb
 alr
 jJc
@@ -79481,7 +80068,7 @@ wbh
 sFi
 dnX
 sNO
-koA
+ncO
 sNO
 dTJ
 sFi
@@ -79638,7 +80225,7 @@ nFb
 sFi
 hFa
 sNO
-alq
+guQ
 sNO
 sWE
 sFi
@@ -79795,7 +80382,7 @@ foz
 sFi
 ykX
 sNO
-alq
+guQ
 sNO
 xsV
 sFi
@@ -79938,7 +80525,7 @@ qVP
 anE
 fDg
 mbe
-dsr
+mCd
 wSD
 aqS
 anE
@@ -79951,8 +80538,8 @@ veo
 veo
 sFi
 nAH
-ncO
-wrl
+chz
+alq
 sNO
 dIR
 sFi
@@ -80109,7 +80696,7 @@ xyR
 sFi
 hiA
 sNO
-alq
+guQ
 sNO
 fpd
 sFi
@@ -80423,7 +81010,7 @@ vxt
 sFi
 xqH
 sNO
-koA
+ncO
 sNO
 jhD
 sFi
@@ -81195,10 +81782,10 @@ anE
 nOX
 ijC
 nHL
-aJv
+azW
 hbH
 dVP
-jSD
+eEL
 jKk
 jKk
 jKk
@@ -81707,7 +82294,7 @@ dmW
 hEO
 mui
 vHE
-dUe
+diA
 eEt
 qYZ
 fXZ
@@ -82158,7 +82745,7 @@ fnR
 sMY
 tQS
 hnk
-bqd
+mka
 msD
 ayh
 npi
@@ -82168,7 +82755,7 @@ bYo
 kBk
 ruP
 bwu
-aSP
+rAp
 jaQ
 nAc
 wVk
@@ -82315,7 +82902,7 @@ fnR
 jfz
 hnk
 tQS
-pbo
+bqd
 lqv
 rCd
 npi
@@ -82744,11 +83331,11 @@ qVP
 qVP
 wuy
 wuy
-dSu
-dSu
-dSu
-dSu
-dSu
+gbS
+gbS
+gbS
+gbS
+gbS
 wuy
 wuy
 wuy
@@ -82900,24 +83487,24 @@ wuy
 wuy
 wuy
 wuy
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
 wuy
 wuy
 vRZ
@@ -82960,7 +83547,7 @@ mwp
 yfI
 cZh
 uEm
-xRk
+cQO
 xfD
 vky
 dAe
@@ -82972,7 +83559,7 @@ vky
 vky
 vky
 vky
-hJF
+mJT
 vky
 tCw
 aQM
@@ -83053,29 +83640,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-dSu
-kpk
-kpk
-kpk
-kpk
-kpk
-kpk
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
-dSu
+gbS
+gbS
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
+gbS
 qnp
-kpk
-kpk
-kpk
-kpk
-kpk
-dSu
-dSu
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+gbS
+gbS
 wuy
 vRZ
 bzI
@@ -83116,8 +83703,8 @@ elo
 mwp
 tTg
 blQ
-hDf
-hDf
+xRk
+xRk
 mwp
 uej
 bNV
@@ -83210,29 +83797,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-kpk
+gbS
+xwJ
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-dSu
-dSu
-dSu
+gbS
+gbS
+gbS
 dsu
-dSu
-dSu
-dSu
+gbS
+gbS
+gbS
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-kpk
-dSu
+xwJ
+gbS
 wuy
 vRZ
 uho
@@ -83367,29 +83954,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-kpk
+gbS
+xwJ
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-dSu
-dSu
-dSu
+gbS
+gbS
+gbS
 nGf
-dSu
-dSu
-dSu
+gbS
+gbS
+gbS
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-kpk
-dSu
+xwJ
+gbS
 wuy
 vRZ
 ham
@@ -83437,10 +84024,10 @@ qyr
 qyr
 qyr
 bHR
-ydc
-diA
+kpq
+idt
 tWq
-qMP
+rXD
 cVO
 weY
 qyr
@@ -83524,29 +84111,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-kpk
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
 gbS
-gbS
-gbS
+xwJ
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+sCc
+sCc
+sCc
 dsu
+sCc
+sCc
+sCc
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+xwJ
 gbS
-gbS
-gbS
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-kpk
-dSu
 wuy
 vRZ
 vRZ
@@ -83681,29 +84268,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-dSu
+gbS
+gbS
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-dSu
-dSu
-dSu
+gbS
+gbS
+gbS
 nGf
-dSu
-dSu
-dSu
+gbS
+gbS
+gbS
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-dSu
-dSu
+gbS
+gbS
 wuy
 qVP
 qVP
@@ -83746,10 +84333,10 @@ bJz
 wqD
 bJz
 bJz
-qwv
 oqy
-oqy
-qve
+hDf
+hDf
+dVu
 bHR
 mWE
 jYt
@@ -83759,7 +84346,7 @@ qyr
 qyr
 qyr
 tfu
-dQc
+qHk
 igw
 fpu
 fpu
@@ -83838,29 +84425,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-kpk
+gbS
+xwJ
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-dSu
-dSu
-dSu
+gbS
+gbS
+gbS
 nGf
-dSu
-dSu
-dSu
+gbS
+gbS
+gbS
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-kpk
-dSu
+xwJ
+gbS
 wuy
 qVP
 qVP
@@ -83896,22 +84483,22 @@ ohU
 wEZ
 wEZ
 lWL
-qUM
-qUM
+pfG
+pfG
 xPJ
-qUM
-qUM
-qUM
-qUM
-hat
+pfG
+pfG
+pfG
+pfG
+kVf
 uSt
 kVO
-kVf
+phJ
 sXZ
 bHX
-diA
+idt
 tWq
-qMP
+rXD
 dHZ
 weY
 qyr
@@ -83995,29 +84582,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-kpk
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
 gbS
-gbS
-gbS
+xwJ
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+sCc
+sCc
+sCc
 dsu
-gbS
-gbS
-gbS
+sCc
+sCc
+sCc
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-kpk
-gbS
+xwJ
+sCc
 wuy
 qVP
 qVP
@@ -84152,28 +84739,28 @@ qVP
 qVP
 qVP
 wuy
-dSu
-kpk
+gbS
+xwJ
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-dSu
-dSu
-dSu
+gbS
+gbS
+gbS
 nGf
-dSu
-dSu
-dSu
+gbS
+gbS
+gbS
 rQA
 rQA
 rQA
 rQA
 rQA
 rQA
-kpk
+xwJ
 dsu
 wuy
 qVP
@@ -84213,7 +84800,7 @@ rcl
 wUC
 aTw
 crJ
-iKl
+iix
 svE
 crJ
 crJ
@@ -84230,7 +84817,7 @@ qyr
 qyr
 qyr
 uck
-odO
+yhZ
 xIM
 pfC
 pXF
@@ -84309,29 +84896,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-dSu
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-dSu
-dSu
-dSu
-nGf
-dSu
-dSu
-dSu
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-dSu
 gbS
+gbS
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+gbS
+gbS
+gbS
+nGf
+gbS
+gbS
+gbS
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+gbS
+sCc
 wuy
 qVP
 qVP
@@ -84374,15 +84961,15 @@ veP
 esC
 tdg
 dAi
-iKl
+iix
 gPB
 qbh
 qbh
 bHR
-dQc
-diA
+qHk
+idt
 tWq
-qMP
+rXD
 aTa
 weY
 qyr
@@ -84466,29 +85053,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-cxh
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
 gbS
-gbS
-gbS
+qON
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+sCc
+sCc
+sCc
 dsu
+sCc
+sCc
+sCc
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 gbS
-gbS
-gbS
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-dSu
-gbS
+sCc
 wuy
 qVP
 kZJ
@@ -84536,7 +85123,7 @@ vky
 vky
 vky
 vky
-cvG
+qJF
 lQE
 aII
 iee
@@ -84623,29 +85210,29 @@ qVP
 qVP
 qVP
 wuy
-dSu
-cxh
+gbS
+qON
+wrl
 jeU
-rGQ
-iol
-rGQ
-iol
+sMz
 jeU
-dSu
-dSu
-dSu
+sMz
+wrl
+gbS
+gbS
+gbS
 nGf
-dSu
-dSu
-dSu
-jeU
-rGQ
-iol
-rGQ
-iol
-jeU
 gbS
 gbS
+gbS
+wrl
+jeU
+sMz
+jeU
+sMz
+wrl
+sCc
+sCc
 wuy
 qVP
 kZJ
@@ -84701,12 +85288,12 @@ qyr
 qyr
 qyr
 uck
-mro
-ldv
-ldv
-ldv
-ldv
-ldv
+odO
+upb
+upb
+upb
+upb
+upb
 cah
 ioB
 nPD
@@ -84783,10 +85370,10 @@ wuy
 wuy
 qQP
 lhT
-imS
-imS
-imS
-imS
+knc
+knc
+knc
+knc
 vTc
 qQP
 qQP
@@ -84796,10 +85383,10 @@ qQP
 qQP
 qQP
 pXJ
-upb
-upb
-upb
-upb
+gqh
+gqh
+gqh
+gqh
 rgW
 qQP
 wuy
@@ -84850,10 +85437,10 @@ qyr
 qyr
 qyr
 bHR
-dQc
-diA
+qHk
+idt
 tWq
-qMP
+rXD
 fwd
 weY
 qyr
@@ -85114,7 +85701,7 @@ isV
 tXh
 uzD
 bAy
-dAF
+ovS
 ogk
 qVP
 qVP
@@ -85271,7 +85858,7 @@ nzy
 sjI
 bIh
 lyZ
-kQW
+dAF
 rUa
 qVP
 qVP
@@ -85289,7 +85876,7 @@ eRR
 dyb
 aUy
 vQq
-psG
+pmS
 riy
 ayu
 dUo
@@ -85313,7 +85900,7 @@ cPX
 wce
 bbh
 hTw
-omF
+trK
 tml
 rCl
 ifc
@@ -85429,7 +86016,7 @@ eIK
 kit
 edO
 hCO
-pmS
+dUe
 qVP
 qVP
 qVP
@@ -85479,7 +86066,7 @@ nGw
 qyr
 nDq
 xLA
-ldv
+upb
 ejX
 mfG
 cPn
@@ -85489,7 +86076,7 @@ mfG
 pqx
 mfG
 mfG
-wxA
+uBu
 wmg
 ust
 qyr
@@ -85586,7 +86173,7 @@ jiK
 iMZ
 blO
 cTo
-pmS
+dUe
 qVP
 qVP
 qVP
@@ -85646,7 +86233,7 @@ bNV
 vrG
 bNV
 bNV
-gwR
+fRr
 bNV
 bNV
 qyr
@@ -85741,8 +86328,8 @@ qMD
 gGE
 sVe
 yim
-hYP
-sPD
+uBx
+chW
 dOf
 qVP
 qVP
@@ -86117,7 +86704,7 @@ qVP
 qVP
 wCo
 gvH
-oYi
+bul
 olT
 jdO
 wCo
@@ -86274,7 +86861,7 @@ dTg
 dTg
 dTg
 cmX
-bul
+htm
 isb
 tsI
 wCo
@@ -86580,7 +87167,7 @@ dmE
 cFv
 crs
 fLg
-anC
+vrr
 dYv
 woI
 qZi
@@ -86854,9 +87441,9 @@ uxc
 wCJ
 vVb
 vVb
-esY
-esY
-esY
+swY
+swY
+swY
 mUn
 mUn
 mUn
@@ -86894,7 +87481,7 @@ azA
 jJt
 lRV
 hNy
-woJ
+hFB
 vCt
 vCt
 vCt
@@ -86989,11 +87576,11 @@ xth
 xth
 xth
 xth
-pAp
+qtx
+snm
+snm
+kBE
 eIL
-eIL
-wFp
-wqu
 xth
 fdA
 uOG
@@ -87009,12 +87596,12 @@ aNP
 aAq
 aGd
 aGd
-brs
+vGe
 kPt
 oyt
 egd
 kNZ
-qpo
+pBG
 mUn
 mUn
 mUn
@@ -87149,7 +87736,7 @@ cNx
 aJZ
 llM
 gMP
-fex
+tlV
 tEB
 xth
 rRW
@@ -87171,7 +87758,7 @@ pWI
 bYx
 bYx
 bYx
-aBf
+lkZ
 mUn
 dpz
 mUn
@@ -87188,28 +87775,28 @@ oIb
 jcd
 bPG
 bSP
-cKw
+fsl
 gRf
 mLj
 uME
 nLC
 qyR
 lzq
-cOX
+oXx
 cBm
 xki
-tcX
-tcX
-tcX
-aur
+flr
+flr
+flr
+raj
 cOX
-tcX
-tcX
+flr
+flr
 tcQ
 dLA
+flr
 tcX
-tcX
-tcX
+flr
 flr
 vwt
 tup
@@ -87306,7 +87893,7 @@ bUh
 oRx
 tYl
 hpF
-oVs
+bsJ
 iVk
 xth
 nCJ
@@ -87318,7 +87905,7 @@ lSF
 gOY
 mHD
 nPN
-slg
+dUu
 icl
 ojj
 tit
@@ -87328,7 +87915,7 @@ iqB
 gvY
 pkg
 cqi
-aBf
+lkZ
 jDd
 dxU
 tsG
@@ -87353,7 +87940,7 @@ ngP
 oYw
 rPR
 kCq
-iix
+ffw
 kCq
 jpQ
 kCq
@@ -87485,7 +88072,7 @@ smA
 gvY
 mUn
 mUn
-aBf
+lkZ
 lch
 gvY
 gvY
@@ -87641,8 +88228,8 @@ gFX
 gFX
 gFX
 kih
-mjx
-pPz
+kpP
+aBf
 fsT
 gvY
 qVP
@@ -87658,7 +88245,7 @@ pLY
 ccd
 jML
 cwa
-vIc
+xsj
 jlM
 uwQ
 gqi
@@ -87697,7 +88284,7 @@ qtY
 eet
 vEb
 val
-jRe
+bJn
 jRe
 bfm
 xKp
@@ -87922,23 +88509,23 @@ qVP
 gsG
 kud
 nQh
-kDP
-kDP
-kDP
-kDP
-kDP
-kDP
-kDP
-guQ
-guQ
+gwR
+gwR
+gwR
+gwR
+gwR
+gwR
+gwR
+imS
+imS
 eCA
-guQ
-guQ
+imS
+imS
 pAx
 gbr
-pSi
+vII
 ukz
-gqh
+pSi
 tfP
 hPr
 jgb
@@ -87946,7 +88533,7 @@ fBA
 tfj
 eFj
 mcE
-wpg
+gSl
 avK
 uiB
 pIx
@@ -88158,15 +88745,15 @@ vmh
 flr
 qcz
 nOt
-tcX
+flr
 aur
-tcX
-tcX
-tcX
-tcX
-tcX
-tcX
-tcX
+flr
+flr
+flr
+flr
+flr
+flr
+flr
 kCT
 pWM
 cON
@@ -88229,7 +88816,7 @@ tuc
 eSR
 rqy
 eSR
-rJq
+iCe
 eSR
 qVP
 qVP
@@ -88237,7 +88824,7 @@ gsG
 jIe
 kxC
 ccb
-jCd
+dkf
 ccb
 rib
 hmJ
@@ -88386,16 +88973,16 @@ tuc
 rqy
 tuc
 rqy
-rJq
+iCe
 rqy
 qVP
 qVP
 gsG
 gsG
 gsG
-mlO
+iZx
 adK
-aHo
+tYh
 gsG
 gsG
 pMH
@@ -88406,8 +88993,8 @@ gsG
 rPz
 oDt
 hqb
-kDP
-kDP
+gwR
+gwR
 nau
 iqf
 sSt
@@ -88543,7 +89130,7 @@ rqy
 rqy
 rqy
 rqy
-rbb
+aJv
 rqy
 qVP
 qVP
@@ -88856,7 +89443,7 @@ qVP
 rqy
 rqy
 tuc
-afp
+kDP
 rqy
 srt
 qVP
@@ -89011,8 +89598,8 @@ rqy
 rqy
 rqy
 rqy
-sBv
-uyg
+iuc
+bWQ
 rqy
 wyu
 qVP
@@ -89081,7 +89668,7 @@ wIJ
 bVx
 kon
 kXC
-qAY
+lOp
 tME
 kky
 kky
@@ -89096,7 +89683,7 @@ sMe
 uvA
 kDx
 bHA
-mCd
+dzC
 vmf
 rKf
 kLx
@@ -89165,9 +89752,9 @@ qVP
 rqy
 rqy
 rqy
-qHk
-ocO
-rnV
+iol
+dag
+hzt
 rqy
 rqy
 rqy
@@ -89202,7 +89789,7 @@ bmS
 jdI
 pIG
 kNf
-nOQ
+juJ
 lwr
 hPz
 xwH
@@ -89253,7 +89840,7 @@ sMe
 ukH
 kDx
 tKw
-cUc
+kCq
 vJQ
 rKf
 ccq
@@ -89321,7 +89908,7 @@ rqy
 rqy
 rqy
 rqy
-afp
+kDP
 rqy
 qVP
 rqy
@@ -89477,7 +90064,7 @@ rqy
 rqy
 rqy
 rqy
-afp
+kDP
 rqy
 qVP
 qVP
@@ -89511,10 +90098,10 @@ cMl
 oaV
 vBz
 pee
-rDI
+qGh
 jgI
 cAY
-swY
+qMP
 oTl
 sRF
 sRF
@@ -89543,11 +90130,11 @@ kOI
 aeQ
 bPG
 fVy
-rXD
+jlM
 hfx
 edW
 jnA
-iJI
+qsx
 sav
 ccB
 aaf
@@ -89567,7 +90154,7 @@ yjk
 yjk
 mSl
 yjk
-tNh
+yjk
 lKY
 yjk
 ofv
@@ -89633,7 +90220,7 @@ qVP
 rqy
 rqy
 tuc
-kbb
+vpn
 qVP
 qVP
 qVP
@@ -89667,11 +90254,11 @@ vPr
 ebH
 fjl
 hfM
-vBi
-nAn
+nsG
+qhC
 tKf
 jYX
-sLK
+iJI
 qoR
 sRF
 keh
@@ -89723,7 +90310,7 @@ lrx
 xxC
 xxC
 rlA
-mBv
+tIj
 xxC
 uKh
 lhm
@@ -89790,7 +90377,7 @@ qVP
 rqy
 rqy
 tuc
-rbb
+aJv
 qVP
 qVP
 qVP
@@ -89839,7 +90426,7 @@ wDy
 rkU
 vQi
 rkU
-gyh
+mlo
 pZv
 sxj
 wDV
@@ -89947,7 +90534,7 @@ qVP
 rqy
 rqy
 tuc
-nBX
+efO
 qVP
 qVP
 qVP
@@ -89977,7 +90564,7 @@ mpT
 eGf
 gkJ
 jZb
-mUb
+ivr
 kEE
 ebH
 kRQ
@@ -89996,7 +90583,7 @@ fDt
 rbK
 rbK
 rbK
-jFO
+dWl
 pZv
 sxj
 eLJ
@@ -90105,7 +90692,7 @@ qVP
 qVP
 rqy
 rqy
-efO
+cKw
 qVP
 qVP
 qVP
@@ -90134,8 +90721,8 @@ anZ
 eGf
 eAg
 sxb
-njI
-iMw
+xLM
+clx
 gkJ
 eAg
 feG
@@ -90186,7 +90773,7 @@ kgQ
 ukL
 qrJ
 exH
-sPk
+dWP
 kBp
 mIX
 mew
@@ -90194,7 +90781,7 @@ pAY
 bAj
 hzL
 snq
-sPk
+dWP
 ukL
 iPq
 exH
@@ -90262,7 +90849,7 @@ qVP
 qVP
 qVP
 rqy
-scu
+dJx
 rqy
 rqy
 rqy
@@ -90292,7 +90879,7 @@ exz
 hFC
 gQv
 tfU
-uGU
+tKz
 ohb
 ebH
 mbT
@@ -90343,7 +90930,7 @@ aDw
 cXX
 nVp
 exH
-sPk
+dWP
 eFH
 gWE
 nDm
@@ -90351,7 +90938,7 @@ nDm
 nDm
 nDm
 cdJ
-sPk
+dWP
 ukL
 iPq
 exH
@@ -90420,7 +91007,7 @@ rqy
 qVP
 qVP
 rqy
-efO
+cKw
 rqy
 rqy
 rqy
@@ -90657,7 +91244,7 @@ bVD
 ukL
 qrJ
 exH
-sPk
+dWP
 vMm
 hrU
 xsl
@@ -90665,7 +91252,7 @@ pBd
 jha
 mVT
 plM
-sPk
+dWP
 ukL
 uta
 exH
@@ -90896,7 +91483,7 @@ qVP
 qVP
 rqy
 rHU
-rbb
+aJv
 rqy
 rqy
 rqy
@@ -91053,7 +91640,7 @@ qVP
 qVP
 qVP
 rHU
-rbb
+aJv
 rqy
 rqy
 rqy
@@ -91210,7 +91797,7 @@ qVP
 qVP
 iHy
 ruE
-azW
+afp
 rqy
 rqy
 rqy
@@ -91252,7 +91839,7 @@ rkX
 bkg
 ieE
 ijk
-jEU
+fBC
 rkU
 sxj
 puN
@@ -91365,9 +91952,9 @@ rqy
 rqy
 rqy
 rqy
-rbb
+aJv
 rEA
-dHB
+oqx
 rEA
 rEA
 sIt
@@ -91394,7 +91981,7 @@ naE
 mCH
 dvF
 hHs
-iCe
+pzM
 dwU
 blf
 blf
@@ -91522,9 +92109,9 @@ rqy
 rqy
 rqy
 rqy
-rbb
+aJv
 rek
-kHw
+sDR
 jJJ
 wAN
 sIt
@@ -91561,12 +92148,12 @@ mbT
 jpS
 vwd
 jaR
-wft
+knH
 eYu
 eYu
 qXg
 cAk
-jEU
+fBC
 bvP
 sxj
 eaH
@@ -91607,9 +92194,9 @@ edX
 hNl
 jhV
 bid
-xwJ
+bUP
 nLV
-nkV
+bzz
 sAH
 edX
 xRl
@@ -91679,11 +92266,11 @@ qVP
 rqy
 rqy
 rqy
-cNY
+ocO
 rEA
-oYE
+uJP
 jBo
-trK
+oYE
 quR
 ruE
 ieM
@@ -91750,10 +92337,10 @@ dHN
 dHN
 kXb
 sTl
-bcm
-bcm
-bcm
-bcm
+fOK
+dSu
+fOK
+fOK
 bcm
 cMP
 cMP
@@ -91836,7 +92423,7 @@ qVP
 rqy
 tuc
 tuc
-rbb
+aJv
 rEA
 aQr
 oXp
@@ -92202,7 +92789,7 @@ yio
 yio
 yio
 yio
-erN
+aQJ
 rDZ
 fEk
 vDP
@@ -92368,7 +92955,7 @@ fVs
 sBp
 soj
 juy
-uQN
+kpk
 iGp
 wZK
 snn
@@ -92816,13 +93403,13 @@ cJM
 hHi
 hHi
 rTI
-wvS
+iwD
 rWq
-wvS
+iwD
 fwj
 qIi
-iwD
-iwD
+cIs
+cIs
 cFk
 faY
 qVP
@@ -93129,14 +93716,14 @@ xJv
 hqp
 xTj
 qwA
-kpP
+dUL
 xNF
 eBq
 aKq
 faY
 pDD
 wgO
-iwD
+cIs
 pYw
 faY
 fPT
@@ -93286,7 +93873,7 @@ uaC
 hqp
 rSF
 kAv
-fdT
+bkG
 hgV
 rlP
 mHv
@@ -93312,7 +93899,7 @@ kyw
 gNo
 rAl
 uXc
-fir
+xLC
 fDQ
 riO
 pkp
@@ -93443,7 +94030,7 @@ uaC
 hqp
 xgO
 kAv
-bxn
+syh
 wcV
 jSw
 rQc
@@ -93455,7 +94042,7 @@ olg
 faY
 otF
 rkU
-etu
+uyg
 rkU
 rkU
 gmN
@@ -93601,9 +94188,9 @@ hqp
 kAg
 pug
 akZ
-fxU
-weg
-bLq
+uQN
+fdT
+nvs
 faY
 ktR
 bbF
@@ -93626,7 +94213,7 @@ kxK
 kgC
 iTo
 uXc
-xLC
+ldv
 pcA
 bVG
 qhu
@@ -93783,7 +94370,7 @@ kxK
 lcv
 rAl
 ayx
-idt
+uGU
 tiS
 dVm
 rIm
@@ -94083,7 +94670,7 @@ iel
 iel
 iel
 iel
-yhZ
+mBv
 eCC
 njj
 wYA
@@ -94240,7 +94827,7 @@ odc
 odc
 odc
 odc
-uTC
+nBX
 tXH
 njj
 ncl
@@ -94554,7 +95141,7 @@ uxN
 uxN
 uxN
 uxN
-yhZ
+mBv
 eCC
 njj
 tNe
@@ -94711,7 +95298,7 @@ iJv
 iJv
 iJv
 iJv
-uTC
+nBX
 aWW
 jfn
 bev
@@ -94868,7 +95455,7 @@ iXU
 ivg
 iXU
 ueC
-jmm
+rbA
 hfD
 wHF
 cvC
@@ -95025,7 +95612,7 @@ iel
 iel
 iel
 iel
-yhZ
+mBv
 eCC
 jfn
 bev
@@ -95182,7 +95769,7 @@ odc
 odc
 odc
 odc
-uTC
+nBX
 aWW
 njj
 tNe
@@ -95496,7 +96083,7 @@ uxN
 uxN
 uxN
 uxN
-yhZ
+mBv
 xdQ
 njj
 ncl
@@ -95653,7 +96240,7 @@ iJv
 iJv
 iJv
 iJv
-uTC
+nBX
 aWW
 njj
 fjW
@@ -95963,16 +96550,16 @@ jfn
 iel
 hKR
 cpt
-ern
+tNh
 qgU
-ern
-ern
-qyQ
+tNh
+tNh
+vHR
 dtP
 njj
 qwK
-dJx
 kyb
+sAI
 pmL
 vNP
 rsD
@@ -112467,7 +113054,7 @@ wuy
 kBk
 dlm
 fLk
-ltj
+jzK
 uFg
 lse
 lse
@@ -113098,7 +113685,7 @@ wuy
 kBk
 avB
 pOx
-nAV
+aGi
 dRt
 bUr
 noU
@@ -113905,7 +114492,7 @@ hwG
 goF
 tgq
 fzN
-soz
+rqC
 pAc
 bOE
 vvm
@@ -114534,7 +115121,7 @@ wuy
 wuy
 jfa
 vVU
-xsj
+rDI
 wuT
 wuT
 mkD
@@ -116104,10 +116691,10 @@ kRE
 bmz
 bmz
 bmz
-wtM
 jbI
-jbI
-jbI
+vrH
+vrH
+vrH
 ikZ
 fyZ
 rKj
@@ -116267,7 +116854,7 @@ mpQ
 mpQ
 eJO
 mpQ
-taM
+qUM
 bCA
 qhL
 qhL
@@ -116423,7 +117010,7 @@ pyh
 ctS
 ctS
 pyh
-nzd
+gjU
 eYM
 jfa
 czR
@@ -116581,7 +117168,7 @@ qGr
 qQy
 pyh
 mpQ
-taM
+qUM
 mpQ
 mpQ
 mpQ
@@ -116732,16 +117319,16 @@ aDi
 jlE
 pyh
 hyP
-iSX
+cUc
 hch
 hch
 hQX
 pyh
 mpQ
-pfG
+sPk
 xbH
-tmm
 eWW
+kBA
 uUC
 mpQ
 jfa
@@ -117052,7 +117639,7 @@ sxJ
 jXz
 pyh
 mpQ
-yeq
+dDl
 cPJ
 tdy
 hFz
@@ -117212,7 +117799,7 @@ jjd
 xpH
 cPJ
 ncG
-iLi
+wpg
 pzN
 cPJ
 wuy
@@ -117369,7 +117956,7 @@ mpQ
 xpH
 cPJ
 vsE
-uiU
+iLi
 bmZ
 cPJ
 wuy

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -672,9 +672,11 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "asn" = (
@@ -976,7 +978,8 @@
 	dir = 8
 	},
 /obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/catwalk_floor/iron_white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "aAn" = (
 /obj/machinery/disposal/bin,
@@ -999,12 +1002,6 @@
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
-"aAT" = (
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "aAU" = (
 /obj/machinery/door/airlock/glass,
 /obj/machinery/door/firedoor,
@@ -1043,6 +1040,12 @@
 /obj/machinery/power/floodlight,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
+"aBZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "aCf" = (
 /obj/structure/ladder/invincible,
 /obj/structure/lattice,
@@ -1200,10 +1203,10 @@
 	},
 /area/station/hallway/primary/central/aft)
 "aGS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "aGY" = (
@@ -1347,6 +1350,12 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
+"aLK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "aLQ" = (
 /obj/structure/table/wood,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -1504,10 +1513,12 @@
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/commons/dorms/barracks/female)
 "aQM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "aQP" = (
@@ -1652,9 +1663,6 @@
 	id = "Cell 2";
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "aTg" = (
@@ -1717,6 +1725,9 @@
 	dir = 8
 	},
 /obj/item/kirbyplants/random,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/medical)
 "aUq" = (
@@ -1885,8 +1896,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "aZX" = (
@@ -2336,8 +2349,13 @@
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "blQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "blX" = (
@@ -2459,6 +2477,17 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"boD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "boH" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -2472,7 +2501,9 @@
 /turf/open/floor/deadspace/mono,
 /area/station/commons/dorms/barracks/female)
 "bpE" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/warden)
 "bpP" = (
@@ -2619,7 +2650,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "bsG" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2657,8 +2687,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "bum" = (
@@ -2743,7 +2775,6 @@
 	},
 /area/station/hallway/primary/central)
 "bvM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2780,16 +2811,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"bwV" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "bxp" = (
 /obj/machinery/power/floodlight,
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
-"bxx" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
 "bxG" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/food_or_drink/refreshing_beverage,
@@ -2915,6 +2950,12 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"bAp" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "bAs" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/wood,
@@ -3003,7 +3044,6 @@
 /area/station/medical/medbay/central)
 "bCA" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/security/brig/upper)
 "bCR" = (
@@ -3198,9 +3238,17 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "bIh" = (
@@ -3818,6 +3866,13 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
+"bYC" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "bYP" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 8
@@ -3893,10 +3948,12 @@
 	req_one_access_txt = "1;4"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "cal" = (
@@ -4042,6 +4099,13 @@
 /mob/living/simple_animal/slug,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
+"cfy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "cfz" = (
 /obj/item/clothing/head/hardhat,
 /turf/open/floor/deadspace/grater,
@@ -4122,6 +4186,13 @@
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
+"cgZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "chj" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/awakenedplushie,
@@ -4179,6 +4250,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
+"cjX" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "ckb" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/machinery/computer/atmos_control/oxygen_tank{
@@ -4534,7 +4615,9 @@
 	dir = 4;
 	id = "Psec command"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
 "cuB" = (
@@ -4563,8 +4646,10 @@
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "cuN" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/security/armory)
 "cuT" = (
@@ -4832,6 +4917,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"cBA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "cBD" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -5073,6 +5169,13 @@
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"cHR" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "cHY" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap{
@@ -5118,11 +5221,6 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
-"cIu" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "cIF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -5182,6 +5280,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
+"cKA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "cKB" = (
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/misc/beach/sand/coastline_t,
@@ -5342,9 +5447,11 @@
 "cPn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "cPy" = (
@@ -5454,6 +5561,14 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
+"cSA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "cSE" = (
 /obj/machinery/light,
 /obj/effect/spawner/random/vending/colavend,
@@ -5554,9 +5669,6 @@
 /obj/machinery/flasher{
 	id = "Cell 4";
 	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
@@ -5677,6 +5789,9 @@
 "cZh" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "cZj" = (
@@ -5824,7 +5939,6 @@
 	dir = 1;
 	name = "P-Sec Upper Storage Room"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/mono,
@@ -5892,12 +6006,15 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
 	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -5932,9 +6049,17 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "djT" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "djU" = (
@@ -6099,7 +6224,6 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/fore)
 "dpc" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -6162,6 +6286,16 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
+"dqV" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "dqX" = (
 /obj/machinery/mechpad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -6446,10 +6580,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dAe" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "dAh" = (
@@ -6760,9 +6896,6 @@
 	id = "Cell 3";
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "dIj" = (
@@ -6783,8 +6916,13 @@
 /obj/item/camera_film,
 /obj/item/camera_film,
 /obj/structure/table/wood,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
 "dIR" = (
@@ -6816,12 +6954,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "dJx" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "6"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
@@ -7347,19 +7484,24 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "dYv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	icon_state = "connector_map-3";
-	dir = 1
-	},
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
-	},
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
+"dYw" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "dYK" = (
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/deadspace/random/rectangles,
@@ -7812,9 +7954,11 @@
 /area/station/engineering/break_room)
 "ejX" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "ekN" = (
@@ -7936,10 +8080,6 @@
 "eoM" = (
 /turf/closed/wall/r_wall,
 /area/station/hallway/primary/central)
-"eoO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "eoV" = (
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
@@ -8115,13 +8255,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"eva" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
 "evb" = (
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/deadspace/random/rectangles,
@@ -8333,11 +8466,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "eAV" = (
+/obj/structure/cable/multiz,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "2"
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "eBa" = (
 /obj/structure/railing{
 	dir = 8
@@ -8434,7 +8568,6 @@
 /area/aegis/hanger)
 "eDR" = (
 /obj/structure/filingcabinet,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "eDU" = (
@@ -8511,7 +8644,12 @@
 	name = "Prison Monitor";
 	pixel_y = 30
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/warden)
 "eEZ" = (
@@ -8614,8 +8752,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "eGD" = (
@@ -8884,6 +9024,14 @@
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
+"eOC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "eON" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -9079,9 +9227,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "eVb" = (
@@ -9160,9 +9310,11 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "eWW" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
 "eXh" = (
@@ -9213,12 +9365,14 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "eYM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "eYU" = (
@@ -9291,6 +9445,16 @@
 /obj/structure/closet/secure_closet/personal,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
+"eZU" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "eZW" = (
 /obj/structure/sink{
 	pixel_y = 20
@@ -9692,15 +9856,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"flF" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "flJ" = (
 /obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron/dark,
@@ -9757,15 +9912,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/miningoffice)
-"fnw" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "fnQ" = (
 /obj/machinery/hydroponics/constructable,
 /obj/effect/turf_decal/box,
@@ -9809,7 +9955,6 @@
 "foK" = (
 /obj/structure/table,
 /obj/item/storage/box/cups,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "foP" = (
@@ -9822,9 +9967,11 @@
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "fpu" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/brig)
 "fpy" = (
@@ -9899,7 +10046,9 @@
 /area/station/service/hydroponics)
 "fqq" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/security/office)
 "fqB" = (
@@ -10052,9 +10201,6 @@
 	id = "Cell 1";
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "fwj" = (
@@ -10120,12 +10266,14 @@
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
 "fyZ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "fzi" = (
@@ -10161,7 +10309,6 @@
 "fzN" = (
 /obj/item/paper_bin,
 /obj/structure/table/wood,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/stamp/law,
 /obj/item/folder/red,
 /turf/open/floor/wood,
@@ -10927,15 +11074,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
-"fXL" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "fXZ" = (
 /obj/machinery/door/airlock{
 	name = "Kitchen Cold Room";
@@ -11091,13 +11229,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "gbS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "8"
 	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "gcw" = (
 /obj/machinery/door/airlock/mining{
 	dir = 1;
@@ -11145,6 +11282,13 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics)
+"gdm" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "gdr" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -11213,7 +11357,9 @@
 /turf/open/water,
 /area/station/maintenance/port/lesser)
 "gfh" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -11470,9 +11616,11 @@
 /area/station/hallway/primary/central)
 "goF" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/box,
 /obj/structure/closet/secure_closet/ds/detective,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "goK" = (
@@ -11497,6 +11645,17 @@
 	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
+"goW" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "gpj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/directional/south,
@@ -11504,6 +11663,15 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
+"gpp" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "gpr" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
@@ -11550,15 +11718,12 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
-	},
-/obj/structure/cable/red{
-	icon_state = "1"
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/area/station/security/warden)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -11729,15 +11894,12 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/structure/cable/red{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/area/aegis/surface)
 "gxI" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_center,
@@ -11842,6 +12004,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "gAv" = (
@@ -11970,13 +12133,6 @@
 	},
 /turf/open/floor/engine/airless,
 /area/station/engineering/supermatter/room)
-"gEy" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "gEz" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
@@ -12073,9 +12229,11 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/ai_monitored/security/armory)
 "gHU" = (
@@ -12273,7 +12431,9 @@
 /obj/machinery/telephone/security,
 /obj/machinery/power/data_terminal,
 /obj/machinery/light/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/warden)
 "gPp" = (
@@ -12329,9 +12489,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "gQs" = (
@@ -12397,7 +12559,6 @@
 /area/station/medical/pharmacy)
 "gRt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "gRv" = (
@@ -12972,11 +13133,19 @@
 /area/station/science/lab)
 "hhx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/central)
 "hhC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/warden)
 "hhV" = (
@@ -13591,8 +13760,10 @@
 /obj/item/paper_bin,
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/folder/red,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "hzd" = (
@@ -13724,7 +13895,6 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "hDf" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/red,
@@ -13778,11 +13948,13 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "hFz" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/greater)
 "hFB" = (
@@ -13941,7 +14113,6 @@
 /area/station/security/interrogation)
 "hJs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/dark/textured,
@@ -14631,8 +14802,15 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/golf_brown,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "idy" = (
 /obj/structure/lattice,
@@ -14735,6 +14913,12 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
+"ifb" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "ifc" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/psychology)
@@ -14754,17 +14938,21 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/lockers)
 "ifS" = (
 /obj/structure/rack,
 /obj/item/gun/grenadelauncher,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/reinforced/spawner/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/ai_monitored/security/armory)
 "igu" = (
@@ -14780,8 +14968,10 @@
 /area/station/cargo/office)
 "igw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -14960,7 +15150,6 @@
 /area/station/cargo/warehouse/upper)
 "ika" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
@@ -15016,11 +15205,13 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "ikZ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "ilk" = (
@@ -15130,6 +15321,9 @@
 /area/station/hallway/primary/fore)
 "iof" = (
 /obj/effect/spawner/structure/window/reinforced/tinted/prepainted/daedalus,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/plating,
 /area/station/security/interrogation)
 "ioi" = (
@@ -15139,19 +15333,33 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "iol" = (
-/obj/structure/chair/office{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig/upper)
-"ios" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
+"iot" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -15164,12 +15372,14 @@
 /area/station/medical/chemistry)
 "ioB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "ioE" = (
@@ -15254,7 +15464,9 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "isb" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "isc" = (
@@ -15326,7 +15538,6 @@
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse)
 "ivq" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/camera/autoname/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -15369,7 +15580,9 @@
 /area/station/hallway/primary/port)
 "ivX" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/security/range)
 "iwy" = (
@@ -15608,7 +15821,9 @@
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
 /obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -15637,6 +15852,12 @@
 "iCG" = (
 /turf/open/floor/wood,
 /area/aegis/mining)
+"iCH" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "iCL" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/deadspace/random/slides{
@@ -15830,7 +16051,6 @@
 "iHt" = (
 /obj/structure/rack,
 /obj/item/storage/box/teargas,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/storage/box/teargas,
 /obj/item/storage/box/flashbangs{
@@ -15839,6 +16059,9 @@
 	},
 /obj/item/storage/box/stingbangs,
 /obj/structure/window/reinforced/spawner/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/ai_monitored/security/armory)
 "iHw" = (
@@ -15974,12 +16197,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/slides,
 /area/station/ai_monitored/security/armory)
-"iKi" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "iKJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -16009,10 +16226,15 @@
 /area/station/engineering/atmos/storage/gas)
 "iKY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/motion/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "iLg" = (
@@ -16020,8 +16242,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "iLi" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/fore/greater)
 "iLC" = (
@@ -16387,9 +16611,11 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
 "iSY" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/warden)
 "iTb" = (
@@ -16529,6 +16755,12 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
+"iWc" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "iWf" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/random/maint_center,
@@ -16696,10 +16928,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics)
 "jbI" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "jbL" = (
@@ -16786,10 +17020,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "jeU" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -17241,7 +17475,7 @@
 	color = "#9FED58"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
@@ -17454,6 +17688,9 @@
 /obj/item/hand_labeler,
 /obj/item/camera/detective,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
 "jth" = (
@@ -17598,9 +17835,17 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/warden)
 "jwI" = (
@@ -17640,6 +17885,11 @@
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"jxU" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "jyl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
@@ -18613,6 +18863,15 @@
 "jZu" = (
 /turf/closed/wall/r_wall,
 /area/aegis/telecomms/high)
+"jZK" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "kap" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/misc/asteroid,
@@ -18670,6 +18929,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
+"kcE" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "kcG" = (
 /obj/machinery/door_timer{
 	id = "Cell 3";
@@ -18759,7 +19023,6 @@
 /obj/structure/table/wood,
 /obj/machinery/fax_machine,
 /obj/machinery/airalarm/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
@@ -19048,6 +19311,10 @@
 /obj/machinery/door/airlock/mining,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse/upper)
+"kkZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "klu" = (
 /obj/structure/table/wood/fancy/royalblue,
 /obj/machinery/camera/autoname/directional/south,
@@ -19184,9 +19451,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
+/turf/open/misc/asteroid,
 /area/aegis/surface)
 "kqt" = (
 /obj/structure/table,
@@ -19318,12 +19586,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
-"ktD" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "ktI" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 9
@@ -19501,6 +19763,7 @@
 /area/station/hallway/secondary/exit)
 "kAI" = (
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "kAJ" = (
@@ -19744,13 +20007,15 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central/aft)
-"kHN" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
+"kHK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "5"
 	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "kHQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -20273,12 +20538,17 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "brig-entrance"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
 "kVj" = (
@@ -20309,7 +20579,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
 "kVY" = (
@@ -20594,13 +20866,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "ldv" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -20690,9 +20960,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "lfY" = (
@@ -21183,12 +21455,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/hallway/primary/central)
-"lut" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
 "luv" = (
 /obj/machinery/door/poddoor/preopen,
 /obj/structure/disposalpipe/segment{
@@ -21289,7 +21555,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "lxS" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21380,9 +21645,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "lAk" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "lAp" = (
@@ -21410,7 +21680,9 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/warden)
 "lBh" = (
@@ -21676,7 +21948,6 @@
 	name = "P-Sec Upper Hallway";
 	req_access_txt = "63"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -21769,7 +22040,9 @@
 /area/station/engineering/supermatter/room)
 "lKM" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/security/armory)
 "lKY" = (
@@ -21781,12 +22054,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"lLB" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
 "lLJ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/box,
@@ -22443,9 +22710,11 @@
 /area/station/security/range)
 "mfG" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "mgj" = (
@@ -23029,9 +23298,23 @@
 	dir = 8
 	},
 /area/station/hallway/primary/port)
-"mvL" = (
-/obj/structure/cable/smart_cable/color/yellow,
+"mvI" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
+"mvL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
 "mvU" = (
@@ -23091,6 +23374,10 @@
 /obj/structure/chair,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
+"mxG" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "mxH" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -23324,7 +23611,9 @@
 	dir = 4;
 	id = "forensic_shutters"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
 "mDF" = (
@@ -23373,15 +23662,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
-"mFk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "mFm" = (
 /obj/item/paper_bin,
 /obj/structure/table/wood/fancy/blue,
@@ -23406,6 +23686,12 @@
 /obj/structure/chair/stool/bar/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"mHr" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "mHv" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/deadspace/random/slides{
@@ -23675,8 +23961,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/lockers)
 "mPy" = (
@@ -23831,7 +24122,9 @@
 /area/station/cargo/warehouse)
 "mUX" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -23887,7 +24180,9 @@
 /area/station/security/brig/upper)
 "mWa" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "mWb" = (
@@ -23913,11 +24208,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
+"mWW" = (
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "mXc" = (
 /obj/effect/spawner/random/trash/food_packaging,
 /obj/machinery/computer{
@@ -24281,7 +24585,9 @@
 /area/aegis/surface)
 "ngy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/medical)
 "ngE" = (
@@ -24595,9 +24901,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "nrk" = (
@@ -24615,7 +24923,6 @@
 /obj/machinery/photocopier,
 /obj/item/toner,
 /obj/item/toner,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "nsl" = (
@@ -24684,6 +24991,14 @@
 /obj/machinery/light/directional/east,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
+"nuD" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "nuK" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/bot,
@@ -24973,9 +25288,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "nCk" = (
@@ -25175,6 +25487,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/aft)
+"nIU" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "nIX" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/deadspace/grater,
@@ -25570,11 +25888,13 @@
 /turf/open/floor/plating,
 /area/station/security/checkpoint/science)
 "nSK" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/rack,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/mod/control/pre_equipped/ds/patrol,
 /obj/structure/window/reinforced/spawner/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/ai_monitored/security/armory)
 "nTe" = (
@@ -25907,9 +26227,14 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "odU" = (
@@ -26113,6 +26438,14 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"ojo" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "ojB" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -26287,9 +26620,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/lockers)
 "ong" = (
@@ -26402,7 +26737,9 @@
 /area/station/medical/medbay/central)
 "oqy" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/plating,
 /area/station/security/brig)
 "oqA" = (
@@ -27049,12 +27386,14 @@
 	dir = 1
 	},
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
 	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/brig)
@@ -27126,9 +27465,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/lockers)
 "oMD" = (
@@ -27562,7 +27903,7 @@
 /area/station/medical/medbay/central)
 "oYE" = (
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -27802,7 +28143,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/central)
 "pfH" = (
@@ -27844,7 +28187,6 @@
 "pgS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "phc" = (
@@ -28160,9 +28502,14 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "prc" = (
@@ -28240,7 +28587,9 @@
 "psI" = (
 /obj/machinery/computer/prisoner/management,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/warden)
 "psK" = (
@@ -28349,7 +28698,6 @@
 	pixel_x = 3;
 	pixel_y = 2
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "pvL" = (
@@ -28774,12 +29122,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
-"pGU" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
 "pHp" = (
 /obj/structure/sign/cec/deck/medical{
 	pixel_y = 32
@@ -29118,18 +29460,6 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"pOY" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
 "pOZ" = (
 /obj/structure/table,
 /obj/item/exodrone{
@@ -29494,7 +29824,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qam" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/security/brig)
 "qar" = (
@@ -29676,8 +30005,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "qfF" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "qfV" = (
@@ -29990,16 +30321,6 @@
 	dir = 4
 	},
 /area/station/security/checkpoint/customs)
-"qnL" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/computer)
 "qnS" = (
 /obj/structure/sign/cec/deck/medical{
 	pixel_y = 32
@@ -30295,7 +30616,6 @@
 /area/station/maintenance/fore/lesser)
 "quD" = (
 /obj/structure/rack,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/shield/riot{
 	pixel_x = 3;
@@ -30310,6 +30630,9 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced/spawner/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/ai_monitored/security/armory)
 "quN" = (
@@ -30323,7 +30646,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -30671,15 +30994,24 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qHk" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
 	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -30803,6 +31135,12 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"qLv" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "qLV" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -30834,11 +31172,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
-"qMG" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "qMH" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/spawner/random/structure/crate,
@@ -30851,14 +31184,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "qMP" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -30967,12 +31298,6 @@
 /obj/structure/closet/secure_closet/ds/engineering_personal,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
-"qQf" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "qQg" = (
 /obj/item/kirbyplants,
 /turf/open/floor/iron/dark/side{
@@ -30992,6 +31317,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -31088,6 +31416,10 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"qTs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "qTV" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -31146,12 +31478,19 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "qUM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/hallway/primary/central)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "qVj" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/structure/railing{
@@ -31363,9 +31702,11 @@
 /area/station/service/hydroponics)
 "rbz" = (
 /obj/machinery/camera/motion/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "rbD" = (
@@ -31590,6 +31931,24 @@
 /obj/structure/ore_box,
 /turf/open/misc/asteroid,
 /area/station/hallway/primary/fore)
+"riv" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "riy" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 8
@@ -31863,9 +32222,11 @@
 	dir = 4;
 	id = "Psec command"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_gray,
 /area/station/command/heads_quarters/hos)
 "rpS" = (
@@ -31998,10 +32359,12 @@
 /area/station/security/lockers)
 "ruf" = (
 /obj/structure/rack,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/medical/medkit,
 /obj/structure/window/reinforced/spawner/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/security/armory)
 "ruh" = (
@@ -32375,6 +32738,17 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
+"rFn" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "rFp" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -32526,7 +32900,6 @@
 	name = "P-Sec Upper Hallway";
 	req_access_txt = "63"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32537,11 +32910,13 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/surgery/theatre)
 "rKj" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
@@ -32588,13 +32963,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/security{
 	dir = 1;
 	name = "P-Sec Looker Room";
 	req_one_access_txt = "1;4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/lockers)
@@ -32767,11 +33144,14 @@
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
 "rQA" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 5
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "rQK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/tool,
@@ -32821,6 +33201,13 @@
 /obj/effect/spawner/random/deadspace/ammo,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"rSM" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/maintenance/fore/greater)
 "rSR" = (
 /obj/effect/spawner/random/deadspace/rig/scaf,
 /turf/open/floor/deadspace/mono,
@@ -33227,9 +33614,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "shk" = (
@@ -33297,7 +33686,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/hallway/secondary/exit)
 "sjP" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/security/interrogation)
 "ski" = (
@@ -33723,14 +34117,13 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "swY" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -33769,7 +34162,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/security/interrogation)
 "sxJ" = (
@@ -33990,7 +34385,6 @@
 /area/station/engineering/atmos)
 "sEi" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "sEl" = (
@@ -34667,9 +35061,11 @@
 /area/station/hallway/primary/central/aft)
 "sXZ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -34921,7 +35317,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "tgq" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "tgs" = (
@@ -35166,10 +35564,12 @@
 "toB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/telephone/security,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig/upper)
 "toS" = (
@@ -35254,8 +35654,10 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/iv_drip,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "ttp" = (
@@ -35620,11 +36022,16 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
 "tCw" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
@@ -35816,7 +36223,9 @@
 /obj/item/radio/intercom/directional/east,
 /obj/item/pen,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/security/interrogation)
 "tKJ" = (
@@ -36044,12 +36453,6 @@
 	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/medical/morgue)
-"tSk" = (
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "tSv" = (
 /obj/structure/table/wood,
 /obj/item/toy/plush/bubbleplush,
@@ -36103,8 +36506,10 @@
 /area/aegis/surface)
 "tTg" = (
 /obj/machinery/computer/security,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "tTm" = (
@@ -36195,6 +36600,9 @@
 /area/aegis/surface)
 "tWq" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
 /area/station/security/brig)
 "tWL" = (
@@ -36846,14 +37254,15 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/service/chapel/monastery)
 "upb" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
 	},
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/red{
+	icon_state = "1"
 	},
-/area/aegis/surface)
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "upl" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/rack,
@@ -36916,6 +37325,15 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/aegis/surface)
+"uqJ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "uqU" = (
 /obj/structure/rack/shelf,
 /obj/item/mod/control/pre_equipped/ds/pcsi,
@@ -36978,6 +37396,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/customs)
+"uso" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "ust" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37055,6 +37479,14 @@
 "utU" = (
 /turf/closed/wall/r_wall,
 /area/station/service/bar)
+"uua" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "uum" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/machinery/atmospherics/components/binary/pump{
@@ -37065,8 +37497,10 @@
 /area/station/engineering/atmos)
 "uuA" = (
 /obj/item/kirbyplants/photosynthetic,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light_switch/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "uuB" = (
@@ -37422,6 +37856,9 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
 "uEm" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "uEr" = (
@@ -37456,10 +37893,12 @@
 "uGc" = (
 /obj/structure/table/reinforced,
 /obj/structure/table/wood,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/item/restraints/handcuffs,
 /obj/machinery/telephone/security,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "uGo" = (
@@ -37489,9 +37928,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
 /turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
+/area/station/engineering/supermatter/room)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37749,12 +38190,13 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible/layer2{
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
+/area/station/security/brig)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -37832,7 +38274,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
 "uSY" = (
@@ -38110,12 +38554,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"uZG" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "uZP" = (
 /obj/effect/spawner/random/contraband,
 /turf/open/floor/plating,
@@ -38145,6 +38583,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "vat" = (
@@ -38241,10 +38680,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
-"vbZ" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "vcg" = (
 /obj/effect/landmark{
 	name = "ShuttleRepairPart"
@@ -38298,7 +38733,9 @@
 /area/station/maintenance/fore/lesser)
 "veP" = (
 /obj/machinery/computer/secure_data,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/warden)
 "vfg" = (
@@ -38428,9 +38865,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
 "vky" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "vkH" = (
@@ -38761,7 +39200,9 @@
 /area/station/cargo/warehouse)
 "vsE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/fore/greater)
 "vsH" = (
@@ -38849,6 +39290,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
+"vvP" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "vwd" = (
 /turf/closed/wall/r_wall,
 /area/station/engineering/storage/tech)
@@ -39469,12 +39916,14 @@
 "vMD" = (
 /obj/structure/disposalpipe/trunk/multiz,
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
@@ -39821,6 +40270,9 @@
 "vUL" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "vUM" = (
@@ -39862,9 +40314,11 @@
 	},
 /area/station/hallway/primary/fore)
 "vVU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "vWg" = (
@@ -40322,8 +40776,10 @@
 /turf/open/floor/stone,
 /area/aegis/surface)
 "wmm" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "wmD" = (
@@ -40338,6 +40794,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
@@ -40430,12 +40889,11 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/dark/side{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
 	},
-/area/station/hallway/primary/central)
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "wpl" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
@@ -40518,11 +40976,19 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "wrl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -40597,9 +41063,16 @@
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "wtM" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/medical)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -41491,6 +41964,9 @@
 "wVE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "wVI" = (
@@ -41571,9 +42047,11 @@
 	req_access_txt = "4"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/detectives_office)
 "wXI" = (
@@ -41704,9 +42182,11 @@
 /area/station/engineering/break_room)
 "xbH" = (
 /obj/machinery/light/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
 "xbM" = (
@@ -41886,9 +42366,11 @@
 	req_one_access_txt = "1;4"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "xfE" = (
@@ -42265,7 +42747,6 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "xpH" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -42298,9 +42779,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "xqL" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
 "xqW" = (
@@ -43014,9 +43497,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "xLC" = (
@@ -43034,7 +43519,9 @@
 /area/aegis/hanger)
 "xLY" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/plating,
 /area/station/security/warden)
 "xMe" = (
@@ -43056,9 +43543,11 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
 "xMV" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/ai_monitored/security/armory)
 "xMZ" = (
@@ -43102,6 +43591,12 @@
 /obj/machinery/firealarm/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
+"xOq" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "xOz" = (
 /obj/machinery/light/small/maintenance/directional/north,
 /obj/effect/spawner/random/structure/closet_maintenance,
@@ -43161,7 +43656,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/central)
 "xQd" = (
@@ -43188,7 +43688,9 @@
 "xRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "xRl" = (
@@ -43196,7 +43698,6 @@
 /area/station/science/misc_lab/range)
 "xRu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -43357,7 +43858,6 @@
 /area/station/hallway/primary/starboard)
 "xYm" = (
 /obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -43656,16 +44156,10 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
@@ -52580,7 +53074,7 @@ qVP
 qVP
 vYH
 mWa
-wtM
+niV
 teS
 upz
 niV
@@ -81234,11 +81728,11 @@ qVP
 qVP
 wuy
 wuy
-kpP
-kpP
-kpP
-kpP
-kpP
+qMP
+qMP
+qMP
+qMP
+qMP
 wuy
 wuy
 wuy
@@ -81310,7 +81804,7 @@ reE
 khL
 qbh
 qbh
-mWE
+wtM
 akB
 qyr
 qVP
@@ -81390,24 +81884,24 @@ wuy
 wuy
 wuy
 wuy
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
 wuy
 wuy
 vRZ
@@ -81462,7 +81956,7 @@ vky
 vky
 vky
 vky
-vky
+cBA
 vky
 tCw
 aQM
@@ -81543,29 +82037,29 @@ qVP
 qVP
 qVP
 wuy
-kpP
-kpP
-iCe
-iCe
-iCe
-iCe
-iCe
-iCe
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
-kpP
+qMP
+qMP
+gwR
+gwR
+gwR
+gwR
+gwR
+gwR
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
+qMP
 qnp
-iCe
-iCe
-iCe
-iCe
-iCe
-kpP
-kpP
+gwR
+gwR
+gwR
+gwR
+gwR
+qMP
+qMP
 wuy
 vRZ
 bzI
@@ -81607,13 +82101,13 @@ mwp
 tTg
 blQ
 hDf
-xRk
+hDf
 mwp
 uej
 bNV
 bNV
 bNV
-mWE
+wtM
 bNV
 bNV
 bNV
@@ -81621,7 +82115,7 @@ bNV
 bNV
 bNV
 bNV
-mWE
+wtM
 bNV
 bNV
 bNV
@@ -81700,29 +82194,29 @@ qVP
 qVP
 qVP
 wuy
-kpP
-iCe
+qMP
+gwR
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-kpP
-kpP
-kpP
+qMP
+qMP
+qMP
 dsu
-kpP
-kpP
-kpP
+qMP
+qMP
+qMP
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-iCe
-kpP
+gwR
+qMP
 wuy
 vRZ
 uho
@@ -81770,7 +82264,7 @@ vHk
 mct
 vmQ
 bHR
-mWE
+wtM
 qWQ
 qyr
 qyr
@@ -81778,7 +82272,7 @@ qyr
 qyr
 qyr
 uck
-mWE
+wtM
 daa
 qyr
 qyr
@@ -81857,29 +82351,29 @@ qVP
 qVP
 qVP
 wuy
-kpP
-iCe
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
-kpP
-kpP
+qMP
+gwR
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qMP
+qMP
+qMP
 nGf
-kpP
-kpP
-kpP
-swY
-swY
-swY
-swY
-swY
-swY
-iCe
-kpP
+qMP
+qMP
+qMP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+gwR
+qMP
 wuy
 vRZ
 ham
@@ -81927,15 +82421,15 @@ qyr
 qyr
 qyr
 bHR
-mWE
-daa
+iot
+uQN
 tWq
-qSo
+aLK
 cVO
 weY
 qyr
 bHR
-mWE
+wtM
 daa
 qSo
 qSo
@@ -82014,14 +82508,14 @@ qVP
 qVP
 qVP
 wuy
-kpP
-iCe
-swY
-swY
-swY
-swY
-swY
-swY
+qMP
+gwR
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 sCc
 sCc
 sCc
@@ -82029,14 +82523,14 @@ dsu
 sCc
 sCc
 sCc
-swY
-swY
-swY
-swY
-swY
-swY
-iCe
-kpP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+gwR
+qMP
 wuy
 vRZ
 vRZ
@@ -82084,7 +82578,7 @@ kGp
 dSB
 aSO
 bHR
-mWE
+wtM
 qpF
 trI
 iee
@@ -82092,7 +82586,7 @@ qam
 fGV
 qyr
 bHR
-mWE
+wtM
 daa
 qKU
 qKU
@@ -82171,29 +82665,29 @@ qVP
 qVP
 qVP
 wuy
-kpP
-kpP
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
-kpP
-kpP
+qMP
+qMP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qMP
+qMP
+qMP
 nGf
-kpP
-kpP
-kpP
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
-kpP
+qMP
+qMP
+qMP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qMP
+qMP
 wuy
 wuy
 wuy
@@ -82237,11 +82731,11 @@ wqD
 bJz
 bJz
 oqy
-oqy
-oqy
-oqy
+cjX
+cjX
+eZU
 bHR
-mWE
+wtM
 jYt
 qyr
 qyr
@@ -82249,7 +82743,7 @@ qyr
 qyr
 qyr
 tfu
-mWE
+qUM
 igw
 fpu
 fpu
@@ -82328,30 +82822,30 @@ qVP
 qVP
 qVP
 wuy
-kpP
-iCe
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
-kpP
-kpP
+qMP
+gwR
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qMP
+qMP
+qMP
 nGf
-kpP
-kpP
-kpP
-swY
-swY
-swY
-swY
-swY
-swY
-iCe
-kpP
-kpP
+qMP
+qMP
+qMP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+gwR
+qMP
+qMP
 wuy
 wuy
 vRZ
@@ -82386,27 +82880,27 @@ ohU
 wEZ
 wEZ
 lWL
-qUM
-qUM
+pfG
+pfG
 xPJ
 pfG
 pfG
 pfG
 pfG
-kVf
+riv
 uSt
 kVO
 kVf
 sXZ
 bHX
-daa
+uQN
 tWq
-qSo
+aLK
 dHZ
 weY
 qyr
 bHR
-mWE
+wtM
 daa
 qKU
 qKU
@@ -82485,14 +82979,14 @@ qVP
 qVP
 qVP
 wuy
-kpP
-iCe
-swY
-swY
-swY
-swY
-swY
-swY
+qMP
+gwR
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 sCc
 sCc
 sCc
@@ -82500,15 +82994,15 @@ dsu
 sCc
 sCc
 sCc
-swY
-swY
-swY
-swY
-swY
-swY
-iCe
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+gwR
 sCc
-kpP
+qMP
 wuy
 wuy
 kZJ
@@ -82555,7 +83049,7 @@ qyr
 qyr
 qyr
 bHR
-mWE
+wtM
 lQE
 bqe
 iee
@@ -82563,7 +83057,7 @@ qam
 wYH
 qyr
 bHR
-mWE
+wtM
 daa
 jNW
 jNW
@@ -82642,30 +83136,30 @@ qVP
 qVP
 qVP
 wuy
-kpP
-iCe
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
-kpP
-kpP
+qMP
+gwR
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qMP
+qMP
+qMP
 nGf
-kpP
-kpP
-kpP
-swY
-swY
-swY
-swY
-swY
-swY
-iCe
+qMP
+qMP
+qMP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+gwR
 dsu
-kpP
+qMP
 wuy
 wuy
 kZJ
@@ -82720,7 +83214,7 @@ qyr
 qyr
 qyr
 uck
-odO
+rFn
 xIM
 pfC
 pXF
@@ -82799,30 +83293,30 @@ qVP
 qVP
 qVP
 wuy
-kpP
-kpP
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
-kpP
-kpP
+qMP
+qMP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qMP
+qMP
+qMP
 nGf
-kpP
-kpP
-kpP
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
+qMP
+qMP
+qMP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qMP
 sCc
-kpP
+qMP
 wuy
 wuy
 kZJ
@@ -82869,15 +83363,15 @@ gPB
 qbh
 qbh
 bHR
-mWE
-daa
+qUM
+uQN
 tWq
-qSo
+aLK
 aTa
 weY
 qyr
 bHR
-mWE
+wtM
 daa
 qyr
 qyr
@@ -82956,14 +83450,14 @@ qVP
 qVP
 qVP
 wuy
-kpP
-pGU
-swY
-swY
-swY
-swY
-swY
-swY
+qMP
+nIU
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
 sCc
 sCc
 sCc
@@ -82971,15 +83465,15 @@ dsu
 sCc
 sCc
 sCc
-swY
-swY
-swY
-swY
-swY
-swY
-kpP
+rQA
+rQA
+rQA
+rQA
+rQA
+rQA
+qMP
 sCc
-kpP
+qMP
 wuy
 kZJ
 kZJ
@@ -83011,7 +83505,7 @@ kdu
 xlL
 dHH
 eaG
-wpg
+eaG
 kou
 ePW
 sMm
@@ -83026,7 +83520,7 @@ vky
 vky
 vky
 vky
-mWE
+wrl
 lQE
 aII
 iee
@@ -83034,7 +83528,7 @@ qam
 hHl
 qyr
 bHR
-mWE
+wtM
 daa
 qbh
 qbh
@@ -83113,30 +83607,30 @@ qVP
 qVP
 qVP
 wuy
-kpP
-pGU
-jeU
-upb
 qMP
-upb
-qMP
+nIU
+gpp
 jeU
-kpP
-kpP
-kpP
+iCe
+jeU
+iCe
+gpp
+qMP
+qMP
+qMP
 nGf
-kpP
-kpP
-kpP
-jeU
-upb
 qMP
-upb
 qMP
+qMP
+gpp
 jeU
+iCe
+jeU
+iCe
+gpp
 sCc
 sCc
-kpP
+qMP
 wuy
 kZJ
 xii
@@ -83178,12 +83672,12 @@ psI
 pnG
 bpE
 faw
-xLY
+gqh
 uej
 bNV
 bNV
 bHR
-mWE
+wtM
 hor
 qyr
 qyr
@@ -83273,10 +83767,10 @@ wuy
 wuy
 qQP
 lhT
-gwR
-gwR
-gwR
-gwR
+qHk
+qHk
+qHk
+qHk
 vTc
 qQP
 qQP
@@ -83286,10 +83780,10 @@ qQP
 qQP
 qQP
 pXJ
-gqh
-gqh
-gqh
-gqh
+upb
+upb
+upb
+upb
 rgW
 qQP
 qQP
@@ -83340,15 +83834,15 @@ qyr
 qyr
 qyr
 bHR
-mWE
-daa
+qUM
+uQN
 tWq
-qSo
+aLK
 fwd
 weY
 qyr
 bHR
-mWE
+wtM
 daa
 qnh
 qyr
@@ -83449,7 +83943,7 @@ weG
 weG
 nJu
 rUa
-rQA
+mHr
 qVP
 qVP
 kZJ
@@ -83497,7 +83991,7 @@ vMZ
 gmr
 cPb
 oYf
-mWE
+wtM
 lQE
 tmp
 iee
@@ -83505,7 +83999,7 @@ qam
 kIo
 qyr
 bHR
-mWE
+wtM
 daa
 wAU
 sBj
@@ -83606,7 +84100,7 @@ uzD
 bAy
 dAF
 ogk
-wrl
+uGU
 qVP
 qVP
 eRR
@@ -83654,7 +84148,7 @@ wie
 mny
 qyr
 bHR
-mWE
+wtM
 ebi
 qyr
 qyr
@@ -83662,7 +84156,7 @@ qyr
 qyr
 qyr
 uck
-mWE
+wtM
 daa
 mdl
 qyr
@@ -83762,8 +84256,8 @@ sjI
 bIh
 lyZ
 dAF
-uQN
-wrl
+mWW
+uGU
 qVP
 qVP
 eRR
@@ -83811,7 +84305,7 @@ efK
 bwU
 qyr
 bHR
-mWE
+wtM
 qbh
 gPB
 qbh
@@ -83819,7 +84313,7 @@ qbh
 qbh
 qbh
 qbh
-mWE
+wtM
 qbh
 qbh
 kFF
@@ -83920,7 +84414,7 @@ kit
 edO
 hCO
 dUe
-wrl
+uGU
 qVP
 qVP
 eRR
@@ -83979,7 +84473,7 @@ mfG
 pqx
 mfG
 mfG
-mfG
+kHK
 wmg
 ust
 qyr
@@ -84077,7 +84571,7 @@ trK
 blO
 cTo
 pmS
-wrl
+uGU
 qVP
 qVP
 eRR
@@ -84136,7 +84630,7 @@ bNV
 vrG
 bNV
 bNV
-mWE
+eOC
 bNV
 bNV
 qyr
@@ -84231,10 +84725,10 @@ qMD
 gGE
 sVe
 yim
-lLB
-mFk
+wpg
+uqJ
 dOf
-lut
+xOq
 qVP
 qVP
 eRR
@@ -84764,7 +85258,7 @@ dTg
 dTg
 dTg
 cmX
-bul
+diA
 isb
 tsI
 wCo
@@ -84913,7 +85407,7 @@ lJw
 cFv
 syO
 pgS
-xYm
+uso
 joj
 woI
 eZS
@@ -85499,12 +85993,12 @@ aNP
 aAq
 aGd
 aGd
-qnL
+dqV
 kPt
 oyt
 egd
 kNZ
-tSk
+iCH
 mUn
 mUn
 mUn
@@ -85658,9 +86152,9 @@ qAi
 vVb
 tQQ
 pWI
-eva
-eva
-eva
+gbS
+gbS
+gbS
 aBf
 mUn
 dpz
@@ -85796,7 +86290,7 @@ bUh
 oRx
 tYl
 hpF
-fXL
+jZK
 iVk
 xth
 nCJ
@@ -85808,7 +86302,7 @@ lSF
 gOY
 mHD
 nPN
-nBX
+wmL
 icl
 ojj
 tit
@@ -85965,7 +86459,7 @@ eQw
 sun
 dJK
 hJJ
-wmL
+nBX
 dCM
 ojj
 aVq
@@ -86131,8 +86625,8 @@ gFX
 gFX
 gFX
 kih
-qQf
-uZG
+ifb
+qLv
 fsT
 gvY
 qVP
@@ -86426,7 +86920,7 @@ eCA
 eCA
 pAx
 gbr
-pOY
+mvI
 ukz
 pSi
 tfP
@@ -86436,7 +86930,7 @@ fBA
 tfj
 eFj
 mcE
-yhZ
+boD
 avK
 uiB
 pIx
@@ -86727,7 +87221,7 @@ gsG
 jIe
 kxC
 ccb
-gbS
+uua
 ccb
 rib
 hmJ
@@ -86883,9 +87377,9 @@ qVP
 gsG
 gsG
 gsG
-gEy
+bYC
 adK
-kHN
+gdm
 gsG
 gsG
 pMH
@@ -86907,7 +87401,7 @@ xtH
 jdI
 fRQ
 xbE
-wmL
+nBX
 bZM
 ojj
 pIx
@@ -87064,7 +87558,7 @@ mXQ
 jdI
 ktu
 xbE
-wmL
+nBX
 nAU
 ojj
 von
@@ -87692,7 +88186,7 @@ bmS
 jdI
 pIG
 kNf
-aAT
+vvP
 lwr
 hPz
 xwH
@@ -88001,10 +88495,10 @@ cMl
 oaV
 vBz
 pee
-vbZ
+mxG
 jgI
 cAY
-eoO
+qTs
 oTl
 sRF
 sRF
@@ -88157,11 +88651,11 @@ vPr
 ebH
 fjl
 hfM
-ios
-bxx
+cgZ
+kcE
 tKf
 jYX
-uGU
+kkZ
 qoR
 sRF
 keh
@@ -88467,7 +88961,7 @@ mpT
 eGf
 gkJ
 jZb
-diA
+cfy
 kEE
 ebH
 kRQ
@@ -88624,8 +89118,8 @@ anZ
 eGf
 eAg
 sxb
-cIu
-qMG
+yhZ
+jxU
 gkJ
 eAg
 feG
@@ -88782,7 +89276,7 @@ exz
 hFC
 gQv
 tfU
-iKi
+bAp
 ohb
 ebH
 mbT
@@ -89543,7 +90037,7 @@ qVP
 qVP
 qVP
 rHU
-eAV
+kpP
 rqy
 rqy
 rqy
@@ -89700,7 +90194,7 @@ qVP
 qVP
 iHy
 ruE
-fnw
+bwV
 rqy
 rqy
 rqy
@@ -89855,9 +90349,9 @@ rqy
 rqy
 rqy
 rqy
-eAV
+kpP
 rEA
-quR
+goW
 rEA
 rEA
 sIt
@@ -89884,7 +90378,7 @@ naE
 mCH
 dvF
 hHs
-dJx
+cHR
 dwU
 blf
 blf
@@ -90012,9 +90506,9 @@ rqy
 rqy
 rqy
 rqy
-eAV
+kpP
 rek
-ktD
+oYE
 jJJ
 wAN
 sIt
@@ -90169,12 +90663,12 @@ qVP
 rqy
 rqy
 rqy
-qHk
+aBZ
 rEA
-flF
-jBo
-oYE
 ldv
+jBo
+dJx
+quR
 ruE
 ieM
 rqy
@@ -90326,7 +90820,7 @@ qVP
 rqy
 tuc
 tuc
-eAV
+kpP
 rEA
 aQr
 oXp
@@ -112395,7 +112889,7 @@ hwG
 goF
 tgq
 fzN
-qfF
+cKA
 pAc
 bOE
 vvm
@@ -113023,7 +113517,7 @@ pyk
 wuy
 wuy
 jfa
-vVU
+cSA
 wVE
 wuT
 wuT
@@ -113180,8 +113674,8 @@ pyk
 wuy
 wuy
 jfa
-idt
-wVE
+xQj
+vVU
 xQj
 grS
 grS
@@ -113338,7 +113832,7 @@ wuy
 wuy
 jfa
 eDR
-wVE
+vVU
 xQj
 ePu
 mLH
@@ -113495,7 +113989,7 @@ jfa
 jfa
 jfa
 nrV
-wVE
+vVU
 xQj
 vCp
 vCp
@@ -113652,7 +114146,7 @@ kqI
 maF
 ubl
 foK
-wVE
+vVU
 xQj
 grS
 txW
@@ -113808,8 +114302,8 @@ pyk
 vfS
 xQj
 xQj
-idt
-wVE
+xQj
+vVU
 xQj
 qHm
 fJj
@@ -113965,8 +114459,8 @@ pyk
 kQI
 xQj
 xQj
-idt
-wVE
+xQj
+vVU
 xQj
 vCp
 vCp
@@ -114120,9 +114614,9 @@ aTj
 rXE
 pyk
 sEi
-iol
-idt
-iol
+grS
+xQj
+grS
 vVU
 xQj
 xQj
@@ -114594,7 +115088,7 @@ kRE
 bmz
 bmz
 bmz
-jbI
+dYw
 jbI
 jbI
 jbI
@@ -114757,7 +115251,7 @@ mpQ
 mpQ
 eJO
 mpQ
-eYM
+idt
 bCA
 qhL
 qhL
@@ -114913,8 +115407,8 @@ pyh
 ctS
 ctS
 pyh
-mpQ
-eYM
+eAV
+iol
 jfa
 czR
 ggl
@@ -115071,7 +115565,7 @@ qGr
 qQy
 pyh
 mpQ
-eYM
+idt
 mpQ
 mpQ
 mpQ
@@ -115222,7 +115716,7 @@ aDi
 jlE
 pyh
 hyP
-lAk
+ojo
 hch
 hch
 hQX
@@ -115231,7 +115725,7 @@ mpQ
 eYM
 xbH
 eWW
-eWW
+swY
 uUC
 mpQ
 jfa
@@ -115542,7 +116036,7 @@ sxJ
 jXz
 pyh
 mpQ
-eYM
+nuD
 cPJ
 tdy
 hFz
@@ -115859,7 +116353,7 @@ mpQ
 xpH
 cPJ
 vsE
-iLi
+rSM
 bmZ
 cPJ
 wuy
@@ -116009,10 +116503,10 @@ bvM
 rJS
 dpc
 dpc
-jbI
-jbI
-jbI
-jbI
+iWc
+iWc
+iWc
+iWc
 ivq
 cPJ
 evB

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -26,25 +26,15 @@
 	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
-"aaw" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse/upper)
 "aaE" = (
 /obj/machinery/portable_atmospherics/canister/plasma,
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "abd" = (
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "abi" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment{
@@ -221,16 +211,10 @@
 /area/station/hallway/primary/central)
 "afp" = (
 /obj/structure/cable/yellow{
-	icon_state = "144"
+	icon_state = "18"
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"afD" = (
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "afX" = (
 /turf/open/floor/deadspace/grille_spare1,
 /area/mine/storage)
@@ -257,6 +241,12 @@
 	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
+"ahe" = (
+/obj/structure/cable/yellow{
+	icon_state = "33"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "ahf" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/siding/white{
@@ -302,6 +292,13 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
+"aiW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/commons/dorms/barracks/male)
 "aiX" = (
 /obj/structure/railing{
 	dir = 4
@@ -343,13 +340,6 @@
 	dir = 5
 	},
 /area/station/hallway/primary/central)
-"ako" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/wood,
-/area/station/security/detectives_office)
 "akr" = (
 /obj/machinery/shower,
 /obj/effect/spawner/random/trash/soap,
@@ -445,6 +435,12 @@
 /obj/effect/spawner/random/clothing/costume,
 /obj/structure/cable/yellow{
 	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
@@ -707,10 +703,6 @@
 /obj/structure/sign/poster/official/random/directional/south,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
-"arS" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "asa" = (
 /obj/machinery/door/window/left/directional/west{
 	name = "P-Sec Infirmary Station"
@@ -727,6 +719,9 @@
 /area/station/security/medical)
 "asn" = (
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/engine,
 /area/station/science/misc_lab/range)
 "asw" = (
@@ -810,14 +805,12 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"aut" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo/warehouse)
 "auw" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -1025,15 +1018,13 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "azW" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
+/turf/open/floor/iron/showroomfloor,
+/area/station/commons/dorms/cryo)
 "aAj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
@@ -1084,7 +1075,7 @@
 /area/station/hallway/primary/port)
 "aBf" = (
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "12"
 	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
@@ -1193,6 +1184,14 @@
 /obj/effect/spawner/random/clothing/backpack,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"aEa" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "aEb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -1284,6 +1283,17 @@
 /obj/machinery/vending/cigarette,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse/upper)
+"aHu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/lobby)
 "aHO" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
@@ -1358,13 +1368,11 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
 "aJv" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms/cryo)
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/lobby)
 "aJH" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -1400,6 +1408,14 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"aKG" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
+	},
+/area/station/security/brig)
 "aLc" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/two,
@@ -1429,19 +1445,6 @@
 /obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
-"aLT" = (
-/obj/effect/turf_decal/tile/bar/opposingcorners,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/white,
-/area/station/service/kitchen)
 "aLW" = (
 /obj/machinery/camera/autoname/directional/south,
 /turf/open/floor/iron/dark/side,
@@ -1561,6 +1564,9 @@
 "aPX" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "aQd" = (
@@ -1678,12 +1684,6 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
-"aSt" = (
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/starboard/greater)
 "aSD" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 4
@@ -1856,6 +1856,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
+"aUO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command blast"
+	},
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "aVc" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/spawner/random/vending/colavend,
@@ -1924,7 +1935,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
@@ -2012,6 +2023,11 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"aZz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/hardwood,
+/area/station/command/heads_quarters/captain)
 "aZX" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/light/small/directional/west,
@@ -2127,6 +2143,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
@@ -2272,14 +2291,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/starboard)
-"bge" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
 "bgg" = (
 /obj/machinery/requests_console/directional/east{
 	department = "Engineering";
@@ -2449,18 +2460,6 @@
 /obj/structure/water_source/puddle,
 /turf/open/floor/grass,
 /area/station/service/library)
-"bkE" = (
-/obj/structure/chair/office{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "bkR" = (
 /obj/structure/table,
 /obj/effect/spawner/random/deadspace/ammo,
@@ -2580,19 +2579,16 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"bns" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "bnu" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
 /obj/effect/mob_spawn/corpse/human/miner,
 /turf/open/floor/wood,
 /area/aegis/mining)
-"bnC" = (
-/obj/machinery/light/directional/west,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/stone,
-/area/aegis/surface)
 "bnO" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
@@ -2667,7 +2663,7 @@
 "bqd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
@@ -2844,7 +2840,7 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "10"
 	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
@@ -3101,10 +3097,6 @@
 /obj/structure/table,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
-"bAk" = (
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "bAs" = (
 /obj/structure/cable/yellow{
 	icon_state = "12"
@@ -3281,6 +3273,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"bEp" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/maintenance/starboard/upper)
 "bEB" = (
 /obj/machinery/light/small/maintenance/directional/west,
 /obj/structure/showcase/machinery/signal_decrypter,
@@ -3297,6 +3298,16 @@
 	},
 /turf/open/water/beach,
 /area/station/hallway/primary/port)
+"bFa" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "bFf" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 4
@@ -3388,9 +3399,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "bHR" = (
@@ -3473,6 +3481,22 @@
 /obj/structure/inflatable/door,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"bKt" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command hallway"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "bKK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/random/maint_left{
@@ -3560,15 +3584,6 @@
 	dir = 8
 	},
 /area/aegis/hanger)
-"bNj" = (
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/hallway/secondary/exit/departure_lounge)
 "bNl" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/sheet/mineral/gold,
@@ -3963,6 +3978,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
+"bWg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "bWt" = (
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
@@ -4395,10 +4418,19 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
-"chP" = (
-/turf/open/misc/asteroid{
-	simulated = 0
+"chN" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse/upper)
+"chP" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/stone,
 /area/aegis/surface)
 "ciq" = (
 /obj/structure/cable/smart_cable/color/yellow,
@@ -4432,6 +4464,23 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
+"cjf" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Mining Privacy";
+	name = "Mining Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "cju" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/deadspace/heavy,
@@ -4458,6 +4507,13 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"ckc" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "ckm" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /turf/open/floor/iron/showroomfloor,
@@ -4764,6 +4820,11 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
+"csx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo/warehouse)
 "csz" = (
 /turf/open/floor/deadspace/cable{
 	dir = 1
@@ -4776,6 +4837,12 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
+"ctn" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/warehouse)
 "ctp" = (
 /obj/structure/railing{
 	dir = 9
@@ -4925,6 +4992,12 @@
 	dir = 8
 	},
 /area/mine/production)
+"cxd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "cxq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -4961,11 +5034,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/deadspace/random/maint_center,
 /area/aegis/mining)
-"cyz" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "cyG" = (
 /turf/open/floor/deadspace/cable_end,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -5083,6 +5151,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"cAL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/command/bridge)
 "cAO" = (
 /obj/structure/table,
 /obj/item/food/mint,
@@ -5392,14 +5471,6 @@
 /obj/effect/spawner/random/trash/janitor_supplies,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"cHQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
 "cHY" = (
 /obj/structure/table,
 /obj/item/stack/package_wrap{
@@ -5499,7 +5570,7 @@
 	icon_state = "3"
 	},
 /turf/open/floor/deadspace/random/rectangles,
-/area/mine/lobby)
+/area/station/command/bridge)
 "cKy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
@@ -5535,18 +5606,6 @@
 /obj/structure/closet/crate/freezer/blood,
 /turf/open/floor/iron/white,
 /area/station/security/medical)
-"cLC" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "cLD" = (
 /obj/effect/decal/cleanable/blood/gibs,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
@@ -5585,6 +5644,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
 "cMt" = (
@@ -5618,6 +5680,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics)
+"cNc" = (
+/obj/structure/cable/yellow{
+	icon_state = "136"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "cNr" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -5639,18 +5707,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
-"cOq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/cryo)
-"cOG" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "cON" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
@@ -5693,17 +5749,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
-"cPe" = (
-/obj/structure/disposalpipe/junction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
 "cPg" = (
 /obj/machinery/light/directional/west,
 /obj/effect/turf_decal/loading_area{
@@ -5746,15 +5791,6 @@
 "cPJ" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/fore/greater)
-"cPN" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "cPQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "12"
@@ -5839,6 +5875,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "cSE" = (
@@ -5853,6 +5891,27 @@
 	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/port)
+"cSQ" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "cST" = (
 /obj/machinery/light/cold/directional/east,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -5891,14 +5950,15 @@
 /turf/open/water,
 /area/station/maintenance/port/lesser)
 "cUc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
-/obj/structure/cable/white{
-	icon_state = "132"
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/turf/open/floor/carpet/royalblack,
-/area/station/service/chapel/monastery)
+/turf/open/floor/plating,
+/area/station/security/brig)
 "cUs" = (
 /obj/machinery/disposal/bin,
 /obj/effect/floor_decal/ds/spline/fancy/wood{
@@ -5913,10 +5973,7 @@
 	dir = 4
 	},
 /obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
@@ -6028,13 +6085,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central/aft)
-"cXH" = (
-/obj/structure/railing{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
 "cXW" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/deadspace/medical,
@@ -6241,6 +6291,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/fore/greater)
 "dfn" = (
@@ -6306,12 +6359,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -6417,15 +6470,6 @@
 /obj/effect/spawner/random/entertainment/arcade,
 /turf/open/floor/carpet/red,
 /area/station/commons/lounge)
-"dlp" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/server)
 "dlH" = (
 /obj/machinery/atmospherics/components/binary/pump/off{
 	dir = 8;
@@ -6769,12 +6813,6 @@
 	dir = 4
 	},
 /area/station/command/bridge)
-"dwN" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
 "dwU" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 1
@@ -6810,10 +6848,6 @@
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
-"dxV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/slides,
-/area/station/cargo/warehouse)
 "dya" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
@@ -6898,10 +6932,6 @@
 "dzC" = (
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"dzP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "dAe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7062,6 +7092,13 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"dDE" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "dEb" = (
 /obj/structure/bed/dogbed/mcgriff,
 /mob/living/simple_animal/pet/dog/pug/mcgriff{
@@ -7106,10 +7143,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
@@ -7136,6 +7170,12 @@
 /obj/machinery/power/floodlight,
 /turf/open/water,
 /area/station/maintenance/port/lesser)
+"dGD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/bathroom,
+/area/mine/production)
 "dGO" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/west,
@@ -7295,13 +7335,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "dJx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/turf/open/floor/carpet/royalblack,
+/area/station/cargo/miningoffice)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
@@ -7416,6 +7455,12 @@
 "dMI" = (
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/fore/lesser)
+"dMW" = (
+/obj/structure/cable/yellow{
+	icon_state = "144"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "dNz" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
@@ -7530,6 +7575,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
+"dQW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides,
+/area/station/cargo/warehouse)
 "dRt" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/entertainment/deck,
@@ -7558,6 +7608,13 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
+"dRP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "dSa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -7566,6 +7623,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
@@ -7578,11 +7638,9 @@
 	},
 /area/aegis/mining)
 "dSu" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "dSB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -7614,11 +7672,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "dSI" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/machinery/conveyor{
+	id = "Lower Marker Conveyor"
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/maintenance/starboard/upper)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "dSZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -7701,9 +7761,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "dUe" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/turf/closed/wall/r_wall,
+/area/station/engineering/supermatter/room)
 "dUl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -7825,13 +7887,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lesser)
-"dWU" = (
-/obj/structure/railing{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
 "dWV" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/maint_right,
@@ -7920,7 +7975,13 @@
 	id = "window command hallway"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "1"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
@@ -7987,6 +8048,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"ebA" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "ebG" = (
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
@@ -8146,9 +8213,14 @@
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
 "efO" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/slides,
-/area/station/cargo/warehouse)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "efQ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -8357,6 +8429,10 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/mono,
 /area/mine/hydroponics)
+"ekY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo/warehouse)
 "eld" = (
 /obj/structure/sign/cec/deck/cargo,
 /turf/closed/wall/r_wall,
@@ -8374,17 +8450,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/deadspace/mono,
 /area/station/service/chapel)
-"elN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/command/bridge)
 "elY" = (
 /obj/machinery/atmospherics/pipe/smart/simple/yellow/visible{
 	dir = 4
@@ -8573,6 +8638,18 @@
 "erk" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo)
+"erO" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "esc" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/machinery/light/small/maintenance/directional/north,
@@ -8640,6 +8717,13 @@
 /obj/effect/spawner/random/deadspace/ammo/mining,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
+"eus" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/service/janitor)
 "euB" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -8698,22 +8782,13 @@
 "evC" = (
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
-"evE" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
 "ewa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/command/bridge)
+/area/aegis/surface)
 "ewj" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/disposal/bin,
@@ -8825,14 +8900,6 @@
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
-"eyJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit/departure_lounge)
 "eyK" = (
 /obj/machinery/power/floodlight,
 /obj/effect/turf_decal/stripes/line{
@@ -9229,16 +9296,6 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/aegis/mining)
-"eHR" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
-	},
-/obj/structure/cable/red{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
 "eHS" = (
 /obj/structure/chair{
 	dir = 4
@@ -9297,7 +9354,10 @@
 "eIL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/monitoring)
@@ -9419,10 +9479,6 @@
 /obj/structure/foamedmetal,
 /turf/open/floor/eighties/red,
 /area/aegis/surface)
-"eMX" = (
-/obj/machinery/airalarm/directional/south,
-/turf/open/floor/deadspace/mono,
-/area/station/cargo)
 "eNc" = (
 /obj/machinery/door/poddoor/shutters/window{
 	id = "armory";
@@ -9485,20 +9541,6 @@
 /obj/structure/chair/sofa/bench/left,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
-"eOt" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
 "eON" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -9640,6 +9682,15 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/eva)
+"eSQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/command/bridge)
 "eSR" = (
 /turf/open/floor/plating,
 /area/aegis/surface)
@@ -9656,10 +9707,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
-"eTi" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/commons/dorms/barracks/male)
 "eTs" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/closet/secure_closet/ds/miner,
@@ -9687,6 +9734,13 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
+"eTQ" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/security/warden)
 "eTU" = (
 /obj/machinery/light/small/maintenance/directional/west,
 /turf/open/floor/plating,
@@ -9791,7 +9845,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "5"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
@@ -9855,7 +9909,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
@@ -10027,7 +10084,13 @@
 "fdT" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
@@ -10041,8 +10104,11 @@
 "feD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
+/area/mine/production)
 "feG" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Distribution Loop";
@@ -10075,11 +10141,10 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/hardwood,
-/area/station/command/heads_quarters/captain)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/iron/norn,
+/area/station/hallway/primary/starboard)
 "ffz" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -10335,13 +10400,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/misc_lab)
 "flr" = (
-/obj/machinery/conveyor{
-	id = "Lower Marker Conveyor"
-	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "flJ" = (
 /obj/machinery/light/no_nightlight/directional/east,
 /turf/open/floor/iron/dark,
@@ -10581,6 +10647,11 @@
 "frg" = (
 /turf/closed/mineral/random/aegis,
 /area/station/commons/dorms/barracks/female)
+"frl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "frw" = (
 /obj/effect/landmark{
 	name = "ShuttleRepairPart"
@@ -10729,18 +10800,16 @@
 /area/station/security/checkpoint/customs)
 "fwp" = (
 /obj/structure/disposalpipe/segment{
-	dir = 4
+	dir = 5
 	},
+/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
 /turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
+/area/station/maintenance/starboard/aft)
 "fwt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -10787,6 +10856,16 @@
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"fyB" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command hallway"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "fyS" = (
 /obj/structure/railing,
 /turf/open/floor/deadspace/mono,
@@ -10835,6 +10914,9 @@
 /obj/structure/table/wood,
 /obj/item/stamp/law,
 /obj/item/folder/red,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "fAI" = (
@@ -10986,6 +11068,15 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/mineral/titanium/survival/pod,
 /area/aegis/surface)
+"fFe" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/central)
 "fFW" = (
 /obj/machinery/light/small/maintenance/directional/south,
 /obj/structure/chair/office{
@@ -11087,16 +11178,6 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/storage/primary)
-"fKB" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/carpet/royalblack,
-/area/station/cargo/miningoffice)
 "fKL" = (
 /obj/structure/chair,
 /obj/machinery/light/directional/north,
@@ -11179,6 +11260,12 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore/lesser)
+"fMo" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "fMs" = (
 /obj/structure/window/reinforced/spawner,
 /obj/item/food/grown/banana/bunch,
@@ -11254,17 +11341,6 @@
 /obj/machinery/lapvend,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
-"fOb" = (
-/obj/structure/disposalpipe/junction{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "fOe" = (
 /obj/structure/reagent_dispensers/beerkeg,
 /turf/open/misc/asteroid,
@@ -11574,6 +11650,14 @@
 "fUM" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/commons/storage/primary)
+"fUQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "fVp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -11609,14 +11693,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
-"fWl" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/slides{
-	dir = 4
-	},
-/area/station/security/brig)
 "fWv" = (
 /obj/machinery/computer/piratepad_control/civilian,
 /turf/open/floor/deadspace/random/rectangles,
@@ -11699,6 +11775,12 @@
 	},
 /turf/open/floor/deadspace/random/golf_gray,
 /area/mine/hydroponics)
+"fYC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "fYH" = (
 /mob/living/simple_animal/slug/glubby,
 /turf/open/floor/wood,
@@ -11745,6 +11827,18 @@
 /obj/machinery/light/small/maintenance/directional/south,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
+"fZP" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "gak" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser{
@@ -11809,11 +11903,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "gbS" = (
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
-/area/aegis/surface)
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "gcw" = (
 /obj/machinery/door/airlock/mining{
 	dir = 1;
@@ -11847,6 +11941,17 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
+"gcX" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Cargo Privacy";
+	name = "Cargo Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "gda" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
@@ -12170,6 +12275,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"gmv" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "gmN" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -12252,8 +12370,8 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/stone,
-/area/aegis/surface)
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gpv" = (
 /obj/structure/cable/yellow{
 	icon_state = "12"
@@ -12287,14 +12405,11 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -12414,11 +12529,13 @@
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/captain)
 "guQ" = (
+/obj/structure/rack,
+/obj/effect/spawner/random/clothing/costume,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "gva" = (
 /obj/structure/railing,
 /turf/open/floor/deadspace/random/rectangles,
@@ -12441,6 +12558,17 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/deadspace/mono,
 /area/station/security/medical)
+"gvJ" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Cargo Privacy";
+	name = "Cargo Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "gvY" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/server)
@@ -12455,6 +12583,14 @@
 /obj/item/retractor,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
+"gwy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/morgue)
 "gwI" = (
 /obj/structure/cable/white{
 	icon_state = "10"
@@ -12468,13 +12604,11 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/floor/deadspace/mono,
-/area/station/cargo/sorting)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "gxI" = (
 /obj/structure/cable/yellow{
 	icon_state = "3"
@@ -12533,19 +12667,6 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood/three_quarters,
 /turf/open/floor/carpet/blue,
 /area/station/service/chapel/office)
-"gzn" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
 "gzq" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/rack,
@@ -12608,35 +12729,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
-"gAY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "gAZ" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
 	power_setting = 50
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"gBa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "gBe" = (
 /obj/structure/sign/map/right{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -12680,12 +12778,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
-"gCH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "gCT" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -12902,12 +12994,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"gKK" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "gKO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -12927,13 +13013,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/female)
-"gLi" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "gMl" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -13450,7 +13529,6 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "gXh" = (
-/obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 8
 	},
@@ -13478,6 +13556,13 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/female)
+"gXv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "gXB" = (
 /obj/machinery/washing_machine,
 /obj/effect/spawner/random/trash,
@@ -13525,6 +13610,17 @@
 "gYJ" = (
 /turf/open/openspace,
 /area/station/cargo/sorting)
+"gYR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/hardwood,
+/area/station/command/heads_quarters/captain)
 "gYS" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -13558,14 +13654,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/misc_lab)
-"gZP" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/exam_room)
 "gZQ" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/corner,
 /obj/structure/disposalpipe/junction/yjunction,
@@ -13617,7 +13705,7 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
@@ -13657,6 +13745,17 @@
 /obj/structure/bed/roller,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"hcd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "hch" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -13732,15 +13831,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/plating,
 /area/misc/testroom)
-"hff" = (
-/obj/machinery/modular_computer/console/preset/engineering{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/monitoring)
 "hfg" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
@@ -13764,17 +13854,6 @@
 	dir = 8
 	},
 /area/station/science/lobby)
-"hfy" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
 "hfD" = (
 /obj/structure/disposalpipe/junction/yjunction,
 /obj/structure/cable/yellow{
@@ -13916,13 +13995,6 @@
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/lobby)
-"hjz" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/tcommsat/server)
 "hjQ" = (
 /obj/effect/turf_decal/box,
 /turf/open/floor/plating,
@@ -13985,6 +14057,14 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"hmT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/mono,
+/area/station/cargo/sorting)
 "hnj" = (
 /obj/structure/stairs/south,
 /turf/open/floor/deadspace/mono,
@@ -14061,20 +14141,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"hph" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "hpk" = (
 /obj/structure/chair{
 	dir = 1
@@ -14118,6 +14184,15 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
+"hpN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "hpQ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -14409,13 +14484,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "9"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/deadspace/hardwood,
-/area/station/command/heads_quarters/captain)
+/turf/open/floor/deadspace/mono,
+/area/station/cargo/sorting)
 "hwp" = (
 /obj/structure/cable/yellow{
 	icon_state = "9"
@@ -14515,17 +14587,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"hyt" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "hyK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/airalarm/directional/north,
@@ -14652,6 +14713,12 @@
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"hCA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/cargo/warehouse)
 "hCD" = (
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/water/beach,
@@ -14675,6 +14742,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"hCX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "hDd" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -14683,10 +14762,16 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "hDf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/red,
-/area/station/security/office)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "hDv" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/customs)
@@ -14773,6 +14858,14 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"hFT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "hFY" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -14884,22 +14977,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"hHG" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "window command hallway"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/command/bridge)
 "hHW" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -14916,21 +14993,6 @@
 	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/engine_smes)
-"hIo" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/maint_center{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
 "hJm" = (
 /obj/structure/chair{
 	dir = 1
@@ -15195,12 +15257,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/greater)
-"hPy" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/warehouse)
 "hPz" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/left/directional/north{
@@ -15390,14 +15446,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
-"hTT" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig/upper)
 "hUi" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -15455,6 +15503,16 @@
 /obj/machinery/light/small/maintenance/directional/east,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
+"hVO" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/male)
 "hVP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -15658,16 +15716,11 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "window command blast"
-	},
-/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "3"
 	},
-/turf/open/floor/plating,
-/area/station/command/bridge)
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "idy" = (
 /obj/structure/lattice,
 /obj/machinery/conveyor{
@@ -15928,16 +15981,6 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"iiX" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/iron/white,
-/area/station/security/medical)
 "ijd" = (
 /obj/structure/table,
 /obj/effect/spawner/random/maintenance/two,
@@ -16022,6 +16065,17 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
+"ijN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "ijZ" = (
 /obj/structure/closet/crate/large/ds,
 /obj/effect/spawner/random/maintenance/two,
@@ -16132,7 +16186,7 @@
 /area/station/security/checkpoint/medical)
 "ilS" = (
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
@@ -16181,11 +16235,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "imS" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "1"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "imT" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -16208,16 +16263,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
-"inN" = (
-/obj/effect/floor_decal/ds/spline/fancy/wood{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/carpet/royalblue,
-/area/station/service/library)
 "iof" = (
 /obj/effect/spawner/structure/window/reinforced/tinted/prepainted/daedalus,
 /obj/structure/cable/yellow{
@@ -16232,11 +16277,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "iol" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
+/obj/structure/chair/office{
+	dir = 4
 	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "iov" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -16273,6 +16321,12 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"ipC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "ipE" = (
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
@@ -16285,6 +16339,14 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/primary/central/aft)
+"iqd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "iqf" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/west,
@@ -16335,6 +16397,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"iri" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/command/bridge)
 "irO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -16489,11 +16562,11 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "iwD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
-/area/station/cargo/warehouse)
+/turf/open/floor/carpet/red,
+/area/station/commons/lounge)
 "iwK" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/tile/yellow/anticorner/contrasted{
@@ -16522,6 +16595,15 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
+"ixI" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/hardwood,
+/area/station/command/heads_quarters/captain)
 "iyj" = (
 /obj/structure/kitchenspike,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -16701,15 +16783,6 @@
 /obj/item/electronics/apc,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
-"iBT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "iBX" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/box/white{
@@ -16724,18 +16797,26 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "2"
+	icon_state = "12"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "9"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse/upper)
+"iCg" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "1"
 	},
 /turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
+/area/station/engineering/supermatter/room)
 "iCm" = (
 /obj/machinery/light/small/directional/east,
 /obj/structure/closet/crate/large/ds/green_horizontal,
@@ -16766,6 +16847,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central/aft)
+"iCO" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "iCX" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 8
@@ -17104,13 +17191,11 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "iJI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "66"
 	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/morgue)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "iJV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 4
@@ -17176,7 +17261,7 @@
 "iLi" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/fore/greater)
@@ -17749,14 +17834,6 @@
 	},
 /turf/open/floor/plating,
 /area/aegis/hanger)
-"iXR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "iXU" = (
 /turf/open/floor/deadspace/cable,
 /area/station/hallway/secondary/exit/departure_lounge)
@@ -17935,15 +18012,19 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jdI" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/red{
-	icon_state = "3"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable/red{
-	icon_state = "1"
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/turf/open/floor/plating,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "jdK" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -17967,11 +18048,17 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"jeU" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
+"jeQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
 	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
+"jeU" = (
 /obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
 /turf/open/misc/asteroid{
 	simulated = 0
 	},
@@ -18071,6 +18158,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"jhs" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "jhv" = (
 /obj/structure/railing,
 /turf/open/floor/deadspace/roller,
@@ -18223,14 +18319,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
-"jkF" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
 "jkH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -18485,7 +18573,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "6"
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/sorting)
@@ -18558,11 +18646,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "jpV" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
 	},
+/turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "jpX" = (
 /obj/structure/rack,
@@ -18706,6 +18793,14 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"jtJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "jtP" = (
 /mob/living/simple_animal/drone/classic/scavbot{
 	dir = 4;
@@ -18766,13 +18861,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"juQ" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "jvn" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/air_input{
 	dir = 8
@@ -18877,13 +18965,6 @@
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
-"jyb" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/maintenance/fore/greater)
 "jyl" = (
 /obj/machinery/atmospherics/pipe/smart/simple/orange/visible,
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible{
@@ -18964,6 +19045,17 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/iron/stairs,
 /area/aegis/hanger)
+"jAG" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "jAQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -18998,6 +19090,12 @@
 /obj/machinery/vending/coffee,
 /turf/open/floor/deadspace/cable_end,
 /area/misc/testroom)
+"jBy" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "jBX" = (
 /obj/structure/window{
 	dir = 4
@@ -19085,14 +19183,6 @@
 /obj/structure/girder/displaced,
 /turf/open/floor/plating,
 /area/aegis/surface)
-"jDZ" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/station/medical/break_room)
 "jEf" = (
 /obj/machinery/button/door/directional/north{
 	name = "Armory Shutters";
@@ -19225,6 +19315,14 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"jIw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "jIB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -19255,6 +19353,9 @@
 /obj/machinery/camera/directional/north{
 	c_tag = "Science Firing Range";
 	network = list("ss13","rd")
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/engine,
 /area/station/science/misc_lab/range)
@@ -19474,6 +19575,12 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"jOM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "jON" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -19508,13 +19615,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"jPn" = (
-/obj/effect/turf_decal/box,
-/obj/effect/spawner/random/clothing/wardrobe_closet,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
 "jPs" = (
 /turf/open/floor/iron/dark/corner{
 	dir = 1
@@ -19573,6 +19673,13 @@
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore/lesser)
+"jQZ" = (
+/obj/machinery/light/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "jRe" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -19678,6 +19785,13 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
+"jTU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "jUL" = (
 /obj/structure/sign/cec/deck{
 	pixel_y = 34
@@ -19860,6 +19974,9 @@
 /area/station/cargo/storage)
 "jYE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "jYG" = (
@@ -20196,12 +20313,6 @@
 	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
-"khU" = (
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "khV" = (
 /obj/structure/table/reinforced,
 /obj/item/radio/intercom/directional/west,
@@ -20231,16 +20342,16 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "kis" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse/upper)
+/area/station/security/brig/upper)
 "kit" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
@@ -20482,10 +20593,10 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "kpk" = (
+/obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/slides,
-/area/station/cargo/warehouse)
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "kpy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -20498,14 +20609,16 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Mining Privacy";
+	name = "Mining Shutters"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "8"
 	},
-/turf/open/floor/deadspace/grille_spare3,
-/area/station/security/checkpoint/customs)
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -20575,6 +20688,12 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/starboard)
+"krG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "krQ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/delivery,
@@ -20786,23 +20905,15 @@
 "kyD" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
+"kyJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "20"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "kyT" = (
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/maintenance/fore/lesser)
-"kzg" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "window command blast"
-	},
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/command/bridge)
 "kzp" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_left,
@@ -20846,17 +20957,6 @@
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/engine_smes)
-"kBf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo/warehouse)
-"kBg" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "kBk" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/lounge)
@@ -20898,6 +20998,17 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"kCr" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "kCt" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -20984,6 +21095,14 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
+"kEi" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "kEv" = (
 /obj/item/megaphone,
 /obj/structure/table/wood,
@@ -21111,12 +21230,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/central/aft)
-"kHh" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "kHQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -21164,6 +21277,12 @@
 /obj/machinery/light/small/maintenance/directional/south,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
+"kJa" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/checkpoint/customs)
 "kJC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -21256,6 +21375,12 @@
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
+"kLN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "kMd" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/effect/turf_decal/stripes/line{
@@ -21376,6 +21501,20 @@
 "kOI" = (
 /turf/open/misc/asteroid,
 /area/station/hallway/primary/fore)
+"kPc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "kPe" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -21455,6 +21594,13 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
+"kQW" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "kRf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -21654,9 +21800,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
 "kVj" = (
@@ -21699,6 +21842,15 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/deadspace/random/golf_gray,
 /area/mine/hydroponics)
+"kWh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "12"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/service/chapel/monastery)
 "kWH" = (
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/random/contraband/permabrig_weapon,
@@ -21791,6 +21943,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
+"kYD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "kYE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -21834,6 +21994,15 @@
 /obj/item/folder/blue,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
+"lab" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock/cafeteria)
 "lao" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
@@ -21983,19 +22152,19 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "ldv" = (
-/obj/structure/disposalpipe/junction{
-	dir = 1
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -22008,6 +22177,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
@@ -22034,12 +22206,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
-"leg" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/carpet/red,
-/area/station/commons/lounge)
 "lem" = (
 /obj/structure/railing{
 	dir = 4
@@ -22081,6 +22247,13 @@
 	dir = 1
 	},
 /area/station/cargo/warehouse/upper)
+"lfb" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "lfp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/north,
@@ -22294,6 +22467,23 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
+"lki" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
+"lks" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "lku" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -22494,12 +22684,6 @@
 "lpI" = (
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/port/lesser)
-"lqp" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "lqv" = (
 /obj/structure/sink{
 	dir = 8;
@@ -22604,12 +22788,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
-"ltp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/brig)
 "lty" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
@@ -22734,19 +22912,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/hallway/primary/central/aft)
-"lxT" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/turf/open/floor/plating,
-/area/station/security/warden)
 "lxX" = (
 /obj/structure/railing,
 /obj/structure/closet/crate/large/ds/green_horizontal,
 /obj/effect/spawner/random/deadspace/ammo,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"lyc" = (
+/obj/structure/cable/multiz,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "lyn" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -22985,6 +23163,11 @@
 "lEf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark,
+/area/station/engineering/atmos)
+"lEg" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
 /area/station/engineering/atmos)
 "lEu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -23258,16 +23441,6 @@
 /obj/structure/grille,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"lMs" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/security/brig)
 "lMy" = (
 /mob/living/simple_animal/hostile/rat,
 /turf/open/floor/deadspace/grater,
@@ -23331,6 +23504,13 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"lOe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "lOp" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 10
@@ -23381,6 +23561,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
+"lOI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "lOT" = (
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
@@ -23542,6 +23730,12 @@
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
+"lTn" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "lTt" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/east,
@@ -23564,9 +23758,6 @@
 /area/station/service/library)
 "lTz" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/male)
 "lTI" = (
@@ -23678,6 +23869,14 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
+"lYv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/exam_room)
 "lYG" = (
 /obj/structure/railing,
 /turf/open/openspace,
@@ -23886,6 +24085,17 @@
 "mdu" = (
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
+"mdw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/wood,
+/area/station/cargo/qm)
 "mdX" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 10
@@ -23907,6 +24117,16 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"mer" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "mew" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Science Admin";
@@ -24185,16 +24405,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"mmH" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/spawner/random/maintenance,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
 "mmQ" = (
 /obj/machinery/airalarm/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
@@ -24255,15 +24465,13 @@
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "mou" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/female)
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "moB" = (
 /obj/machinery/door/airlock/hydroponics/glass{
 	name = "Abandoned Hydroponics";
@@ -24488,18 +24696,6 @@
 	dir = 4
 	},
 /area/station/hallway/primary/fore)
-"mtB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "mtQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "12"
@@ -24641,15 +24837,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
-"mxJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/command/bridge)
 "mxM" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/east,
@@ -24680,12 +24867,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
-"mzA" = (
-/obj/structure/cable/yellow{
-	icon_state = "40"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "mzU" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_left{
@@ -24713,39 +24894,12 @@
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
-"mAh" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/wood,
-/area/station/commons/lounge)
 "mAl" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
 /obj/effect/spawner/random/food_or_drink/three_course_meal,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
-"mAD" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/maint_center{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
-"mAN" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/morgue)
 "mAV" = (
 /obj/machinery/rnd/production/fabricator/department/security,
 /obj/machinery/airalarm/directional/west,
@@ -24820,13 +24974,12 @@
 	},
 /area/mine/production)
 "mCd" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
+/turf/open/floor/stone,
 /area/aegis/surface)
 "mCl" = (
 /obj/structure/window/reinforced/spawner/west,
@@ -24852,6 +25005,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/commons/dorms/barracks/male)
+"mCC" = (
+/obj/machinery/light/directional/north,
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "mCF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -25031,12 +25194,16 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
-"mIv" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
+"mIw" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command hallway"
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "mIX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -25062,29 +25229,27 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"mJt" = (
-/obj/structure/flora/ausbushes/ppflowers,
-/mob/living/simple_animal/butterfly,
-/turf/open/floor/grass,
-/area/station/hallway/primary/fore)
-"mJG" = (
-/obj/machinery/door/airlock/security/glass{
-	id_tag = "outerbrig";
-	name = "P-Sec Brig";
-	req_access_txt = "63";
-	dir = 1
-	},
+"mJq" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
-	cycle_id = "brig-entrance"
-	},
+/obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/security/brig)
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
+"mJt" = (
+/obj/structure/flora/ausbushes/ppflowers,
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/grass,
+/area/station/hallway/primary/fore)
 "mJN" = (
 /obj/structure/railing{
 	dir = 8
@@ -25123,17 +25288,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
-"mKV" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "mLj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
@@ -25437,6 +25591,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"mSK" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "mST" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/showroomfloor,
@@ -25479,6 +25642,12 @@
 "mUn" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"mUA" = (
+/obj/structure/cable/yellow{
+	icon_state = "68"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "mUC" = (
 /obj/machinery/door/poddoor,
 /obj/machinery/conveyor{
@@ -25775,6 +25944,9 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "naA" = (
@@ -25790,6 +25962,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"naF" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/hallway/primary/port)
 "nbo" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 8;
@@ -25873,7 +26054,7 @@
 /area/station/maintenance/fore/lesser)
 "ncO" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
@@ -26021,6 +26202,16 @@
 /obj/structure/railing,
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
+"nhW" = (
+/obj/effect/floor_decal/ds/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/station/service/library)
 "nih" = (
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/iron,
@@ -26128,7 +26319,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "10"
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
@@ -26261,6 +26452,12 @@
 /obj/machinery/camera/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"nqb" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "nqi" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/structure/chair/office,
@@ -26423,14 +26620,6 @@
 	dir = 4
 	},
 /area/aegis/mining)
-"nwl" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/stone,
-/area/aegis/surface)
 "nwv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -26463,7 +26652,13 @@
 	},
 /obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "8"
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
@@ -26499,6 +26694,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"nyF" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "nyU" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/qm)
@@ -26549,6 +26750,17 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
+"nzN" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
+"nzU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "nzW" = (
 /obj/effect/spawner/random/maintenance/two,
 /obj/structure/rack,
@@ -26684,13 +26896,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "nBX" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/command/bridge)
 "nCk" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -26776,17 +26986,6 @@
 "nDA" = (
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
-"nDH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
-"nEm" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/plating,
-/area/station/engineering/atmos)
 "nED" = (
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -26914,13 +27113,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/aft)
-"nID" = (
-/obj/structure/cable/multiz,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/iron/dark,
-/area/station/security/brig/upper)
 "nIX" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/deadspace/grater,
@@ -27034,10 +27226,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
-"nMn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/deadspace/mono,
-/area/station/cargo)
 "nMp" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 6
@@ -27059,11 +27247,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse)
 "nMG" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/security/checkpoint/customs)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "nMM" = (
 /obj/machinery/air_sensor/plasma_tank,
 /obj/machinery/camera/directional/east{
@@ -27084,6 +27271,17 @@
 	},
 /turf/open/floor/iron,
 /area/station/service/bar)
+"nMY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "nNi" = (
 /obj/machinery/cryopod{
 	dir = 8
@@ -27155,11 +27353,10 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "nOQ" = (
-/obj/structure/lattice,
-/obj/effect/spawner/random/structure/grille,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/yellow{
+	icon_state = "40"
 	},
+/turf/open/misc/asteroid,
 /area/aegis/surface)
 "nOX" = (
 /obj/machinery/cryopod,
@@ -27427,6 +27624,14 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
+"nVW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "nWb" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/slides{
@@ -27533,6 +27738,20 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/openspace,
 /area/aegis/surface)
+"nZu" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "nZH" = (
 /obj/structure/flora/ausbushes/brflowers,
 /mob/living/simple_animal/butterfly,
@@ -27564,6 +27783,14 @@
 /obj/machinery/meter,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"oau" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "oaQ" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -27638,7 +27865,7 @@
 /area/station/command/bridge)
 "ocO" = (
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
 /turf/open/misc/ironsand,
 /area/aegis/surface)
@@ -27676,7 +27903,7 @@
 	dir = 4
 	},
 /obj/structure/cable/white{
-	icon_state = "12"
+	icon_state = "132"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/service/chapel/monastery)
@@ -27946,14 +28173,6 @@
 /obj/effect/landmark,
 /turf/open/floor/deadspace/roller,
 /area/aegis/surface)
-"okh" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "okw" = (
 /obj/machinery/firealarm/directional/north,
 /obj/structure/cable/orange{
@@ -28060,6 +28279,16 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
+"omM" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "omN" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 1
@@ -28215,9 +28444,6 @@
 /area/station/medical/medbay/central)
 "oqy" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2"
 	},
@@ -28391,6 +28617,14 @@
 /obj/structure/closet/body_bag,
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/deadspace/grater,
+/area/station/medical/morgue)
+"ovv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "ovA" = (
 /obj/machinery/recharge_station,
@@ -28686,45 +28920,11 @@
 /obj/item/circular_saw/bonecutter,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"oDC" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
-"oDD" = (
-/obj/structure/cable/yellow{
-	icon_state = "132"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "oDH" = (
 /obj/effect/decal/cleanable/cobweb,
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/station/engineering/main)
-"oEb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/maint_center{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
 "oEw" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 4
@@ -28846,17 +29046,6 @@
 	},
 /turf/open/floor/plating,
 /area/aegis/surface)
-"oHX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "oHZ" = (
 /obj/machinery/light/small/maintenance/directional/east,
 /turf/open/floor/plating,
@@ -28955,6 +29144,13 @@
 	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/brig)
+"oJK" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "oKi" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -28991,12 +29187,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central/aft)
-"oLh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 1
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "oLQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "UndergroundMining";
@@ -29140,13 +29330,6 @@
 "oQh" = (
 /turf/closed/wall/r_wall,
 /area/station/service/chapel/storage)
-"oQo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
-	dir = 8
-	},
-/obj/machinery/meter/monitored/waste_loop,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
 "oQE" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/engine,
@@ -29320,13 +29503,6 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
-"oTJ" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
 "oTX" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -29340,10 +29516,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "3"
 	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
@@ -29417,15 +29590,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
-"oWK" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock/cafeteria)
 "oWL" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
@@ -29518,10 +29682,7 @@
 /area/station/medical/medbay/central)
 "oYE" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "6"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -29717,14 +29878,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"pep" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
 "pev" = (
 /obj/effect/landmark/start/medical_doctor,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -29779,12 +29932,11 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "pfG" = (
-/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "3"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "pfH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -29795,12 +29947,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
-"pfQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "pfX" = (
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/deadspace/mono,
@@ -29948,6 +30094,13 @@
 /obj/item/bot_assembly/scavbot,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
+"plx" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command hallway"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "plB" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/deadspace/mono,
@@ -30018,6 +30171,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"pmj" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "pml" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
@@ -30037,14 +30199,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"pmQ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/wood,
-/area/station/command/heads_quarters/hos)
 "pmR" = (
 /obj/item/shard,
 /obj/machinery/computer{
@@ -30053,11 +30207,16 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "pmS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
-/turf/closed/wall/r_wall,
-/area/station/engineering/supermatter/room)
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "pnj" = (
 /obj/structure/railing{
 	dir = 6
@@ -30122,6 +30281,16 @@
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
+"ppa" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "ppE" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -30291,12 +30460,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
-"pty" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/command/bridge)
 "ptP" = (
 /obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/bot,
@@ -30322,6 +30485,13 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"pur" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/maintenance/fore/greater)
 "puN" = (
 /obj/structure/sign/cec/deck{
 	pixel_y = 34
@@ -30372,14 +30542,6 @@
 "pvL" = (
 /turf/open/floor/plating,
 /area/station/cargo/storage)
-"pvO" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
 "pvW" = (
 /obj/item/pickaxe/rock,
 /turf/open/misc/asteroid,
@@ -30441,6 +30603,25 @@
 /obj/effect/spawner/random/food_or_drink/snack,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
+"pyb" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command blast"
+	},
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
+"pyd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "pyh" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hos)
@@ -30855,6 +31036,13 @@
 /obj/item/wallframe/apc,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"pIq" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "pIx" = (
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
@@ -31040,12 +31228,6 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
-"pMO" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "pNe" = (
 /obj/machinery/door/airlock/security{
 	name = "Security Checkpoint #2";
@@ -31076,6 +31258,12 @@
 	},
 /turf/open/floor/iron/dark/textured_corner,
 /area/station/medical/medbay/central)
+"pNt" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "pNB" = (
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
@@ -31358,15 +31546,6 @@
 /obj/item/clothing/head/cseco,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hos)
-"pVC" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "pVI" = (
 /obj/item/storage/box/gloves,
 /obj/structure/table,
@@ -31407,6 +31586,21 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningdock/oresilo)
+"pWF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "pWI" = (
 /obj/structure/filingcabinet{
 	pixel_x = 3
@@ -31639,7 +31833,13 @@
 	name = "Cargo Shutters"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1"
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/plating,
 /area/station/cargo/qm)
@@ -31757,7 +31957,7 @@
 "qfF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "5"
 	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
@@ -31803,6 +32003,16 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/deadspace/mono,
 /area/station/medical/exam_room)
+"qgP" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/female)
 "qgU" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Departure Lounge - Starboard Aft"
@@ -31868,10 +32078,17 @@
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "qhR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/commons/dorms/cryo)
 "qhZ" = (
 /obj/structure/rack,
 /obj/item/clothing/under/rank/medical/scrubs/purple,
@@ -31910,6 +32127,9 @@
 "qjg" = (
 /obj/structure/cable/yellow{
 	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
@@ -31996,16 +32216,14 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "qly" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/area/aegis/surface)
 "qlA" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plating,
@@ -32356,20 +32574,6 @@
 /obj/structure/ladder/invincible,
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
-"qtJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
 "qtR" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -32627,18 +32831,9 @@
 /turf/open/floor/iron/norn,
 /area/station/medical/office)
 "qAY" = (
-/obj/effect/turf_decal/bot_white,
-/obj/effect/spawner/random/maintenance,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/turf/open/floor/deadspace/random/slides,
+/area/station/cargo/warehouse)
 "qBi" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
@@ -32820,12 +33015,11 @@
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qHk" = (
-/obj/structure/railing{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -32940,12 +33134,6 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse)
-"qLd" = (
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/stone,
-/area/aegis/surface)
 "qLg" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/bureaucracy/briefcase{
@@ -32957,6 +33145,14 @@
 	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
+"qLk" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "qLm" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
@@ -33010,14 +33206,12 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "qMP" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/structure/railing{
+	dir = 8
 	},
-/turf/open/misc/asteroid{
-	simulated = 0
-	},
-/area/aegis/surface)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "qMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -33033,6 +33227,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
+"qNg" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "qNt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -33124,6 +33323,11 @@
 /obj/structure/closet/secure_closet/ds/engineering_personal,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"qPX" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "qQg" = (
 /obj/item/kirbyplants,
 /turf/open/floor/iron/dark/side{
@@ -33214,6 +33418,14 @@
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
 /area/misc/testroom)
+"qSt" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/break_room)
 "qSB" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -33244,20 +33456,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"qTm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/mine/lobby)
 "qTV" = (
 /obj/machinery/light/small/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -33433,12 +33631,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/lobby)
-"qXx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/deadspace/bathroom,
-/area/mine/production)
 "qXD" = (
 /obj/effect/spawner/random/vending/snackvend,
 /turf/open/floor/deadspace/random/maint_center,
@@ -33596,16 +33788,6 @@
 	dir = 8
 	},
 /area/mine/production)
-"rcj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/light/floor/has_bulb,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
 "rcl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -33636,6 +33818,12 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
+"rdf" = (
+/obj/structure/cable/yellow{
+	icon_state = "24"
+	},
+/turf/open/floor/plating,
+/area/aegis/surface)
 "rdm" = (
 /obj/structure/railing{
 	dir = 5
@@ -33669,15 +33857,6 @@
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/fore)
-"rep" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/norn,
-/area/station/hallway/primary/central)
 "rez" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment{
@@ -33859,16 +34038,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
-"rjT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light/directional/south,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
 "rkf" = (
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -33887,13 +34056,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"rkA" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "rkL" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
@@ -33980,13 +34142,19 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "rlW" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "9"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command blast"
 	},
-/turf/open/floor/stone,
-/area/aegis/surface)
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "rma" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Cryo - Left"
@@ -34080,17 +34248,13 @@
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
 "rpe" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/area/station/hallway/secondary/exit/departure_lounge)
 "rpp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -34187,6 +34351,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/cargo/lobby)
+"rrK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/cargo/warehouse)
 "rrP" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /obj/machinery/light_switch/directional/west,
@@ -34325,6 +34496,12 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron/white,
 /area/station/commons/lounge)
+"rvn" = (
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "rvx" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
@@ -34391,21 +34568,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/wood,
 /area/station/cargo/qm)
-"rxm" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/main)
 "rxo" = (
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
@@ -34476,7 +34638,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "6"
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
@@ -34588,10 +34750,11 @@
 	},
 /area/station/hallway/primary/central/aft)
 "rCI" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo/warehouse)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "rCX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -34621,15 +34784,6 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"rDy" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/central)
 "rDE" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 4
@@ -34643,12 +34797,19 @@
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "rDI" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock/cafeteria)
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "rDN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -34673,12 +34834,6 @@
 /obj/machinery/light/small/maintenance/directional/south,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
-"rEc" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 1
-	},
-/turf/open/floor/deadspace/mono,
-/area/station/cargo)
 "rEA" = (
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/fore)
@@ -34704,13 +34859,6 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
-"rFO" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "window command hallway"
-	},
-/turf/open/floor/plating,
-/area/station/command/bridge)
 "rFX" = (
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
@@ -34792,6 +34940,9 @@
 /area/station/cargo/storage)
 "rIu" = (
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "rIL" = (
@@ -34915,9 +35066,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "rKS" = (
@@ -34969,6 +35117,15 @@
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/station/maintenance/fore/lesser)
+"rMC" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/grille_spare3,
+/area/station/security/checkpoint/customs)
 "rMK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/binary/pump/on,
@@ -35031,6 +35188,19 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/courtroom)
+"rNT" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/white,
+/area/station/service/kitchen)
 "rOn" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/tcomms,
@@ -35038,12 +35208,6 @@
 /obj/item/pen,
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
-"rOt" = (
-/obj/structure/cable/yellow{
-	icon_state = "68"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "rOE" = (
 /obj/structure/sign/poster/official/moth_epi{
 	pixel_x = -32
@@ -35118,14 +35282,17 @@
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
 "rQA" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid{
-	simulated = 0
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
-/area/aegis/surface)
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "rQK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/tool,
@@ -35212,10 +35379,10 @@
 /area/station/command/bridge)
 "rTT" = (
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "129"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/command/bridge)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "rTW" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -35293,22 +35460,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/mechbay)
-"rVD" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "window command hallway"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/plating,
-/area/station/command/bridge)
 "rVF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/purple/visible{
 	dir = 8
@@ -35356,7 +35507,8 @@
 /area/station/medical/surgery/theatre)
 "rXD" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/golf_brown,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "rXE" = (
 /turf/open/floor/deadspace/random/slides{
@@ -35618,6 +35770,18 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
+"shj" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "shk" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/disposalpipe/segment{
@@ -35652,6 +35816,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"sis" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "siV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
@@ -36040,6 +36215,18 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"stc" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/command/bridge)
+"stX" = (
+/obj/structure/cable/yellow{
+	icon_state = "132"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "sua" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -36074,14 +36261,6 @@
 /obj/machinery/light/small/maintenance/directional/east,
 /turf/open/floor/deadspace/hardwood,
 /area/station/maintenance/port/lesser)
-"suG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
 "suL" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse/upper)
@@ -36090,6 +36269,22 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
+"svi" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
+"svl" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/norn,
+/area/station/hallway/primary/central)
 "svo" = (
 /obj/structure/rack/shelf,
 /obj/effect/turf_decal/bot_white,
@@ -36127,20 +36322,6 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse/upper)
-"svP" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "window command blast"
-	},
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/command/bridge)
 "swq" = (
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/female)
@@ -36163,16 +36344,14 @@
 /turf/open/floor/plating,
 /area/station/engineering/atmos)
 "swY" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Mining Privacy";
-	name = "Mining Shutters"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
 	},
-/obj/structure/cable/yellow{
-	icon_state = "8"
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/floor/plating,
-/area/station/cargo/qm)
+/area/aegis/surface)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
 	dir = 4
@@ -36349,17 +36528,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "sCc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/maintenance/starboard/aft)
+/area/aegis/surface)
 "sCd" = (
 /obj/structure/closet/crate/large,
 /obj/effect/spawner/random/maintenance/two,
@@ -36448,6 +36621,9 @@
 /area/station/engineering/atmos)
 "sEi" = (
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "sEl" = (
@@ -36505,6 +36681,13 @@
 "sFi" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/locker)
+"sFy" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "sFB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced/grille,
@@ -36617,17 +36800,6 @@
 /obj/structure/table,
 /turf/open/floor/stone,
 /area/aegis/surface)
-"sKj" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/iron/dark,
-/area/station/science/breakroom)
 "sKB" = (
 /obj/machinery/conveyor{
 	id = "Lower Marker Conveyor";
@@ -36809,12 +36981,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sPk" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "1"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/main)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "sPH" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/bot,
@@ -37080,11 +37249,6 @@
 	},
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
-"sWD" = (
-/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/station/engineering/atmos/storage/gas)
 "sWE" = (
 /obj/structure/closet/wardrobe/black,
 /turf/open/floor/deadspace/heavy,
@@ -37232,12 +37396,6 @@
 /obj/effect/spawner/random/clothing/mafia_outfit,
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
-"sZZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/station/cargo/qm)
 "tak" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
@@ -37304,6 +37462,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -37405,7 +37566,7 @@
 "tfU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "tfW" = (
@@ -37496,12 +37657,6 @@
 "thU" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/warehouse/upper)
-"tih" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "tij" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37529,23 +37684,6 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom,
 /area/station/medical/coldroom)
-"tiD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
-	id = "window command blast"
-	},
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/plating,
-/area/station/command/bridge)
 "tiS" = (
 /obj/structure/table/reinforced,
 /turf/open/floor/deadspace/random/slides,
@@ -37603,14 +37741,12 @@
 /obj/machinery/computer/med_data,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
-"tkM" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"tkH" = (
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "18"
 	},
-/turf/open/floor/iron/dark,
-/area/station/science/breakroom)
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "tkZ" = (
 /obj/item/stack/rods,
 /turf/open/floor/deadspace/grater,
@@ -37671,12 +37807,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/starboard)
-"tmU" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark/telecomms,
-/area/station/tcommsat/server)
 "tmW" = (
 /obj/machinery/door/airlock/mining/glass{
 	name = "Quartermaster";
@@ -37737,6 +37867,15 @@
 /obj/machinery/gibber,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
+"tpi" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "tpk" = (
 /obj/machinery/door/airlock/external{
 	name = "Cave-In Shelter 2"
@@ -37777,15 +37916,9 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "trK" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/iron/grimy,
-/area/station/tcommsat/computer)
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/service/hydroponics)
 "trL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -37885,14 +38018,6 @@
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/iron/white,
 /area/station/science/research)
-"tuw" = (
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/iron/dark,
-/area/station/engineering/storage/tech)
 "tux" = (
 /obj/structure/table,
 /obj/item/crowbar/red,
@@ -37967,12 +38092,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/male)
-"tvi" = (
-/obj/structure/cable/yellow{
-	icon_state = "18"
-	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
 "tvx" = (
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -38154,6 +38273,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"tAy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "tAI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/norn,
@@ -38164,6 +38289,14 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
+"tAZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "tBf" = (
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -38197,6 +38330,20 @@
 /obj/machinery/power/data_terminal,
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/hos)
+"tBK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "tBM" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/slides{
@@ -38327,6 +38474,17 @@
 /obj/item/storage/medkit/surgery,
 /turf/closed/wall/r_wall,
 /area/station/medical/medbay/aft)
+"tGC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/command/bridge)
 "tHg" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/icecream_vat,
@@ -38345,12 +38503,11 @@
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/male)
 "tIj" = (
-/obj/structure/railing{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/plating,
-/area/station/cargo/warehouse)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/command/bridge)
 "tIu" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_right,
@@ -38451,6 +38608,17 @@
 /obj/structure/table,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"tLC" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "tLZ" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
@@ -38508,14 +38676,16 @@
 	},
 /area/station/hallway/primary/starboard)
 "tNh" = (
+/obj/structure/disposalpipe/junction{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/command/bridge)
+/area/station/cargo/storage)
 "tNI" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4;
@@ -38591,7 +38761,10 @@
 "tQQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
@@ -38707,6 +38880,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "tTd" = (
@@ -38754,6 +38930,18 @@
 /obj/structure/table/wood,
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
+"tUq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "tUB" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/deadspace/random/golf_gray,
@@ -38858,6 +39046,20 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
+"tXm" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command blast"
+	},
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "tXB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -38940,10 +39142,7 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
@@ -39016,12 +39215,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
-"ucc" = (
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/cargo)
 "uck" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/deadspace/random/slides{
@@ -39110,6 +39303,9 @@
 /obj/item/multitool/circuit{
 	pixel_x = -8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "ueH" = (
@@ -39121,6 +39317,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
+"ueM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "ufc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -39139,10 +39349,6 @@
 /obj/item/clothing/head/welding/knight,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"ugs" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/closed/wall/r_wall,
-/area/station/engineering/atmos/storage/gas)
 "ugt" = (
 /obj/structure/chair/sofa/bench{
 	dir = 8
@@ -39162,6 +39368,10 @@
 	},
 /turf/open/floor/iron/norn,
 /area/station/service/hydroponics/upper)
+"ugP" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "ugU" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/item/stack/ore/iron,
@@ -39311,6 +39521,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"ulv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "uly" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/entertainment/money_large,
@@ -39519,6 +39736,14 @@
 /obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/brig)
+"upx" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "upz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39609,21 +39834,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"urz" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/hallway/primary/port)
-"urC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
-	},
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "urO" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/spawner/random/structure/closet_empty/crate,
@@ -39753,11 +39963,19 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"uuR" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock/cafeteria)
 "uuS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/mono,
-/area/station/cargo)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "uvc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -39844,17 +40062,6 @@
 /obj/item/clothing/gloves/ring/diamond,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"uxL" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "miningsecprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/science)
 "uxN" = (
 /obj/structure/chair{
 	dir = 4
@@ -39865,13 +40072,15 @@
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation)
 "uyg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/grater,
-/area/station/security/brig/upper)
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "uyk" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/vending/hydroseeds,
@@ -40094,15 +40303,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/primary)
-"uCr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "uCC" = (
 /turf/open/floor/deadspace/grille_spare2,
 /area/aegis/surface)
@@ -40173,6 +40373,13 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"uFw" = (
+/obj/effect/turf_decal/box,
+/obj/effect/spawner/random/clothing/wardrobe_closet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "uFY" = (
 /obj/machinery/telecomms/processor/preset_three,
 /obj/machinery/camera/directional/north{
@@ -40224,8 +40431,11 @@
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -40246,10 +40456,6 @@
 "uHK" = (
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/hallway/primary/central/aft)
-"uHY" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/grater,
-/area/station/cargo/warehouse)
 "uHZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_left,
@@ -40402,6 +40608,9 @@
 	name = "Chapel Office Maintenance";
 	req_one_access_txt = "22"
 	},
+/obj/structure/cable/white{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/monastery)
 "uNu" = (
@@ -40497,42 +40706,15 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
-"uQx" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "miningsecprivacy";
-	name = "privacy shutter"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/security/checkpoint/science)
 "uQL" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Mining Privacy";
-	name = "Mining Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/qm)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -40611,14 +40793,6 @@
 "uSq" = (
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics)
-"uSr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/security/brig)
 "uSt" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -40744,24 +40918,6 @@
 	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
-"uVg" = (
-/obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/engineering/monitoring)
-"uVx" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Solar Access";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "uVy" = (
 /turf/open/floor/carpet,
 /area/station/maintenance/fore/lesser)
@@ -40807,18 +40963,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
-"uXf" = (
-/obj/structure/chair/stool/directional/south,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
 "uXj" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 2
@@ -41411,16 +41555,15 @@
 "vmk" = (
 /turf/closed/wall/r_wall,
 /area/mine/hydroponics)
+"vmF" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "vmK" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "window command hallway"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/command/bridge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides,
+/area/station/cargo/warehouse)
 "vmO" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -41512,23 +41655,6 @@
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
-"vqq" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Cargo Privacy";
-	name = "Cargo Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/qm)
 "vqr" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41709,6 +41835,20 @@
 	dir = 9
 	},
 /area/station/hallway/primary/starboard)
+"vvb" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "vvj" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/aegis/surface)
@@ -41763,13 +41903,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vwz" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/cable/yellow{
-	icon_state = "12"
+	icon_state = "3"
 	},
-/turf/open/floor/stone,
-/area/aegis/surface)
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock/cafeteria)
 "vwZ" = (
 /obj/structure/sign/cec/deck/research{
 	pixel_y = -32
@@ -41923,13 +42062,6 @@
 /obj/machinery/autolathe,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/port/lesser)
-"vAq" = (
-/obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/iron/dark,
-/area/station/cargo/miningdock/cafeteria)
 "vAI" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
@@ -42019,14 +42151,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
-"vCR" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/turf/open/floor/deadspace/mono,
-/area/station/cargo/sorting)
 "vCY" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
@@ -42332,13 +42456,6 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
-"vKJ" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "vKM" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/chair/office{
@@ -42386,19 +42503,6 @@
 /obj/effect/spawner/random/contraband/armory,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"vMc" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "8"
-	},
-/turf/open/floor/plating,
-/area/station/hallway/secondary/exit)
 "vMm" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -42485,6 +42589,9 @@
 "vNC" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/light/small/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/engine,
 /area/station/science/misc_lab/range)
 "vNP" = (
@@ -42524,6 +42631,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"vPL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "vPM" = (
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/hallway/primary/fore)
@@ -42697,7 +42812,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "vTF" = (
@@ -42849,7 +42964,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
-	icon_state = "10"
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
@@ -42863,12 +42981,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/hallway/primary/aft)
-"vWE" = (
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
 "vXO" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
@@ -43043,10 +43155,20 @@
 	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit)
+"wdC" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "wdL" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"wdQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "wdW" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard,
@@ -43077,11 +43199,9 @@
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "weG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "weI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/mono,
@@ -43232,6 +43352,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
+"wiw" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "wiB" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/deadspace/grater,
@@ -43333,20 +43462,6 @@
 /obj/machinery/holopad,
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
-"wmf" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/medical,
-/area/station/medical/medbay/aft)
 "wmg" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/catwalk_floor/iron_dark,
@@ -43409,13 +43524,6 @@
 	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
-"woq" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/service/janitor)
 "wot" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -43482,14 +43590,14 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpg" = (
-/obj/effect/turf_decal/bot_white,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "12"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
+	dir = 8
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "wpl" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
@@ -43574,11 +43682,14 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "wrl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
-	icon_state = "24"
+	icon_state = "5"
 	},
-/turf/open/floor/plating,
-/area/aegis/surface)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/structure/cable/yellow{
@@ -43661,11 +43772,20 @@
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "wtM" = (
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -43791,10 +43911,29 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
-	icon_state = "9"
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
+"wxT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/cargo/qm)
+"wxV" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "wyu" = (
 /obj/structure/rack,
 /obj/item/disk/holodisk/ds13/odd_shanty,
@@ -44218,12 +44357,6 @@
 	dir = 1
 	},
 /area/station/hallway/primary/starboard)
-"wHU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
-	},
-/area/station/cargo/warehouse)
 "wIb" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -44356,16 +44489,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
-"wNp" = (
-/obj/machinery/light/directional/north,
-/obj/structure/chair{
-	pixel_y = -2
-	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
 "wNz" = (
 /obj/structure/table,
 /obj/effect/spawner/random/bureaucracy/briefcase,
@@ -44389,20 +44512,6 @@
 /obj/effect/turf_decal/siding/purple,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
-"wNW" = (
-/obj/structure/rack,
-/obj/effect/spawner/random/clothing/costume,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "9"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/deadspace/heavy,
-/area/station/commons/locker)
 "wNX" = (
 /obj/structure/railing{
 	dir = 8
@@ -44466,14 +44575,6 @@
 /obj/machinery/light/directional/north,
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
-"wQS" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/wood,
-/area/station/cargo/qm)
 "wRj" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 1
@@ -44570,16 +44671,6 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/deadspace/bathroom,
 /area/mine/production)
-"wUd" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/commons/dorms/barracks/male)
 "wUk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -45035,6 +45126,20 @@
 "xeU" = (
 /turf/open/openspace,
 /area/station/cargo/warehouse/upper)
+"xfk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "xfB" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -45099,6 +45204,13 @@
 /obj/item/gun/ballistic/automatic/pistol/rivet,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"xgR" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "xhi" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 8
@@ -45239,6 +45351,15 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
+"xjG" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/hallway/secondary/exit/departure_lounge)
 "xki" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
@@ -45257,6 +45378,14 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"xkv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "xkM" = (
 /turf/open/floor/deadspace/mono,
 /area/aegis/mining)
@@ -45549,8 +45678,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "xsj" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
-/turf/open/floor/deadspace/random/golf_brown,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/mono,
 /area/station/cargo)
 "xsl" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -45749,14 +45880,10 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "xwJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/commons/dorms/cryo)
+/area/aegis/surface)
 "xwY" = (
 /obj/effect/landmark/pestspawn,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -45815,6 +45942,12 @@
 	dir = 1
 	},
 /area/station/security/courtroom)
+"xxW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/cargo/warehouse)
 "xye" = (
 /obj/item/gps,
 /obj/item/gps,
@@ -46011,6 +46144,20 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
+"xEw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/medbay/aft)
 "xEC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input{
 	dir = 8
@@ -46021,14 +46168,6 @@
 /obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/eva)
-"xEU" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
 "xFb" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/cable/yellow{
@@ -46142,15 +46281,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/central)
-"xIi" = (
-/obj/structure/cable/yellow{
-	icon_state = "6"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "10"
-	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/command/bridge)
 "xIA" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
@@ -46244,17 +46374,6 @@
 "xKp" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/break_room)
-"xKt" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "Cargo Privacy";
-	name = "Cargo Shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2"
-	},
-/turf/open/floor/plating,
-/area/station/cargo/qm)
 "xKG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -46301,7 +46420,7 @@
 	name = "privacy shutter"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "2"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/science)
@@ -46471,17 +46590,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
-"xRa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/hardwood,
-/area/station/command/heads_quarters/captain)
 "xRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "xRl" = (
@@ -46501,14 +46612,6 @@
 "xRH" = (
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
-"xSa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/deadspace/random/golf_brown,
-/area/station/command/bridge)
 "xSd" = (
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
@@ -46652,8 +46755,8 @@
 	},
 /area/station/hallway/primary/starboard)
 "xYm" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "12"
 	},
@@ -46706,6 +46809,15 @@
 /obj/effect/spawner/random/entertainment/money_large,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"xZo" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/command/bridge)
 "xZH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -46777,12 +46889,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
-"yci" = (
-/obj/structure/cable/yellow{
-	icon_state = "129"
-	},
-/turf/open/misc/ironsand,
-/area/aegis/surface)
 "ycm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
@@ -46827,6 +46933,13 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
+"yeu" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "yey" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/grater,
@@ -46845,14 +46958,6 @@
 /obj/machinery/door/poddoor/preopen,
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
-"yeQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/norn,
-/area/station/hallway/primary/starboard)
 "yfc" = (
 /obj/machinery/computer/mecha{
 	dir = 8
@@ -46868,12 +46973,6 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
-"yfg" = (
-/obj/structure/cable/yellow{
-	icon_state = "12"
-	},
-/turf/open/floor/plating,
-/area/station/maintenance/solars/port/fore)
 "yfn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -46913,11 +47012,13 @@
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "ygs" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/cable/yellow{
 	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/command/bridge)
+/area/station/cargo/storage)
 "ygt" = (
 /obj/structure/rack/shelf,
 /obj/item/plate_shard/marker_shard,
@@ -46981,16 +47082,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/effect/spawner/structure/window/reinforced/grille,
 /obj/structure/cable/yellow{
-	icon_state = "3"
+	icon_state = "1"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "5"
-	},
-/turf/open/floor/catwalk_floor/iron_dark,
+/turf/open/floor/plating,
 /area/station/engineering/main)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
@@ -55374,7 +55470,7 @@ uoP
 trm
 mNO
 mNO
-cUc
+odB
 trm
 ssE
 jxc
@@ -55531,7 +55627,7 @@ iba
 gTe
 mNO
 mNO
-odB
+kWh
 trm
 trm
 jxc
@@ -55688,7 +55784,7 @@ uoP
 trm
 mNO
 mNO
-odB
+kWh
 trm
 trm
 jxc
@@ -55845,7 +55941,7 @@ jxc
 trm
 mNO
 mNO
-odB
+kWh
 trm
 oAN
 jxc
@@ -57947,8 +58043,8 @@ hgU
 qkb
 mNS
 vQc
-mAN
 aXf
+ovv
 qli
 qli
 qli
@@ -58414,7 +58510,7 @@ eAl
 bXp
 yjT
 dAN
-wmf
+xEw
 gGN
 qWI
 utT
@@ -58724,7 +58820,7 @@ lAb
 qgO
 dfD
 ibV
-gZP
+lYv
 xDY
 mBz
 isc
@@ -58733,7 +58829,7 @@ gGN
 qWI
 ofx
 eoV
-iJI
+gwy
 pbI
 ktX
 aaa
@@ -65635,8 +65731,8 @@ qVP
 erk
 erk
 iVy
-nMn
-uuS
+dSu
+frl
 jiS
 jiS
 gRg
@@ -65950,7 +66046,7 @@ erk
 tmo
 ebG
 tDQ
-jPn
+uFw
 wEX
 hBa
 ebG
@@ -66107,8 +66203,8 @@ erk
 erk
 ebG
 ebG
-feD
-mIv
+nMG
+krG
 ebG
 ebG
 erk
@@ -66578,7 +66674,7 @@ erk
 erk
 ebG
 ebG
-feD
+nMG
 ebG
 ebG
 ebG
@@ -67049,7 +67145,7 @@ erk
 erk
 xUZ
 ebG
-feD
+nMG
 ebG
 ebG
 uyM
@@ -67205,8 +67301,8 @@ vAm
 erk
 jiS
 ebG
-xsj
-feD
+bns
+nMG
 jiS
 jiS
 aIS
@@ -67361,10 +67457,10 @@ etJ
 ulq
 erk
 fkx
+iCO
 ilS
-ucc
-feD
-rEc
+nMG
+xsj
 erk
 erk
 erk
@@ -67520,8 +67616,8 @@ erk
 jiS
 jiS
 rfJ
-feD
-eMX
+nMG
+lks
 erk
 qVP
 qVP
@@ -67677,7 +67773,7 @@ erk
 eUJ
 erk
 uBz
-uuS
+frl
 jiS
 erk
 qVP
@@ -75495,7 +75591,7 @@ sCv
 epE
 sCv
 lVh
-urC
+kLN
 sCv
 kWK
 sCv
@@ -75645,29 +75741,29 @@ qVP
 qVP
 kWK
 sCv
-gCH
+jpV
 sCv
 sCv
 sCv
 sCv
 sCv
 sCv
-dUe
+sPk
 sCv
 kWK
 sCv
 sCv
-arS
-uHY
-uHY
-uHY
-uHY
-qhR
-dUe
-dUe
-dUe
-dUe
-pMO
+abd
+weG
+weG
+weG
+weG
+rXD
+sPk
+sPk
+sPk
+sPk
+jOM
 gHW
 tbB
 gHW
@@ -75802,14 +75898,14 @@ qVP
 qVP
 kWK
 goN
-wHU
+xxW
 goN
 goN
 goN
 goN
 goN
 goN
-iwD
+hCA
 goN
 kWK
 mgm
@@ -75819,7 +75915,7 @@ goN
 goN
 goN
 goN
-jpV
+rrK
 goN
 goN
 goN
@@ -75959,14 +76055,14 @@ qVP
 qVP
 kWK
 lDu
-rXD
+aut
 lDu
 nOn
 lDu
 lDu
 nOn
 lDu
-kBf
+ekY
 lDu
 lTv
 lDu
@@ -75976,7 +76072,7 @@ lDu
 lDu
 lDu
 nOn
-rCI
+csx
 lDu
 nOn
 lDu
@@ -76116,14 +76212,14 @@ qVP
 qVP
 uYj
 mPy
-dxV
+qAY
 mPy
 uYj
 mPy
 mPy
 uYj
 mPy
-efO
+vmK
 mPy
 uYj
 mPy
@@ -76133,7 +76229,7 @@ mPy
 mPy
 mPy
 uYj
-kpk
+dQW
 mPy
 uYj
 mPy
@@ -76273,14 +76369,14 @@ rqy
 qVP
 lxi
 mvU
-dWU
+xgR
 wwS
 wwS
 sCv
 sCv
 wwS
 wwS
-qHk
+qMP
 wwS
 wwS
 wwS
@@ -76290,7 +76386,7 @@ wwS
 wwS
 wwS
 wwS
-qhR
+rXD
 sCv
 wwS
 wwS
@@ -76430,24 +76526,24 @@ ozq
 pFl
 mUC
 wnU
-flr
-flr
-flr
-flr
-flr
-flr
-flr
-flr
-flr
-flr
-flr
-flr
-flr
-flr
-flr
-flr
-flr
-flr
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
 bmx
 bmx
 bmx
@@ -76587,14 +76683,14 @@ rqy
 qVP
 lxi
 wUu
-tIj
+nzN
 gvZ
 gvZ
 sCv
 sCv
 gvZ
 gvZ
-cXH
+yeu
 gvZ
 gvZ
 gvZ
@@ -76604,7 +76700,7 @@ gvZ
 gvZ
 gvZ
 gvZ
-qhR
+rXD
 sCv
 gvZ
 gvZ
@@ -76744,14 +76840,14 @@ qVP
 qVP
 uYj
 goN
-iwD
+hCA
 goN
 uYj
 goN
 goN
 uYj
 goN
-wHU
+xxW
 goN
 uYj
 goN
@@ -76761,7 +76857,7 @@ goN
 goN
 goN
 uYj
-jpV
+rrK
 goN
 uYj
 goN
@@ -76901,14 +76997,14 @@ qVP
 qVP
 kWK
 lDu
-kBf
+ekY
 lDu
 asE
 lDu
 lDu
 asE
 lDu
-rXD
+aut
 lDu
 lTv
 lDu
@@ -76918,7 +77014,7 @@ lDu
 lDu
 lDu
 asE
-rCI
+csx
 lDu
 asE
 lDu
@@ -77058,14 +77154,14 @@ qVP
 qVP
 kWK
 mPy
-efO
+vmK
 mPy
 mPy
 mPy
 mPy
 mPy
 mPy
-dxV
+qAY
 mPy
 kWK
 aPO
@@ -77075,7 +77171,7 @@ mPy
 mPy
 mPy
 mPy
-kpk
+dQW
 mPy
 mPy
 mPy
@@ -77215,30 +77311,30 @@ qVP
 qVP
 kWK
 sCv
-dUe
+sPk
 sCv
 sCv
 sCv
 sCv
 sCv
 sCv
-uHY
+weG
 sCv
 kWK
 sCv
-cOG
-dUe
-dUe
-dUe
-dUe
-dUe
-qhR
-uHY
-uHY
-uHY
-uHY
-uHY
-oLh
+uQN
+sPk
+sPk
+sPk
+sPk
+sPk
+rXD
+weG
+weG
+weG
+weG
+weG
+ipC
 sCv
 sCv
 kWK
@@ -77372,14 +77468,14 @@ qVP
 qVP
 kWK
 sCv
-pfQ
+cxd
 sCv
 sCv
 sCv
 sCv
 sCv
 sCv
-nDH
+tAy
 sCv
 kWK
 sCv
@@ -77389,7 +77485,7 @@ cQh
 cQh
 cQh
 sCv
-qhR
+rXD
 sCv
 sCv
 sCv
@@ -77545,18 +77641,18 @@ sCv
 sCv
 dqU
 tCy
-okh
-okh
 cSt
 cSt
-cSt
-cSt
-cSt
-cSt
-cSt
-cSt
+gqh
+gqh
+gqh
+gqh
+gqh
+gqh
+gqh
+gqh
 aqr
-hPy
+ctn
 sCv
 mHX
 ljF
@@ -80059,7 +80155,7 @@ xVM
 xVM
 xVM
 fQc
-urz
+naF
 pMt
 gRy
 rwp
@@ -80497,10 +80593,10 @@ anE
 nOX
 ijC
 rwR
-aJv
+azW
 hbH
 fXy
-wUd
+hVO
 iYH
 iYH
 iYH
@@ -80824,7 +80920,7 @@ mwV
 hfO
 mwV
 mwV
-lTz
+aiW
 mwV
 mwV
 hfO
@@ -80832,7 +80928,7 @@ mwV
 eDu
 mwV
 mwV
-eTi
+lTz
 qwb
 alr
 jJc
@@ -81295,7 +81391,7 @@ wbh
 sFi
 dnX
 sNO
-ncO
+qHk
 sNO
 dTJ
 sFi
@@ -81438,7 +81534,7 @@ qVP
 anE
 gRv
 gRv
-xwJ
+cUw
 sxL
 cYy
 anE
@@ -81452,7 +81548,7 @@ nFb
 sFi
 hFa
 sNO
-alq
+guQ
 sNO
 sWE
 sFi
@@ -81595,7 +81691,7 @@ qVP
 anE
 sxe
 nAx
-xwJ
+cUw
 vqU
 bro
 anE
@@ -81609,7 +81705,7 @@ foz
 sFi
 ykX
 sNO
-alq
+guQ
 sNO
 xsV
 sFi
@@ -81752,7 +81848,7 @@ qVP
 anE
 fDg
 mbe
-cUw
+qhR
 wSD
 aqS
 anE
@@ -81765,8 +81861,8 @@ veo
 veo
 sFi
 nAH
-wtM
-wNW
+ncO
+alq
 sNO
 dIR
 sFi
@@ -81909,7 +82005,7 @@ qVP
 anE
 hTF
 tXB
-xwJ
+cUw
 vqU
 oJf
 anE
@@ -81923,7 +82019,7 @@ xyR
 sFi
 hiA
 sNO
-alq
+guQ
 sNO
 fpd
 sFi
@@ -82237,7 +82333,7 @@ vxt
 sFi
 xqH
 sNO
-ncO
+qHk
 sNO
 jhD
 sFi
@@ -82587,7 +82683,7 @@ bSi
 bat
 bat
 bat
-hwQ
+trK
 uSq
 qVP
 kjv
@@ -83009,10 +83105,10 @@ anE
 nOX
 ijC
 nHL
-aJv
+azW
 hbH
 dVP
-mou
+qgP
 jKk
 jKk
 jKk
@@ -83520,7 +83616,7 @@ tyr
 dmW
 hEO
 mui
-aLT
+rNT
 vHE
 eEt
 qYZ
@@ -83972,7 +84068,7 @@ fnR
 sMY
 tQS
 hnk
-bqd
+eus
 msD
 ayh
 npi
@@ -83982,7 +84078,7 @@ bYo
 kBk
 ruP
 bwu
-gBa
+hcd
 jaQ
 nAc
 wVk
@@ -84129,7 +84225,7 @@ fnR
 jfz
 hnk
 tQS
-woq
+bqd
 lqv
 rCd
 npi
@@ -84558,11 +84654,11 @@ qVP
 qVP
 wuy
 wuy
-chP
-chP
-chP
-chP
-chP
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
 wuy
 wuy
 wuy
@@ -84714,24 +84810,24 @@ wuy
 wuy
 wuy
 wuy
-chP
-chP
-chP
-chP
-chP
-chP
-chP
-chP
-chP
-chP
-chP
-chP
-chP
-chP
-chP
-chP
-chP
-chP
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
 wuy
 wuy
 vRZ
@@ -84774,7 +84870,7 @@ mwp
 yfI
 cZh
 uEm
-xRk
+nVW
 xfD
 vky
 dAe
@@ -84786,7 +84882,7 @@ vky
 vky
 vky
 vky
-hyt
+nMY
 vky
 tCw
 aQM
@@ -84867,29 +84963,29 @@ qVP
 qVP
 qVP
 wuy
-chP
-chP
-nOQ
-nOQ
-nOQ
-nOQ
-nOQ
-nOQ
-chP
-chP
-chP
-chP
-chP
-chP
-chP
+xwJ
+xwJ
+ewa
+ewa
+ewa
+ewa
+ewa
+ewa
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
 qnp
-nOQ
-nOQ
-nOQ
-nOQ
-nOQ
-chP
-chP
+ewa
+ewa
+ewa
+ewa
+ewa
+xwJ
+xwJ
 wuy
 vRZ
 bzI
@@ -84930,8 +85026,8 @@ elo
 mwp
 tTg
 blQ
-hDf
-hDf
+xRk
+xRk
 mwp
 uej
 bNV
@@ -85024,29 +85120,29 @@ qVP
 qVP
 qVP
 wuy
-chP
-nOQ
+xwJ
+ewa
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-chP
-chP
-chP
+xwJ
+xwJ
+xwJ
 dsu
-chP
-chP
-chP
+xwJ
+xwJ
+xwJ
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-nOQ
-chP
+ewa
+xwJ
 wuy
 vRZ
 uho
@@ -85181,29 +85277,29 @@ qVP
 qVP
 qVP
 wuy
-chP
-nOQ
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-chP
-chP
-chP
+xwJ
+ewa
+swY
+swY
+swY
+swY
+swY
+swY
+xwJ
+xwJ
+xwJ
 nGf
-chP
-chP
-chP
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-nOQ
-chP
+xwJ
+xwJ
+xwJ
+swY
+swY
+swY
+swY
+swY
+swY
+ewa
+xwJ
 wuy
 vRZ
 ham
@@ -85251,10 +85347,10 @@ qyr
 qyr
 qyr
 bHR
-hph
-fWl
+xfk
+aKG
 tWq
-ltp
+uuS
 cVO
 weY
 qyr
@@ -85338,29 +85434,29 @@ qVP
 qVP
 qVP
 wuy
-chP
-nOQ
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-gbS
-gbS
-gbS
+xwJ
+ewa
+swY
+swY
+swY
+swY
+swY
+swY
+sCc
+sCc
+sCc
 dsu
-gbS
-gbS
-gbS
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-nOQ
-chP
+sCc
+sCc
+sCc
+swY
+swY
+swY
+swY
+swY
+swY
+ewa
+xwJ
 wuy
 vRZ
 vRZ
@@ -85495,29 +85591,29 @@ qVP
 qVP
 qVP
 wuy
-chP
-chP
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-chP
-chP
-chP
+xwJ
+xwJ
+swY
+swY
+swY
+swY
+swY
+swY
+xwJ
+xwJ
+xwJ
 nGf
-chP
-chP
-chP
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-chP
-chP
+xwJ
+xwJ
+xwJ
+swY
+swY
+swY
+swY
+swY
+swY
+xwJ
+xwJ
 wuy
 qVP
 qVP
@@ -85560,10 +85656,10 @@ bJz
 wqD
 bJz
 bJz
-kBg
 oqy
-oqy
-lMs
+ppa
+ppa
+cUc
 bHR
 mWE
 jYt
@@ -85573,7 +85669,7 @@ qyr
 qyr
 qyr
 tfu
-fwp
+tBK
 igw
 fpu
 fpu
@@ -85652,29 +85748,29 @@ qVP
 qVP
 qVP
 wuy
-chP
-nOQ
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-chP
-chP
-chP
+xwJ
+ewa
+swY
+swY
+swY
+swY
+swY
+swY
+xwJ
+xwJ
+xwJ
 nGf
-chP
-chP
-chP
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-nOQ
-chP
+xwJ
+xwJ
+xwJ
+swY
+swY
+swY
+swY
+swY
+swY
+ewa
+xwJ
 wuy
 qVP
 qVP
@@ -85717,15 +85813,15 @@ qUM
 qUM
 qUM
 qUM
-mJG
+kVf
 uSt
 kVO
-kVf
+cSQ
 sXZ
 bHX
-fWl
+aKG
 tWq
-ltp
+uuS
 dHZ
 weY
 qyr
@@ -85809,29 +85905,29 @@ qVP
 qVP
 qVP
 wuy
-chP
-nOQ
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-gbS
-gbS
-gbS
+xwJ
+ewa
+swY
+swY
+swY
+swY
+swY
+swY
+sCc
+sCc
+sCc
 dsu
-gbS
-gbS
-gbS
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-nOQ
-gbS
+sCc
+sCc
+sCc
+swY
+swY
+swY
+swY
+swY
+swY
+ewa
+sCc
 wuy
 qVP
 qVP
@@ -85966,28 +86062,28 @@ qVP
 qVP
 qVP
 wuy
-chP
-nOQ
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-chP
-chP
-chP
+xwJ
+ewa
+swY
+swY
+swY
+swY
+swY
+swY
+xwJ
+xwJ
+xwJ
 nGf
-chP
-chP
-chP
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-nOQ
+xwJ
+xwJ
+xwJ
+swY
+swY
+swY
+swY
+swY
+swY
+ewa
 dsu
 wuy
 qVP
@@ -86027,7 +86123,7 @@ rcl
 wUC
 aTw
 crJ
-lxT
+eTQ
 svE
 crJ
 crJ
@@ -86044,7 +86140,7 @@ qyr
 qyr
 qyr
 uck
-fOb
+kCr
 xIM
 pfC
 pXF
@@ -86123,29 +86219,29 @@ qVP
 qVP
 qVP
 wuy
-chP
-chP
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-chP
-chP
-chP
+xwJ
+xwJ
+swY
+swY
+swY
+swY
+swY
+swY
+xwJ
+xwJ
+xwJ
 nGf
-chP
-chP
-chP
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-chP
-gbS
+xwJ
+xwJ
+xwJ
+swY
+swY
+swY
+swY
+swY
+swY
+xwJ
+sCc
 wuy
 qVP
 qVP
@@ -86188,15 +86284,15 @@ veP
 esC
 tdg
 dAi
-lxT
+eTQ
 gPB
 qbh
 qbh
 bHR
-fwp
-fWl
+tBK
+aKG
 tWq
-ltp
+uuS
 aTa
 weY
 qyr
@@ -86280,29 +86376,29 @@ qVP
 qVP
 qVP
 wuy
-chP
-abd
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-gbS
-gbS
-gbS
+xwJ
+pNt
+swY
+swY
+swY
+swY
+swY
+swY
+sCc
+sCc
+sCc
 dsu
-gbS
-gbS
-gbS
-rQA
-rQA
-rQA
-rQA
-rQA
-rQA
-chP
-gbS
+sCc
+sCc
+sCc
+swY
+swY
+swY
+swY
+swY
+swY
+xwJ
+sCc
 wuy
 qVP
 kZJ
@@ -86350,7 +86446,7 @@ vky
 vky
 vky
 vky
-oDC
+kPc
 lQE
 aII
 iee
@@ -86437,29 +86533,29 @@ qVP
 qVP
 qVP
 wuy
-chP
-abd
+xwJ
+pNt
+jhs
 jeU
-qMP
-mCd
-qMP
-mCd
+qly
 jeU
-chP
-chP
-chP
+qly
+jhs
+xwJ
+xwJ
+xwJ
 nGf
-chP
-chP
-chP
+xwJ
+xwJ
+xwJ
+jhs
 jeU
-qMP
-mCd
-qMP
-mCd
+qly
 jeU
-gbS
-gbS
+qly
+jhs
+sCc
+sCc
 wuy
 qVP
 kZJ
@@ -86494,7 +86590,7 @@ thc
 pJb
 pJb
 pJb
-rep
+svl
 mpA
 wUC
 crJ
@@ -86516,11 +86612,11 @@ qyr
 qyr
 uck
 odO
-oHX
-oHX
-oHX
-oHX
-oHX
+hDf
+hDf
+hDf
+hDf
+hDf
 cah
 ioB
 nPD
@@ -86597,10 +86693,10 @@ wuy
 wuy
 qQP
 lhT
-eHR
-eHR
-eHR
-eHR
+uyg
+uyg
+uyg
+uyg
 vTc
 qQP
 qQP
@@ -86610,10 +86706,10 @@ qQP
 qQP
 qQP
 pXJ
-jdI
-jdI
-jdI
-jdI
+iCg
+iCg
+iCg
+iCg
 rgW
 qQP
 wuy
@@ -86664,10 +86760,10 @@ qyr
 qyr
 qyr
 bHR
-fwp
-fWl
+tBK
+aKG
 tWq
-ltp
+uuS
 fwd
 weY
 qyr
@@ -86754,7 +86850,7 @@ qVP
 qVP
 qQP
 hBo
-weG
+gXh
 aIL
 aIL
 aIL
@@ -86767,10 +86863,10 @@ fnm
 geM
 bwR
 gFk
-weG
 gXh
-weG
-weG
+diA
+gXh
+gXh
 nJu
 qQP
 qVP
@@ -86928,7 +87024,7 @@ isV
 tXh
 uzD
 bAy
-rjT
+mer
 ogk
 qVP
 qVP
@@ -87085,7 +87181,7 @@ nzy
 sjI
 bIh
 lyZ
-iBT
+wpg
 rUa
 qVP
 qVP
@@ -87104,7 +87200,7 @@ dyb
 aUy
 vQq
 riy
-inN
+nhW
 ayu
 dUo
 bPG
@@ -87123,7 +87219,7 @@ hKc
 xZb
 wce
 fPN
-rDy
+fFe
 wce
 bbh
 hTw
@@ -87243,7 +87339,7 @@ eIK
 kit
 edO
 hCO
-pmS
+dUe
 qVP
 qVP
 qVP
@@ -87293,7 +87389,7 @@ nGw
 qyr
 nDq
 xLA
-oHX
+hDf
 ejX
 mfG
 cPn
@@ -87303,7 +87399,7 @@ mfG
 pqx
 mfG
 mfG
-uCr
+wrl
 wmg
 ust
 qyr
@@ -87400,7 +87496,7 @@ jiK
 iMZ
 blO
 cTo
-pmS
+dUe
 qVP
 qVP
 qVP
@@ -87460,7 +87556,7 @@ bNV
 vrG
 bNV
 bNV
-uSr
+oau
 bNV
 bNV
 qyr
@@ -87555,7 +87651,7 @@ qMD
 gGE
 sVe
 yim
-gqh
+hpN
 dAF
 dOf
 qVP
@@ -87931,7 +88027,7 @@ qVP
 qVP
 wCo
 gvH
-bul
+bFa
 olT
 jdO
 wCo
@@ -88088,7 +88184,7 @@ dTg
 dTg
 dTg
 cmX
-iiX
+bul
 isb
 tsI
 wCo
@@ -88216,7 +88312,7 @@ dUo
 dUo
 dUo
 vVQ
-hIo
+pWF
 iGp
 dUo
 onl
@@ -88237,7 +88333,7 @@ lJw
 cFv
 syO
 pgS
-cOq
+xYm
 joj
 woI
 eZS
@@ -88394,7 +88490,7 @@ dmE
 cFv
 crs
 fLg
-xYm
+mou
 dYv
 woI
 qZi
@@ -88668,9 +88764,9 @@ uxc
 wCJ
 vVb
 vVb
-hjz
-hjz
-hjz
+kQW
+kQW
+kQW
 mUn
 mUn
 mUn
@@ -88803,11 +88899,11 @@ xth
 xth
 xth
 xth
-uVg
-azW
-azW
-gzn
+lfb
 eIL
+eIL
+lki
+imS
 xth
 fdA
 uOG
@@ -88823,12 +88919,12 @@ aNP
 aAq
 aGd
 aGd
-trK
+tQQ
 kPt
 oyt
 egd
 kNZ
-khU
+wdC
 mUn
 mUn
 mUn
@@ -88963,7 +89059,7 @@ cNx
 aJZ
 llM
 gMP
-hff
+tpi
 tEB
 xth
 rRW
@@ -88975,17 +89071,17 @@ xdT
 sun
 ajy
 gWu
-dJx
+dEQ
 ghX
 ojj
 qAi
 vVb
-tQQ
+gXv
 pWI
 bYx
 bYx
 bYx
-guQ
+aBf
 mUn
 dpz
 mUn
@@ -89009,22 +89105,22 @@ uME
 nLC
 qyR
 lzq
-ldv
+vvb
 cBm
 xki
-tcX
-tcX
-tcX
-rcj
+flr
+flr
+flr
+aur
 cOX
-tcX
-tcX
+flr
+flr
 tcQ
 dLA
+flr
 tcX
-rpe
-tcX
-tcX
+flr
+flr
 vwt
 tup
 vmf
@@ -89120,7 +89216,7 @@ bUh
 oRx
 tYl
 hpF
-bkE
+fZP
 iVk
 xth
 nCJ
@@ -89132,7 +89228,7 @@ lSF
 gOY
 mHD
 nPN
-uXf
+erO
 icl
 ojj
 tit
@@ -89142,7 +89238,7 @@ iqB
 gvY
 pkg
 cqi
-guQ
+aBf
 jDd
 dxU
 tsG
@@ -89299,7 +89395,7 @@ smA
 gvY
 mUn
 mUn
-guQ
+aBf
 lch
 gvY
 gvY
@@ -89446,7 +89542,7 @@ cLU
 cLU
 ojj
 hFY
-dJx
+dEQ
 dJK
 ojj
 gFX
@@ -89455,8 +89551,8 @@ gFX
 gFX
 gFX
 kih
-tmU
-aBf
+lTn
+jBy
 fsT
 gvY
 qVP
@@ -89472,7 +89568,7 @@ pLY
 ccd
 jML
 cwa
-mAD
+jdI
 jlM
 uwQ
 gqi
@@ -89511,7 +89607,7 @@ qtY
 eet
 vEb
 val
-jDZ
+qSt
 jRe
 bfm
 xKp
@@ -89603,7 +89699,7 @@ fpO
 gsG
 tuG
 xbE
-dJx
+dEQ
 eFo
 iNX
 pIx
@@ -89745,14 +89841,14 @@ kDP
 kDP
 eCA
 eCA
-yhZ
+shj
 eCA
 eCA
 pAx
 gbr
 pSi
 ukz
-rxm
+wtM
 tfP
 hPr
 jgb
@@ -89760,7 +89856,7 @@ fBA
 tfj
 eFj
 mcE
-dEQ
+pmS
 avK
 uiB
 pIx
@@ -89969,18 +90065,18 @@ xCy
 wbK
 oEA
 vmh
-tcX
+flr
 qcz
 nOt
-tcX
-aur
-tcX
-tcX
-tcX
-tcX
-tcX
-tcX
-tcX
+flr
+mJq
+flr
+flr
+flr
+flr
+flr
+flr
+flr
 kCT
 pWM
 cON
@@ -90051,7 +90147,7 @@ gsG
 jIe
 kxC
 ccb
-xEU
+aPX
 ccb
 rib
 hmJ
@@ -90074,7 +90170,7 @@ djs
 djs
 ojj
 hFY
-dJx
+dEQ
 dJK
 ojj
 pIx
@@ -90207,9 +90303,9 @@ qVP
 gsG
 gsG
 gsG
-oTJ
+sFy
 adK
-sPk
+yhZ
 gsG
 gsG
 pMH
@@ -90357,7 +90453,7 @@ rqy
 rqy
 rqy
 rqy
-uGU
+gwR
 rqy
 qVP
 qVP
@@ -90376,7 +90472,7 @@ gsG
 gsG
 oBx
 ccb
-aPX
+vmF
 ccb
 ubN
 xnC
@@ -90514,7 +90610,7 @@ qVP
 rqy
 eSR
 rqy
-wrl
+rdf
 jnM
 qVP
 qVP
@@ -90670,7 +90766,7 @@ qVP
 rqy
 rqy
 tuc
-afp
+dMW
 rqy
 srt
 qVP
@@ -90825,8 +90921,8 @@ rqy
 rqy
 rqy
 rqy
-tvi
-yci
+afp
+rTT
 rqy
 wyu
 qVP
@@ -90859,7 +90955,7 @@ upl
 upb
 mKE
 jqC
-dJx
+dEQ
 jzk
 uiB
 pIx
@@ -90979,9 +91075,9 @@ qVP
 rqy
 rqy
 rqy
-kHh
-ocO
-gKK
+tkH
+pfG
+jeQ
 rqy
 rqy
 rqy
@@ -91016,7 +91112,7 @@ bmS
 upb
 pIG
 kNf
-imS
+nyF
 lwr
 hPz
 xwH
@@ -91135,7 +91231,7 @@ rqy
 rqy
 rqy
 rqy
-afp
+dMW
 rqy
 qVP
 rqy
@@ -91291,7 +91387,7 @@ rqy
 rqy
 rqy
 rqy
-afp
+dMW
 rqy
 qVP
 qVP
@@ -91325,10 +91421,10 @@ cMl
 oaV
 vBz
 pee
-bAk
+ugP
 jgI
 cAY
-ugs
+wdQ
 oTl
 sRF
 sRF
@@ -91447,7 +91543,7 @@ qVP
 rqy
 rqy
 tuc
-oDD
+stX
 qVP
 qVP
 qVP
@@ -91481,11 +91577,11 @@ vPr
 ebH
 fjl
 hfM
-oQo
-sWD
+jTU
+qPX
 tKf
 jYX
-dzP
+nzU
 qoR
 sRF
 keh
@@ -91604,7 +91700,7 @@ qVP
 rqy
 rqy
 tuc
-uGU
+gwR
 qVP
 qVP
 qVP
@@ -91653,7 +91749,7 @@ wDy
 rkU
 vQi
 rkU
-suG
+jtJ
 pZv
 sxj
 wDV
@@ -91761,7 +91857,7 @@ qVP
 rqy
 rqy
 tuc
-iol
+rvn
 qVP
 qVP
 qVP
@@ -91791,7 +91887,7 @@ mpT
 eGf
 gkJ
 jZb
-gLi
+lOe
 kEE
 ebH
 kRQ
@@ -91810,7 +91906,7 @@ fDt
 rbK
 rbK
 rbK
-mtB
+fwp
 pZv
 sxj
 eLJ
@@ -91919,7 +92015,7 @@ qVP
 qVP
 rqy
 rqy
-rOt
+mUA
 qVP
 qVP
 qVP
@@ -91948,8 +92044,8 @@ anZ
 eGf
 eAg
 sxb
-cyz
-nEm
+qNg
+lEg
 gkJ
 eAg
 feG
@@ -92076,7 +92172,7 @@ qVP
 qVP
 qVP
 rqy
-mzA
+nOQ
 rqy
 rqy
 rqy
@@ -92105,8 +92201,8 @@ aRD
 exz
 hFC
 gQv
+fYC
 tfU
-lqp
 ohb
 ebH
 mbT
@@ -92234,8 +92330,8 @@ rqy
 qVP
 qVP
 rqy
-rOt
-rqy
+iJI
+ahe
 rqy
 rqy
 rHU
@@ -92391,10 +92487,10 @@ rqy
 rqy
 qVP
 qVP
-xKg
-ruE
-ruE
-ieM
+rqy
+rqy
+mUA
+kyJ
 rHU
 rqy
 tuc
@@ -92550,7 +92646,7 @@ rqy
 qVP
 qVP
 rqy
-rqy
+cNc
 xKg
 ruE
 ieM
@@ -92710,7 +92806,7 @@ qVP
 qVP
 rqy
 rHU
-uGU
+gwR
 rqy
 rqy
 rqy
@@ -92867,7 +92963,7 @@ qVP
 qVP
 qVP
 rHU
-uGU
+gwR
 rqy
 rqy
 rqy
@@ -93024,7 +93120,7 @@ qVP
 qVP
 iHy
 ruE
-cPN
+pmj
 rqy
 rqy
 rqy
@@ -93066,7 +93162,7 @@ rkX
 bkg
 ieE
 ijk
-sCc
+tUq
 rkU
 sxj
 puN
@@ -93179,7 +93275,7 @@ rqy
 rqy
 rqy
 rqy
-uGU
+gwR
 rEA
 quR
 rEA
@@ -93208,7 +93304,7 @@ naE
 mCH
 dvF
 hHs
-pfG
+dRP
 dwU
 blf
 blf
@@ -93217,7 +93313,7 @@ woN
 bDj
 bnW
 vwd
-tuw
+haR
 eDU
 rkX
 wzw
@@ -93266,7 +93362,7 @@ lxf
 jAQ
 nvn
 iDM
-nkV
+mSK
 rGI
 edX
 all
@@ -93336,9 +93432,9 @@ rqy
 rqy
 rqy
 rqy
-uGU
+gwR
 rek
-yfg
+ebA
 jJJ
 wAN
 sIt
@@ -93375,12 +93471,12 @@ mbT
 jpS
 vwd
 jaR
-haR
+qLk
 eYu
 eYu
 qXg
 cAk
-sCc
+tUq
 bvP
 sxj
 eaH
@@ -93423,7 +93519,7 @@ jhV
 bid
 bUP
 nLV
-dlp
+nkV
 sAH
 edX
 xRl
@@ -93493,12 +93589,12 @@ qVP
 rqy
 rqy
 rqy
-tih
+ocO
 rEA
-oYE
+uGU
 jBo
-afD
-uVx
+oYE
+tLC
 ruE
 ieM
 rqy
@@ -93564,11 +93660,11 @@ dHN
 dHN
 kXb
 sTl
+upx
 bcm
-sKj
-bcm
-bcm
-tkM
+upx
+upx
+aEa
 cMP
 cMP
 mhi
@@ -93650,7 +93746,7 @@ qVP
 rqy
 tuc
 tuc
-uGU
+gwR
 rEA
 aQr
 oXp
@@ -94016,7 +94112,7 @@ yio
 yio
 yio
 yio
-gAY
+hCX
 rDZ
 fEk
 vDP
@@ -94182,7 +94278,7 @@ fVs
 sBp
 soj
 juy
-oEb
+rDI
 iGp
 wZK
 snn
@@ -94631,12 +94727,12 @@ hHi
 hHi
 rTI
 rWq
-kpP
+rMC
 rWq
 fwj
 qIi
-nMG
-nMG
+kJa
+kJa
 cFk
 faY
 qVP
@@ -94943,14 +95039,14 @@ xJv
 hqp
 xTj
 qwA
-juQ
+svi
 xNF
 eBq
 aKq
 faY
 pDD
 wgO
-nMG
+kJa
 pYw
 faY
 fPT
@@ -95100,7 +95196,7 @@ uaC
 hqp
 rSF
 kAv
-iCe
+fdT
 hgV
 rlP
 mHv
@@ -95126,7 +95222,7 @@ kyw
 gNo
 rAl
 uXc
-xLC
+jAG
 fDQ
 riO
 pkp
@@ -95257,7 +95353,7 @@ uaC
 hqp
 xgO
 kAv
-fdT
+dDE
 wcV
 jSw
 rQc
@@ -95269,7 +95365,7 @@ olg
 faY
 otF
 rkU
-pVC
+efO
 rkU
 rkU
 gmN
@@ -95415,9 +95511,9 @@ hqp
 kAg
 pug
 akZ
-vKJ
-vMc
-rkA
+pIq
+gmv
+oJK
 faY
 ktR
 bbF
@@ -95440,7 +95536,7 @@ kxK
 kgC
 iTo
 uXc
-uQx
+nZu
 pcA
 bVG
 qhu
@@ -95597,7 +95693,7 @@ kxK
 lcv
 rAl
 ayx
-uxL
+xLC
 tiS
 dVm
 rIm
@@ -95897,7 +95993,7 @@ iel
 iel
 iel
 iel
-dwN
+gpu
 eCC
 njj
 wYA
@@ -96054,7 +96150,7 @@ odc
 odc
 odc
 odc
-eyJ
+rpe
 tXH
 njj
 ncl
@@ -96244,7 +96340,7 @@ fCw
 fUt
 trT
 aes
-qly
+tZt
 swv
 qUq
 sCq
@@ -96368,7 +96464,7 @@ uxN
 uxN
 uxN
 uxN
-dwN
+gpu
 eCC
 njj
 tNe
@@ -96401,7 +96497,7 @@ swv
 swv
 iUp
 swv
-qly
+tZt
 swv
 tij
 pvL
@@ -96525,7 +96621,7 @@ iJv
 iJv
 iJv
 iJv
-eyJ
+rpe
 aWW
 jfn
 bev
@@ -96558,7 +96654,7 @@ icC
 icC
 itU
 icC
-cPe
+tNh
 swv
 tij
 pvL
@@ -96682,7 +96778,7 @@ iXU
 ivg
 iXU
 ueC
-bNj
+xjG
 hfD
 wHF
 cvC
@@ -96698,11 +96794,11 @@ dZO
 sAo
 sAo
 oZq
-yeQ
+ffw
 rrw
-hfy
+sis
 vtr
-evE
+kEi
 lOB
 cgv
 wEk
@@ -96715,7 +96811,7 @@ xnH
 epg
 ngl
 ngl
-tZt
+ueM
 swv
 tij
 pvL
@@ -96839,7 +96935,7 @@ iel
 iel
 iel
 iel
-dwN
+gpu
 eCC
 jfn
 bev
@@ -96857,7 +96953,7 @@ sAo
 kYq
 cCP
 mBt
-diA
+ckc
 fzw
 xew
 eGW
@@ -96872,7 +96968,7 @@ swv
 swv
 swv
 swv
-qly
+tZt
 swv
 tij
 pvL
@@ -96996,7 +97092,7 @@ odc
 odc
 odc
 odc
-eyJ
+rpe
 aWW
 njj
 tNe
@@ -97029,7 +97125,7 @@ lHv
 swv
 lty
 swv
-qly
+tZt
 swv
 tij
 pvL
@@ -97171,7 +97267,7 @@ sej
 lmF
 aLW
 ayy
-wNp
+mCC
 tVH
 tMP
 vrC
@@ -97186,7 +97282,7 @@ juz
 xNd
 trT
 aes
-qly
+tZt
 swv
 gbi
 oFO
@@ -97310,7 +97406,7 @@ uxN
 uxN
 uxN
 uxN
-dwN
+gpu
 xdQ
 njj
 ncl
@@ -97343,7 +97439,7 @@ swv
 swv
 swv
 swv
-qly
+tZt
 swv
 swv
 swv
@@ -97467,7 +97563,7 @@ iJv
 iJv
 iJv
 iJv
-eyJ
+rpe
 aWW
 njj
 fjW
@@ -97507,7 +97603,7 @@ ngl
 ngl
 ngl
 ngl
-jkF
+ygs
 jpF
 shR
 oQR
@@ -97652,19 +97748,19 @@ lLU
 nyU
 nyU
 nyU
-xKt
-vqq
+gvJ
 qcm
+gcX
 nyU
 eFY
-qly
+tZt
 xFe
 ilB
 evb
 swv
 xFe
 ghq
-wpg
+wiw
 swv
 shR
 lXt
@@ -97777,24 +97873,24 @@ jfn
 iel
 hKR
 cpt
-dSu
+rCI
 qgU
-dSu
-dSu
-vWE
+rCI
+rCI
+fMo
 dtP
 njj
 qwK
-aSt
+gbS
 kyb
 pmL
 vNP
 rsD
 eHS
 cCT
-cKw
-cKw
-qTm
+aJv
+aJv
+ldF
 rKt
 hSX
 lVO
@@ -97814,14 +97910,14 @@ tuB
 peY
 nyU
 swv
-qly
+tZt
 evb
 swv
 xFe
 swv
 xFe
 swv
-qAY
+wxV
 ngl
 qno
 qbt
@@ -97951,34 +98047,34 @@ rKt
 rKt
 rKt
 rKt
-ldF
+aHu
 mNP
 mNP
 rUg
 cml
-fKB
+cMn
 lkQ
 lVO
 nHM
-vAq
+vwz
 xsQ
 jyy
 nyU
 brk
 syb
 pCw
+mdw
 oUk
-wQS
 tmW
 ngl
-eOt
+ldv
 xFe
 swv
 evb
 swv
 evb
 swv
-mmH
+omM
 swv
 shR
 qIY
@@ -98113,12 +98209,12 @@ rKt
 rKt
 sAu
 xYG
-cMn
+dJx
 vkm
 lVO
 kiq
 jjG
-rDI
+uuR
 uTS
 cHJ
 hpz
@@ -98270,12 +98366,12 @@ rKt
 rKt
 rUg
 piI
-cMn
+dJx
 igF
 lVO
 vpw
 sVG
-rDI
+uuR
 sIH
 uLy
 mCX
@@ -98432,9 +98528,9 @@ tXl
 lVO
 dsg
 imT
-rDI
+uuR
 sIH
-uQN
+cjf
 wGC
 fts
 lue
@@ -98589,12 +98685,12 @@ lVO
 lVO
 iaO
 iaO
-rDI
+uuR
 sIH
-swY
+kpP
 sUB
 xMe
-sZZ
+wxT
 rIL
 kLy
 nyU
@@ -98746,7 +98842,7 @@ pzZ
 lVO
 fLK
 xzt
-rDI
+uuR
 sIH
 nyU
 nyU
@@ -98902,7 +98998,7 @@ oqG
 vYd
 sfB
 vvK
-oWK
+lab
 mUd
 hGw
 lLU
@@ -99232,8 +99328,8 @@ iQt
 qBi
 ijm
 txt
-vCR
 jpj
+hvU
 piB
 piB
 txt
@@ -99368,8 +99464,8 @@ jpa
 ney
 mRg
 cxq
-rAb
-wxK
+kYD
+jIw
 xUf
 xOZ
 qpB
@@ -99389,7 +99485,7 @@ hvt
 owQ
 nZZ
 txt
-gwR
+hmT
 sQY
 gYJ
 gYJ
@@ -100309,9 +100405,9 @@ oQX
 hJT
 xkY
 lyW
-nBX
+lOI
 mQm
-bge
+rAb
 sNc
 oje
 bID
@@ -101410,7 +101506,7 @@ xlt
 tAk
 fDi
 ixd
-cHQ
+bWg
 xUf
 cpf
 bLY
@@ -102190,7 +102286,7 @@ xlt
 bum
 uhl
 qYJ
-qXx
+dGD
 xlt
 rcd
 uQt
@@ -102351,8 +102447,8 @@ drM
 xlt
 cxa
 eph
-pep
-pvO
+wxK
+feD
 sxh
 cpf
 gTq
@@ -103921,8 +104017,8 @@ rqy
 rqy
 muO
 rfo
-qLd
-rlW
+nqb
+iqd
 muO
 rqy
 rfo
@@ -104078,7 +104174,7 @@ rqy
 rqy
 rqy
 rfo
-gpu
+chP
 aQP
 rqy
 rqy
@@ -104235,7 +104331,7 @@ rqy
 rqy
 rqy
 rfo
-gpu
+chP
 aQP
 rqy
 rqy
@@ -104392,7 +104488,7 @@ qVP
 rqy
 rqy
 rfo
-gpu
+chP
 aQP
 rqy
 rqy
@@ -104549,7 +104645,7 @@ qVP
 qVP
 rqy
 rfo
-gpu
+chP
 aQP
 rqy
 rqy
@@ -104706,7 +104802,7 @@ qVP
 rqy
 rqy
 rfo
-gpu
+chP
 aQP
 rqy
 rqy
@@ -104863,7 +104959,7 @@ qVP
 rqy
 rqy
 rfo
-gpu
+chP
 aQP
 rqy
 rqy
@@ -105020,7 +105116,7 @@ qVP
 qVP
 rqy
 rfo
-gpu
+chP
 aQP
 bbq
 rqy
@@ -105177,7 +105273,7 @@ qVP
 rqy
 rqy
 rfo
-gpu
+chP
 aQP
 bbq
 rqy
@@ -105334,7 +105430,7 @@ rqy
 jKh
 rqy
 rfo
-gpu
+chP
 aQP
 bbq
 rqy
@@ -105491,7 +105587,7 @@ rqy
 rqy
 rqy
 rfo
-gpu
+chP
 aQP
 rqy
 rqy
@@ -105649,7 +105745,7 @@ rqy
 rqy
 rfo
 xHF
-nwl
+tAZ
 rqy
 rqy
 rqy
@@ -105806,7 +105902,7 @@ rfo
 rfo
 rfo
 bPH
-vwz
+mCd
 rfo
 rfo
 rfo
@@ -105963,7 +106059,7 @@ rfo
 rfo
 rfo
 bPH
-vwz
+mCd
 rfo
 rfo
 rfo
@@ -106119,8 +106215,8 @@ bbq
 rqy
 rqy
 rfo
-bnC
-rlW
+jQZ
+iqd
 rqy
 rqy
 rqy
@@ -106276,7 +106372,7 @@ rqy
 rqy
 rqy
 rfo
-gpu
+chP
 aQP
 rqy
 rqy
@@ -108631,7 +108727,7 @@ xvI
 xvI
 xvI
 xvI
-kis
+iCe
 lxu
 lxu
 lxu
@@ -108788,7 +108884,7 @@ oaR
 oaR
 lxu
 lxu
-aaw
+chN
 lxu
 lxu
 qef
@@ -114281,7 +114377,7 @@ wuy
 kBk
 dlm
 fLk
-leg
+iwD
 uFg
 lse
 lse
@@ -114912,7 +115008,7 @@ wuy
 kBk
 avB
 pOx
-mAh
+kpk
 dRt
 bUr
 noU
@@ -115551,8 +115647,8 @@ tcx
 lMF
 gUT
 cPy
-xRa
-hvU
+aZz
+gYR
 sjv
 uAD
 aRk
@@ -115709,7 +115805,7 @@ lMF
 unu
 thP
 eIj
-ffw
+ixI
 wtN
 hwG
 lSo
@@ -115719,7 +115815,7 @@ hwG
 goF
 tgq
 fzN
-ako
+qfF
 pAc
 bOE
 vvm
@@ -115876,7 +115972,7 @@ pyk
 pvH
 pYv
 aLQ
-qfF
+ulv
 pAc
 bOE
 nRK
@@ -116022,7 +116118,7 @@ dSG
 khV
 lRE
 eqx
-xSa
+bHF
 lGt
 uDQ
 fOy
@@ -116171,7 +116267,7 @@ ong
 ong
 ong
 ong
-idt
+pyb
 fIk
 xpQ
 iOi
@@ -116179,9 +116275,9 @@ qUK
 qUK
 qUK
 rsk
-ewa
+rKO
 dQi
-dZB
+mIw
 kGY
 kZg
 uSd
@@ -116328,7 +116424,7 @@ ong
 ong
 ong
 ong
-svP
+tXm
 bqk
 sRj
 hQq
@@ -116336,9 +116432,9 @@ hQq
 sRj
 gva
 dhn
-rKO
-pty
-rVD
+tGC
+stc
+bKt
 kGY
 kZg
 uSd
@@ -116347,8 +116443,8 @@ pyk
 wuy
 wuy
 jfa
-vVU
-hTT
+xkv
+vPL
 wuT
 wuT
 mkD
@@ -116485,9 +116581,9 @@ ong
 ong
 ong
 ong
-tiD
+nyo
 vTH
-ygs
+tIj
 qrX
 nDr
 sRj
@@ -116495,7 +116591,7 @@ gva
 aqO
 xpF
 dQi
-vmK
+fyB
 kGY
 kZg
 uSd
@@ -116642,9 +116738,9 @@ ong
 ong
 ong
 ong
-kzg
+rlW
 eHr
-rTT
+nBX
 dzm
 xtQ
 sRj
@@ -116799,9 +116895,9 @@ ozh
 ozh
 ozh
 ozh
-nyo
+aUO
 dUU
-rTT
+nBX
 bPD
 bPD
 sRj
@@ -116966,7 +117062,7 @@ mYe
 gva
 gEz
 dQi
-rFO
+plx
 kGY
 kZg
 uSd
@@ -117113,9 +117209,9 @@ wZN
 wZN
 wZN
 wZN
-idt
+pyb
 bgk
-rTT
+nBX
 hQq
 hQq
 sRj
@@ -117270,15 +117366,15 @@ ong
 ong
 ong
 ong
-svP
+tXm
 vCL
-rTT
+nBX
 nOI
 awd
 sRj
 gva
 dQi
-xSa
+bHF
 dQi
 uDQ
 iIN
@@ -117427,27 +117523,27 @@ ong
 ong
 ong
 ong
-tiD
+nyo
 vTH
-tNh
+eSQ
 xmx
 iRu
 sRj
 gva
 dQi
-xSa
+bHF
 dQi
-dZB
+mIw
 kGY
 kZg
 aTj
 rXE
 pyk
 sEi
-grS
-xQj
-grS
-wVE
+iol
+idt
+iol
+vVU
 xQj
 xQj
 qgZ
@@ -117584,17 +117680,17 @@ ong
 ong
 ong
 ong
-kzg
+rlW
 xYs
-rTT
+nBX
 bPD
 bPD
 sRj
 gva
 dwy
-bHF
-pty
-hHG
+iri
+stc
+dZB
 kGY
 kZg
 aTj
@@ -117741,17 +117837,17 @@ ong
 ong
 ong
 ong
-nyo
+aUO
 bfG
-xIi
+xZo
 bbp
+cKw
 qjg
-mxJ
-qjg
+cKw
 ocJ
-elN
+cAL
 dQi
-vmK
+fyB
 kGY
 kZg
 aTj
@@ -117906,7 +118002,7 @@ pyY
 eON
 rui
 kTe
-xSa
+bHF
 lHc
 uDQ
 kGY
@@ -117918,7 +118014,7 @@ kRE
 bmz
 bmz
 bmz
-cLC
+rQA
 jbI
 jbI
 jbI
@@ -118081,7 +118177,7 @@ mpQ
 mpQ
 eJO
 mpQ
-eYM
+ijN
 bCA
 qhL
 qhL
@@ -118237,8 +118333,8 @@ pyh
 ctS
 ctS
 pyh
-nID
-qtJ
+lyc
+eYM
 jfa
 czR
 ggl
@@ -118395,7 +118491,7 @@ qGr
 qQy
 pyh
 mpQ
-eYM
+ijN
 mpQ
 mpQ
 mpQ
@@ -118546,16 +118642,16 @@ aDi
 jlE
 pyh
 hyP
-pmQ
+hFT
 hch
 hch
 hQX
 pyh
 mpQ
-mKV
+kis
 xbH
+pyd
 eWW
-iXR
 uUC
 mpQ
 jfa
@@ -118684,7 +118780,7 @@ bRD
 aFR
 tHh
 ydj
-dSI
+bEp
 bbC
 uDQ
 mos
@@ -118866,7 +118962,7 @@ sxJ
 jXz
 pyh
 mpQ
-uyg
+fUQ
 cPJ
 tdy
 hFz
@@ -119026,7 +119122,7 @@ jjd
 xpH
 cPJ
 ncG
-jyb
+iLi
 pzN
 cPJ
 wuy
@@ -119183,7 +119279,7 @@ mpQ
 xpH
 cPJ
 vsE
-iLi
+pur
 bmZ
 cPJ
 wuy

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -8596,6 +8596,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/aft)
 "eqk" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Sets SM cooling room turfs to unsimulated
- Changes SM waste filter to filter into waste loop
- Remaps majority of non-hallway rooms with manual cables
- Moves some 'incoming' atmos pipes around in atmos so they aren't in CE's room
- Switches waste loop thermo-machine to on and at 50% power due to SM filter going into waste loop
- Tweaks cryo pipes to include a filter

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
