### PR TITLE
Manual cabling + tweaks + conflict resolution

### DIFF
--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -4,7 +4,6 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "aaf" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "aak" = (
@@ -19,10 +18,12 @@
 	req_access_txt = "22;27";
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
 "aaE" = (
@@ -31,12 +32,9 @@
 /turf/open/floor/engine/plasma,
 /area/station/engineering/atmos)
 "abd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "abi" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment{
@@ -67,8 +65,10 @@
 /area/station/engineering/engine_smes)
 "abY" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningdock/oresilo)
 "acb" = (
@@ -158,16 +158,24 @@
 /area/station/engineering/atmos)
 "adK" = (
 /obj/machinery/door/firedoor,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Engineering Storage";
 	req_access_txt = "10"
 	},
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "aes" = (
@@ -177,12 +185,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "aeI" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -200,7 +210,9 @@
 	},
 /area/station/hallway/primary/central)
 "afp" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "afX" = (
@@ -229,6 +241,12 @@
 	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
+"ahe" = (
+/obj/structure/cable/yellow{
+	icon_state = "33"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "ahf" = (
 /obj/machinery/light/small/directional/north,
 /obj/effect/turf_decal/siding/white{
@@ -247,11 +265,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "ahD" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "ahQ" = (
@@ -267,9 +287,18 @@
 /area/station/security/checkpoint/customs)
 "aiw" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
+"aiW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/maint_right,
+/area/station/commons/dorms/barracks/male)
 "aiX" = (
 /obj/structure/railing{
 	dir = 4
@@ -402,9 +431,17 @@
 /turf/open/floor/engine,
 /area/station/science/misc_lab/range)
 "alq" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/rack,
 /obj/effect/spawner/random/clothing/costume,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "alr" = (
@@ -434,6 +471,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/commons/dorms/barracks/male)
 "ami" = (
@@ -444,17 +484,24 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "amN" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -600,7 +647,9 @@
 /area/station/science/lab)
 "aqr" = (
 /obj/machinery/door/airlock/mining,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "aqD" = (
@@ -617,7 +666,9 @@
 "aqS" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
 "arg" = (
@@ -662,14 +713,18 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "asn" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/engine,
 /area/station/science/misc_lab/range)
 "asw" = (
@@ -747,19 +802,27 @@
 /area/station/commons/dorms/barracks/male)
 "aur" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"aut" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo/warehouse)
 "auw" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "auB" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "auT" = (
@@ -887,7 +950,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
@@ -958,15 +1023,20 @@
 "azW" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "aAj" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/catwalk_floor/iron_white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "aAn" = (
 /obj/machinery/disposal/bin,
@@ -982,9 +1052,11 @@
 	},
 /obj/effect/landmark/navigate_destination/tcomms,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
 "aAU" = (
@@ -1005,12 +1077,17 @@
 	},
 /area/station/hallway/primary/port)
 "aBf" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "aBg" = (
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/telephone/service,
+/obj/structure/cable/white{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
 "aBD" = (
@@ -1030,10 +1107,12 @@
 /area/station/commons/storage/primary)
 "aCy" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "aCE" = (
@@ -1108,20 +1187,32 @@
 /obj/effect/spawner/random/clothing/backpack,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"aEa" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "aEb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/primary/central/aft)
 "aEu" = (
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aEw" = (
@@ -1135,11 +1226,13 @@
 	name = "Atmospherics Monitoring";
 	req_access_txt = "24"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "aEX" = (
@@ -1154,18 +1247,25 @@
 /obj/structure/railing{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/starboard/upper)
 "aGd" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
 "aGC" = (
 /obj/item/kirbyplants{
 	icon_state = "plant-10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
@@ -1176,16 +1276,27 @@
 	},
 /area/station/hallway/primary/central/aft)
 "aGS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+/obj/machinery/airalarm/directional/west,
+/obj/machinery/atmospherics/components/trinary/filter/atmos/flipped/o2{
 	dir = 1
 	},
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "aGY" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse/upper)
+"aHu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/lobby)
 "aHO" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
@@ -1260,11 +1371,11 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
 "aJv" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/iron/showroomfloor,
-/area/station/commons/dorms/cryo)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/lobby)
 "aJH" = (
 /obj/structure/chair{
 	pixel_y = -2
@@ -1300,6 +1411,14 @@
 	dir = 1
 	},
 /area/station/hallway/secondary/exit)
+"aKG" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
+	},
+/area/station/security/brig)
 "aLc" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/random/maintenance/two,
@@ -1369,9 +1488,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "aNG" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aNI" = (
@@ -1380,9 +1501,11 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "aNP" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "aOh" = (
@@ -1411,12 +1534,14 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "aOS" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "aPd" = (
@@ -1441,9 +1566,11 @@
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse)
 "aPX" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "aQd" = (
@@ -1456,7 +1583,9 @@
 /area/station/engineering/atmos)
 "aQr" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "aQw" = (
@@ -1475,13 +1604,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/commons/dorms/barracks/female)
 "aQM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "aQP" = (
@@ -1492,7 +1626,9 @@
 "aRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
 "aRn" = (
@@ -1519,6 +1655,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/trunk{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
@@ -1556,9 +1695,11 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "aSJ" = (
@@ -1599,9 +1740,11 @@
 /area/station/security/brig)
 "aSR" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "aSW" = (
@@ -1616,18 +1759,17 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/commons/dorms/laundry)
 "aTa" = (
 /obj/machinery/flasher{
 	id = "Cell 2";
 	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
@@ -1636,12 +1778,14 @@
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "aTj" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -1691,13 +1835,18 @@
 	dir = 8
 	},
 /obj/item/kirbyplants/random,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/medical)
 "aUq" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "aUt" = (
@@ -1711,6 +1860,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
+"aUO" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command blast"
+	},
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "aVc" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/effect/spawner/random/vending/colavend,
@@ -1754,11 +1914,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "aWM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "aWO" = (
@@ -1769,7 +1931,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -1777,7 +1938,9 @@
 "aXf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "aXp" = (
@@ -1832,7 +1995,6 @@
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "aYU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -1842,7 +2004,6 @@
 	dir = 8
 	},
 /obj/machinery/fax_machine,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/machinery/power/data_terminal,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
@@ -1860,10 +2021,17 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
+"aZz" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/hardwood,
+/area/station/command/heads_quarters/captain)
 "aZX" = (
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/light/small/directional/west,
@@ -1878,8 +2046,10 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "bat" = (
@@ -1907,7 +2077,9 @@
 /area/station/security/brig)
 "bbp" = (
 /obj/machinery/light/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "bbq" = (
@@ -1929,12 +2101,14 @@
 	},
 /area/station/hallway/primary/fore)
 "bbC" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "bbF" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/window/brigdoor/left/directional/west{
 	req_access_txt = "63"
 	},
@@ -1943,8 +2117,10 @@
 "bbK" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "bbS" = (
@@ -1968,8 +2144,13 @@
 /area/station/security/brig)
 "bcm" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "bct" = (
@@ -2042,9 +2223,11 @@
 /area/station/science/research)
 "beN" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
@@ -2095,6 +2278,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "3"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/misc/asteroid,
 /area/station/solars/port/fore)
 "bfG" = (
@@ -2127,8 +2313,10 @@
 	pixel_x = 4
 	},
 /obj/machinery/telephone/engineering,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "bgk" = (
@@ -2139,6 +2327,8 @@
 "bgx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "bgI" = (
@@ -2153,9 +2343,11 @@
 /area/station/medical/storage)
 "bhd" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "bhD" = (
@@ -2173,12 +2365,14 @@
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
 "bhT" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 1
 	},
 /obj/structure/closet/toolcloset,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "bid" = (
@@ -2189,7 +2383,6 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "bir" = (
@@ -2227,8 +2420,10 @@
 /obj/item/stock_parts/subspace/crystal,
 /obj/item/stock_parts/subspace/crystal,
 /obj/item/stock_parts/subspace/crystal,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "bjI" = (
@@ -2279,7 +2474,9 @@
 /area/aegis/surface)
 "blf" = (
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "blr" = (
@@ -2303,12 +2500,20 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "blO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 6
+	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "blQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "blX" = (
@@ -2317,9 +2522,11 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "bmx" = (
@@ -2356,8 +2563,9 @@
 	},
 /obj/item/radio/intercom/directional/south,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "bmY" = (
@@ -2378,6 +2586,10 @@
 /obj/machinery/firealarm/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
+"bns" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "bnu" = (
 /obj/structure/bed,
 /obj/item/bedsheet/dorms,
@@ -2401,7 +2613,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "boh" = (
@@ -2421,6 +2635,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/central)
 "boB" = (
@@ -2440,7 +2657,9 @@
 /turf/open/floor/deadspace/mono,
 /area/station/commons/dorms/barracks/female)
 "bpE" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/warden)
 "bpP" = (
@@ -2450,6 +2669,9 @@
 /area/aegis/mining)
 "bqd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
 "bqe" = (
@@ -2480,7 +2702,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "bqC" = (
@@ -2587,7 +2808,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "bsG" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2625,8 +2845,10 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "bum" = (
@@ -2711,7 +2933,6 @@
 	},
 /area/station/hallway/primary/central)
 "bvM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2734,7 +2955,9 @@
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "bwu" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "bwR" = (
@@ -2809,9 +3032,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -2847,7 +3072,6 @@
 /obj/structure/window/reinforced/spawner/west,
 /obj/item/bikehorn/airhorn,
 /obj/structure/closet/secure_closet/personal,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/wood,
 /area/aegis/mining)
 "bzE" = (
@@ -2856,7 +3080,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "bzI" = (
@@ -2879,7 +3105,9 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "bAs" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "bAx" = (
@@ -2917,7 +3145,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bBh" = (
@@ -2946,7 +3176,7 @@
 	dir = 8
 	},
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/central/aft)
+/area/station/security/brig/upper)
 "bBP" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/box,
@@ -2966,12 +3196,13 @@
 /area/station/medical/medbay/central)
 "bCA" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/security/brig/upper)
 "bCR" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -2998,7 +3229,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/bridge_pipe/cyan/visible,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "bDz" = (
@@ -3026,12 +3259,16 @@
 /obj/structure/table/glass,
 /obj/item/disk/holodisk/ds13/cryo,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "bEf" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/hydroponics/constructable,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "bEj" = (
@@ -3043,6 +3280,15 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"bEp" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/maintenance/starboard/upper)
 "bEB" = (
 /obj/machinery/light/small/maintenance/directional/west,
 /obj/structure/showcase/machinery/signal_decrypter,
@@ -3059,6 +3305,16 @@
 	},
 /turf/open/water/beach,
 /area/station/hallway/primary/port)
+"bFa" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
+/area/station/security/medical)
 "bFf" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 4
@@ -3088,6 +3344,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "bFS" = (
@@ -3122,8 +3381,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "bGQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "bHy" = (
@@ -3140,9 +3401,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bHF" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "bHR" = (
@@ -3159,9 +3422,17 @@
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "bIh" = (
@@ -3194,9 +3465,11 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
 "bID" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
 "bII" = (
@@ -3215,6 +3488,22 @@
 /obj/structure/inflatable/door,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"bKt" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command hallway"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "bKK" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/random/maint_left{
@@ -3222,10 +3511,12 @@
 	},
 /area/station/hallway/primary/port)
 "bKN" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "bKS" = (
@@ -3321,6 +3612,9 @@
 	id = "FL room"
 	},
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/hop)
 "bNV" = (
@@ -3333,6 +3627,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "bOc" = (
@@ -3384,12 +3681,14 @@
 	},
 /area/station/hallway/primary/starboard)
 "bPk" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bPs" = (
@@ -3400,7 +3699,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
 "bPy" = (
@@ -3454,10 +3755,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/service/chapel)
 "bRr" = (
@@ -3536,6 +3839,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/maint_center{
 	dir = 8
 	},
@@ -3596,7 +3902,6 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/monitoring)
 "bUr" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/chair/stool/directional/north,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
@@ -3671,12 +3976,23 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
 "bWf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
+"bWg" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "bWt" = (
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
@@ -3715,9 +4031,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "bXp" = (
@@ -3768,6 +4086,9 @@
 /area/station/cargo/warehouse/upper)
 "bYx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/tcommsat/server)
 "bYy" = (
@@ -3809,13 +4130,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/camera/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "bZM" = (
@@ -3849,10 +4172,12 @@
 	req_one_access_txt = "1;4"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "cal" = (
@@ -3916,7 +4241,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "ccd" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/toilet/restrooms)
 "cch" = (
@@ -3929,11 +4256,12 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "ccB" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
@@ -4024,8 +4352,10 @@
 /obj/item/storage/lunchbox/unitology,
 /obj/item/storage/lunchbox/unitology,
 /obj/item/storage/lunchbox/unitology,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/service/library)
 "cgv" = (
@@ -4036,6 +4366,11 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
 "cgw" = (
@@ -4046,10 +4381,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
 "cgN" = (
@@ -4088,10 +4425,20 @@
 /obj/machinery/camera/autoname/directional/west,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
+"chN" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse/upper)
 "chP" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/mine/lobby)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "ciq" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
@@ -4106,9 +4453,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "ciE" = (
@@ -4122,6 +4471,23 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central)
+"cjf" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Mining Privacy";
+	name = "Mining Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "cju" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/deadspace/heavy,
@@ -4148,6 +4514,13 @@
 /obj/machinery/atmospherics/pipe/bridge_pipe/green/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"ckc" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "ckm" = (
 /obj/structure/closet/crate/trashcart/laundry,
 /turf/open/floor/iron/showroomfloor,
@@ -4186,8 +4559,10 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
 "clQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/female)
 "clS" = (
@@ -4209,8 +4584,10 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
 "cmw" = (
@@ -4289,7 +4666,6 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "coK" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_center,
 /area/aegis/mining)
 "cpf" = (
@@ -4298,7 +4674,9 @@
 /area/station/cargo/miningdock/oresilo)
 "cpt" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit/departure_lounge)
 "cpC" = (
@@ -4332,9 +4710,11 @@
 /area/station/tcommsat/server)
 "cql" = (
 /obj/structure/chair/office,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
@@ -4350,7 +4730,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/fax_machine,
 /obj/structure/fireaxecabinet/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
@@ -4385,9 +4764,11 @@
 /obj/structure/table,
 /obj/machinery/telephone/research,
 /obj/machinery/light/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/item/folder,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "crE" = (
@@ -4395,7 +4776,6 @@
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "crF" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/command{
 	name = "Medical Director's Office";
 	req_one_access_txt = "40";
@@ -4405,6 +4785,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/cmo)
 "crJ" = (
@@ -4415,10 +4798,12 @@
 	name = "Church of Unitology"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/central)
 "crZ" = (
@@ -4442,6 +4827,11 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
+"csx" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo/warehouse)
 "csz" = (
 /turf/open/floor/deadspace/cable{
 	dir = 1
@@ -4454,6 +4844,12 @@
 /obj/effect/spawner/random/maintenance/two,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
+"ctn" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/warehouse)
 "ctp" = (
 /obj/structure/railing{
 	dir = 9
@@ -4472,8 +4868,13 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse)
 "ctA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
 "ctS" = (
@@ -4483,35 +4884,48 @@
 	dir = 4;
 	id = "Psec command"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/hos)
 "cuB" = (
 /obj/machinery/modular_computer/console/preset/id{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/hop)
 "cuI" = (
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "cuM" = (
 /obj/structure/table,
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/telephone/command,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/white,
 /area/station/command/heads_quarters/rd)
 "cuN" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/security/armory)
 "cuT" = (
@@ -4525,9 +4939,11 @@
 /area/station/commons/dorms/barracks/female)
 "cvi" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "cvu" = (
@@ -4538,7 +4954,9 @@
 /area/station/hallway/secondary/command)
 "cvC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 1
 	},
@@ -4555,7 +4973,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/aegis/hanger)
 "cwa" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
 	},
@@ -4579,6 +4999,12 @@
 	dir = 8
 	},
 /area/mine/production)
+"cxd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 8
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "cxq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
@@ -4592,6 +5018,9 @@
 "cxw" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/cable/white{
+	icon_state = "6"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/service/chapel/monastery)
@@ -4626,9 +5055,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -4637,7 +5068,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/machinery/airalarm/directional/north,
 /turf/open/floor/deadspace/random/slides{
@@ -4672,9 +5102,11 @@
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
 "czP" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
 "czR" = (
@@ -4688,9 +5120,11 @@
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/central)
 "cAk" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "cAo" = (
@@ -4727,6 +5161,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"cAL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/command/bridge)
 "cAO" = (
 /obj/structure/table,
 /obj/item/food/mint,
@@ -4743,15 +5188,17 @@
 "cAY" = (
 /obj/structure/table,
 /obj/machinery/telephone/engineering,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "cAZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "cBh" = (
@@ -4768,12 +5215,17 @@
 /area/station/medical/chemistry)
 "cBm" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cBD" = (
@@ -4810,7 +5262,6 @@
 /area/aegis/surface)
 "cCP" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/dark/corner,
 /area/station/hallway/primary/starboard)
 "cCT" = (
@@ -4818,16 +5269,21 @@
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "cCU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "cDn" = (
@@ -4837,9 +5293,17 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "cDr" = (
@@ -4883,6 +5347,9 @@
 "cFk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
@@ -4929,11 +5396,13 @@
 /turf/open/floor/deadspace/cable_start,
 /area/misc/testroom)
 "cGm" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "cGB" = (
@@ -4964,7 +5433,6 @@
 "cHi" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/poddoor/preopen{
 	id = "captain hideout";
 	dir = 4
@@ -5038,7 +5506,9 @@
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
 "cIg" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -5090,7 +5560,9 @@
 /area/station/service/chapel)
 "cJM" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "cJO" = (
@@ -5104,17 +5576,16 @@
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "cKw" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/maint_right{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/area/station/hallway/primary/fore)
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/command/bridge)
 "cKy" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "cKB" = (
@@ -5179,8 +5650,13 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "cMn" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
 "cMt" = (
@@ -5202,6 +5678,9 @@
 "cMQ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "cMZ" = (
@@ -5211,6 +5690,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics)
+"cNc" = (
+/obj/structure/cable/yellow{
+	icon_state = "136"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "cNr" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -5226,8 +5711,10 @@
 /turf/open/floor/catwalk_floor/iron,
 /area/station/engineering/monitoring)
 "cOf" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
 "cON" = (
@@ -5250,12 +5737,17 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cPb" = (
@@ -5277,9 +5769,11 @@
 "cPn" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "cPy" = (
@@ -5317,7 +5811,9 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "cPX" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/central)
 "cQh" = (
@@ -5386,7 +5882,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/medical/morgue)
 "cSt" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "cSE" = (
@@ -5401,6 +5901,27 @@
 	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/port)
+"cSQ" = (
+/obj/machinery/door/airlock/security/glass{
+	id_tag = "outerbrig";
+	name = "P-Sec Brig";
+	req_access_txt = "63";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
+	cycle_id = "brig-entrance"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig)
 "cST" = (
 /obj/machinery/light/cold/directional/east,
 /obj/effect/turf_decal/tile/red/half/contrasted{
@@ -5409,11 +5930,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "cTo" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/atmospherics/components/trinary/filter/atmos/h2{
+	dir = 8
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
@@ -5424,11 +5945,13 @@
 /obj/item/radio/intercom/directional/east,
 /obj/structure/table/wood,
 /obj/machinery/telephone,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/light/directional/east,
 /obj/effect/turf_decal/siding/wood/corner{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
 	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
@@ -5437,12 +5960,15 @@
 /turf/open/water,
 /area/station/maintenance/port/lesser)
 "cUc" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "cUs" = (
 /obj/machinery/disposal/bin,
 /obj/effect/floor_decal/ds/spline/fancy/wood{
@@ -5456,7 +5982,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
 "cUD" = (
@@ -5469,7 +5997,9 @@
 	},
 /obj/machinery/camera/autoname/directional/west,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "cUQ" = (
@@ -5490,9 +6020,6 @@
 	id = "Cell 4";
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "cVQ" = (
@@ -5506,9 +6033,11 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "cVS" = (
@@ -5550,9 +6079,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "cWV" = (
@@ -5612,6 +6143,9 @@
 "cZh" = (
 /obj/structure/chair/office,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "cZj" = (
@@ -5657,14 +6191,18 @@
 /area/station/command/heads_quarters/cmo)
 "daQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
 "daT" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "dbi" = (
@@ -5750,8 +6288,10 @@
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/telephone/research,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
 "dfh" = (
@@ -5759,9 +6299,11 @@
 	dir = 1;
 	name = "P-Sec Upper Storage Room"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/fore/greater)
 "dfn" = (
@@ -5827,15 +6369,12 @@
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "diA" = (
-/obj/structure/sign/warning/securearea{
-	pixel_y = 32
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "diZ" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
@@ -5850,6 +6389,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/maint_center{
 	dir = 8
 	},
@@ -5867,12 +6409,23 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "djT" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "djU" = (
@@ -5960,10 +6513,15 @@
 	},
 /area/station/hallway/primary/port)
 "dmq" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "dmE" = (
@@ -6037,12 +6595,11 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/fore)
 "dpc" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/grater,
-/area/station/hallway/primary/central/aft)
+/area/station/security/brig/upper)
 "dpo" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/right{
@@ -6060,10 +6617,12 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/rd)
 "dpv" = (
@@ -6164,7 +6723,9 @@
 "dsu" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/marker_beacon/burgundy,
-/turf/open/misc/asteroid,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "dsJ" = (
 /turf/open/floor/deadspace/random/maint_center,
@@ -6266,7 +6827,9 @@
 /obj/machinery/atmospherics/components/trinary/mixer/airmix{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "dxn" = (
@@ -6332,9 +6895,11 @@
 /area/station/engineering/atmos)
 "dyS" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "dyV" = (
@@ -6364,6 +6929,9 @@
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 1
 	},
+/obj/structure/cable/white{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/service/chapel/monastery)
 "dzy" = (
@@ -6378,10 +6946,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dAe" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "dAh" = (
@@ -6421,6 +6991,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
+	dir = 9
+	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "dAN" = (
@@ -6428,10 +7004,12 @@
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/cable/multiz,
 /obj/structure/disposalpipe/trunk/multiz{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
@@ -6450,7 +7028,6 @@
 /area/station/hallway/primary/central)
 "dBf" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/checkpoint/customs)
@@ -6503,9 +7080,11 @@
 	name = "Cryogenics Bay";
 	req_access_txt = "5"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "dDu" = (
@@ -6521,9 +7100,18 @@
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/delivery,
 /obj/item/clothing/glasses/meson/engine,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"dDE" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "dEb" = (
 /obj/structure/bed/dogbed/mcgriff,
 /mob/living/simple_animal/pet/dog/pug/mcgriff{
@@ -6554,24 +7142,31 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dEQ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "dFA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/multitool,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "dFK" = (
@@ -6588,6 +7183,12 @@
 /obj/machinery/power/floodlight,
 /turf/open/water,
 /area/station/maintenance/port/lesser)
+"dGD" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/bathroom,
+/area/mine/production)
 "dGO" = (
 /obj/structure/table/wood,
 /obj/machinery/light/small/directional/west,
@@ -6674,21 +7275,20 @@
 	name = "Break Room";
 	req_access_txt = "5"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "dHZ" = (
 /obj/machinery/flasher{
 	id = "Cell 3";
 	pixel_x = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
@@ -6707,11 +7307,16 @@
 /area/mine/storage)
 "dIM" = (
 /obj/structure/table/wood,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/paper_bin,
 /obj/item/folder/red,
 /obj/item/stamp/law,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
 "dIR" = (
@@ -6743,11 +7348,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "dJx" = (
-/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
+/turf/open/floor/carpet/royalblack,
+/area/station/cargo/miningoffice)
 "dJK" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/rectangles,
@@ -6784,8 +7390,10 @@
 "dKR" = (
 /obj/structure/table/wood/fancy/green,
 /obj/machinery/telephone/command,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/captain)
 "dLe" = (
@@ -6795,13 +7403,15 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "dLg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/eva)
 "dLj" = (
@@ -6814,9 +7424,14 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "dLK" = (
@@ -6830,7 +7445,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/airalarm/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "dMf" = (
@@ -6848,6 +7468,12 @@
 "dMI" = (
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/fore/lesser)
+"dMW" = (
+/obj/structure/cable/yellow{
+	icon_state = "144"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "dNz" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 4
@@ -6856,8 +7482,13 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "dOa" = (
@@ -6865,7 +7496,10 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
 "dOf" = (
-/turf/open/floor/iron/ported/techfloor,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "dOx" = (
 /obj/machinery/cryopod{
@@ -6891,7 +7525,9 @@
 /area/station/cargo/sorting)
 "dOS" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/commons/storage/primary)
 "dPf" = (
@@ -6909,7 +7545,9 @@
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/female)
 "dPG" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "dQh" = (
@@ -6950,6 +7588,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
+"dQW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides,
+/area/station/cargo/warehouse)
 "dRt" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/entertainment/deck,
@@ -6960,8 +7603,10 @@
 	dir = 8;
 	network = "tcommsat"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
 "dRE" = (
@@ -6976,27 +7621,39 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
+"dRP" = (
+/obj/machinery/atmospherics/pipe/smart/simple/pink/visible,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "dSa" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "dSg" = (
 /obj/effect/decal/cleanable/cobweb{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
 /area/aegis/mining)
 "dSu" = (
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/central/aft)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "dSB" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -7028,18 +7685,20 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "dSI" = (
-/obj/machinery/shower{
-	dir = 8
+/obj/machinery/conveyor{
+	id = "Lower Marker Conveyor"
 	},
-/obj/effect/turf_decal/bot,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/bathroom,
-/area/aegis/mining)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "dSZ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 8
 	},
@@ -7073,9 +7732,11 @@
 /area/station/engineering/supermatter/room)
 "dTs" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/cable,
 /area/station/hallway/secondary/exit/departure_lounge)
 "dTw" = (
@@ -7102,19 +7763,21 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "dUe" = (
-/obj/machinery/atmospherics/components/trinary/filter/atmos/h2{
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
 	dir = 8
 	},
-/turf/open/floor/iron/ported/techfloor,
+/turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "dUl" = (
 /obj/structure/disposalpipe/segment{
@@ -7142,9 +7805,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -7183,9 +7848,11 @@
 /obj/effect/landmark/navigate_destination/dockarrival,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/dorms/cryo)
 "dWo" = (
@@ -7268,18 +7935,11 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "dYv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector{
-	icon_state = "connector_map-3";
-	dir = 1
-	},
-/obj/effect/turf_decal/box/white{
-	color = "#9FED58"
-	},
 /obj/machinery/firealarm/directional/east,
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
-/turf/open/floor/iron/dark/textured,
+/turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "dYK" = (
 /obj/machinery/mineral/equipment_vendor,
@@ -7305,6 +7965,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/mine/eva)
 "dZu" = (
@@ -7324,7 +7987,15 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "window command hallway"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "dZE" = (
@@ -7390,6 +8061,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"ebA" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "ebG" = (
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
@@ -7417,7 +8094,6 @@
 	pixel_x = 20
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "ecy" = (
@@ -7427,9 +8103,11 @@
 	},
 /area/aegis/mining)
 "ecH" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/tech,
 /area/station/hallway/primary/central/aft)
 "ecL" = (
@@ -7446,7 +8124,9 @@
 "edm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "edr" = (
@@ -7459,9 +8139,11 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "edO" = (
@@ -7474,7 +8156,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "edX" = (
@@ -7489,7 +8170,9 @@
 /area/station/commons/dorms/barracks/male)
 "eem" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
 "eer" = (
@@ -7524,9 +8207,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "efF" = (
@@ -7542,8 +8227,13 @@
 /area/station/security/brig)
 "efO" = (
 /obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/maint_center,
-/area/station/service/chapel/monastery)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "efQ" = (
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
@@ -7599,7 +8289,15 @@
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/engine_smes)
 "egd" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/server)
 "egf" = (
@@ -7683,9 +8381,11 @@
 /area/station/cargo/warehouse/upper)
 "eiv" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "eiy" = (
@@ -7705,7 +8405,6 @@
 /obj/machinery/camera/directional/east{
 	c_tag = "Engineering - Desk"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/newscaster/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
@@ -7726,9 +8425,11 @@
 /area/station/engineering/break_room)
 "ejX" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "ekN" = (
@@ -7741,6 +8442,10 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/mono,
 /area/mine/hydroponics)
+"ekY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo/warehouse)
 "eld" = (
 /obj/structure/sign/cec/deck/cargo,
 /turf/closed/wall/r_wall,
@@ -7857,8 +8562,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery/theatre)
 "epg" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "eph" = (
@@ -7871,6 +8579,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "epA" = (
@@ -7898,6 +8609,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/aft)
 "eqk" = (
@@ -7907,7 +8621,6 @@
 /area/station/hallway/primary/port)
 "eqm" = (
 /obj/structure/table,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/controller,
 /obj/item/compact_remote,
 /obj/item/compact_remote,
@@ -7941,6 +8654,18 @@
 "erk" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo)
+"erO" = (
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "esc" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/machinery/light/small/maintenance/directional/north,
@@ -8008,11 +8733,21 @@
 /obj/effect/spawner/random/deadspace/ammo/mining,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
+"eus" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/service/janitor)
 "euB" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
 	},
@@ -8021,8 +8756,10 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "evb" = (
@@ -8062,9 +8799,12 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
 "ewa" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/miningoffice)
+/obj/structure/lattice,
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "ewj" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/disposal/bin,
@@ -8120,7 +8860,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/bathroom,
 /area/aegis/mining)
 "exz" = (
@@ -8156,7 +8895,9 @@
 	},
 /obj/item/storage/photo_album/chapel,
 /obj/machinery/light_switch/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/service/chapel/office)
 "eyr" = (
@@ -8237,7 +8978,9 @@
 /area/station/engineering/atmos)
 "eAV" = (
 /obj/machinery/light/floor/has_bulb,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "eBa" = (
@@ -8256,7 +8999,9 @@
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/secondary/exit/departure_lounge)
 "eBq" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -8289,16 +9034,17 @@
 /area/station/maintenance/fore/lesser)
 "eCA" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "eCC" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit/departure_lounge)
 "eCJ" = (
@@ -8334,7 +9080,6 @@
 /area/aegis/hanger)
 "eDR" = (
 /obj/structure/filingcabinet,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "eDU" = (
@@ -8358,9 +9103,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "eEa" = (
@@ -8388,9 +9135,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "eEx" = (
@@ -8411,7 +9163,12 @@
 	name = "Prison Monitor";
 	pixel_y = 30
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/warden)
 "eEZ" = (
@@ -8423,11 +9180,13 @@
 	id = "Engineering";
 	name = "Engineering Security Doors"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/break_room)
 "eFm" = (
@@ -8471,7 +9230,6 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "eGb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -8495,9 +9253,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "eGt" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "eGC" = (
@@ -8510,8 +9270,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "eGD" = (
@@ -8551,7 +9313,6 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_center,
 /area/aegis/mining)
 "eHS" = (
@@ -8559,16 +9320,20 @@
 	dir = 4
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "eHW" = (
 /turf/closed/wall/r_wall,
 /area/station/medical/surgery)
 "eIj" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain)
 "eIq" = (
@@ -8607,7 +9372,12 @@
 /area/station/engineering/supermatter/room)
 "eIL" = (
 /obj/effect/spawner/structure/window/reinforced/plasma,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/engineering/monitoring)
 "eIZ" = (
@@ -8674,10 +9444,12 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "eKJ" = (
@@ -8693,7 +9465,9 @@
 "eLF" = (
 /obj/machinery/light/small/maintenance/directional/west,
 /obj/machinery/power/terminal,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/service/chapel/monastery)
 "eLI" = (
@@ -8715,6 +9489,9 @@
 /obj/machinery/telephone/security,
 /obj/machinery/power/data_terminal,
 /obj/machinery/door/window/brigdoor/left/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "eMN" = (
@@ -8741,9 +9518,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -8787,7 +9566,9 @@
 	},
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "ePf" = (
@@ -8896,7 +9677,9 @@
 "eRL" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
 /obj/machinery/meter,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "eRR" = (
@@ -8918,6 +9701,15 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/eva)
+"eSQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/command/bridge)
 "eSR" = (
 /turf/open/floor/plating,
 /area/aegis/surface)
@@ -8943,8 +9735,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
 "eTw" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
 "eTK" = (
@@ -8959,6 +9753,13 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
+"eTQ" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/security/warden)
 "eTU" = (
 /obj/machinery/light/small/maintenance/directional/west,
 /turf/open/floor/plating,
@@ -8976,14 +9777,15 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "eVb" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/general/hidden,
 /turf/open/floor/plating,
 /area/station/science/server)
@@ -9004,9 +9806,11 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "eVG" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "eVH" = (
@@ -9057,9 +9861,11 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "eWW" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
 "eXh" = (
@@ -9071,8 +9877,10 @@
 /area/station/engineering/atmos)
 "eXP" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -9097,32 +9905,43 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "eYu" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "eYM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "eYU" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "eZc" = (
@@ -9146,7 +9965,9 @@
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
 "eZs" = (
@@ -9281,6 +10102,15 @@
 /area/station/engineering/storage_shared)
 "fdT" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
 "fdX" = (
@@ -9291,15 +10121,13 @@
 	},
 /area/station/hallway/primary/starboard)
 "feD" = (
-/obj/machinery/door/airlock/mining{
-	name = "Cargo Bay";
-	req_one_access_txt = "31;48"
-	},
-/obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "feG" = (
 /obj/machinery/door/airlock/atmos/glass{
 	name = "Distribution Loop";
@@ -9308,8 +10136,6 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
@@ -9323,20 +10149,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "ffw" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/turf/open/floor/iron/norn,
+/area/station/hallway/primary/starboard)
 "ffz" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -9354,9 +10181,11 @@
 /obj/machinery/light/directional/north,
 /obj/machinery/newscaster/directional/north,
 /obj/machinery/telephone/service,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/item/reagent_containers/glass/rag,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "ffE" = (
@@ -9462,14 +10291,16 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
 "fjl" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/supply/visible{
+	dir = 10
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "fjn" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -9481,7 +10312,9 @@
 "fjr" = (
 /obj/structure/table,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "fju" = (
@@ -9538,7 +10371,9 @@
 /area/station/service/hydroponics/upper)
 "fkx" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo)
 "fkE" = (
@@ -9556,7 +10391,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "fkY" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/misc/testroom)
 "flj" = (
@@ -9579,14 +10416,15 @@
 	dir = 4
 	},
 /obj/machinery/light_switch/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/misc_lab)
 "flr" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "flJ" = (
@@ -9639,10 +10477,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/miningoffice)
 "fnQ" = (
@@ -9678,17 +10518,18 @@
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/male)
 "foI" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "foK" = (
 /obj/structure/table,
 /obj/item/storage/box/cups,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "foP" = (
@@ -9701,9 +10542,11 @@
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "fpu" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/brig)
 "fpy" = (
@@ -9719,23 +10562,33 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/light_switch/directional{
 	pixel_x = -24;
 	pixel_y = -8
 	},
 /obj/machinery/vending/medical,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "fpH" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "fpO" = (
@@ -9757,11 +10610,13 @@
 	req_access_txt = "33";
 	stripe_paint = "#ff9900"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "fqc" = (
@@ -9772,13 +10627,20 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "fqh" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
 "fqq" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/security/office)
 "fqB" = (
@@ -9804,6 +10666,11 @@
 "frg" = (
 /turf/closed/mineral/random/aegis,
 /area/station/commons/dorms/barracks/female)
+"frl" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "frw" = (
 /obj/effect/landmark{
 	name = "ShuttleRepairPart"
@@ -9833,6 +10700,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right{
 	dir = 8
 	},
@@ -9865,6 +10735,9 @@
 /area/station/engineering/main)
 "fts" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/cargo/qm)
 "ftv" = (
@@ -9931,9 +10804,6 @@
 	id = "Cell 1";
 	pixel_x = -24
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "fwj" = (
@@ -9941,22 +10811,33 @@
 	name = "Shuttle Bay";
 	req_access_txt = "63"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/customs)
 "fwp" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
-"fwt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
+"fwt" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "fwv" = (
@@ -9994,17 +10875,29 @@
 /obj/machinery/portable_atmospherics/canister/plasma,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"fyB" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command hallway"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "fyS" = (
 /obj/structure/railing,
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
 "fyZ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/junction/yjunction{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "fzi" = (
@@ -10018,7 +10911,6 @@
 /area/station/command/heads_quarters/hos)
 "fzw" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
@@ -10029,7 +10921,6 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "fzI" = (
@@ -10039,15 +10930,19 @@
 /area/station/hallway/primary/port)
 "fzN" = (
 /obj/structure/table/wood,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/computer/security/wooden_tv{
 	pixel_x = 3;
 	pixel_y = 2
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "fAI" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "fBk" = (
@@ -10067,16 +10962,23 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "fBC" = (
-/obj/structure/disposalpipe/trunk/multiz,
-/turf/closed/wall/r_wall,
-/area/station/medical/medbay/aft)
+/obj/effect/turf_decal/siding/wood{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/wood,
+/area/station/medical/psychology)
 "fCw" = (
 /obj/structure/table,
 /obj/item/paper_bin{
@@ -10140,7 +11042,6 @@
 /area/station/maintenance/starboard/aft)
 "fDO" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -10150,7 +11051,9 @@
 /obj/machinery/computer/secure_data{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -10185,6 +11088,15 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/mineral/titanium/survival/pod,
 /area/aegis/surface)
+"fFe" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/central)
 "fFW" = (
 /obj/machinery/light/small/maintenance/directional/south,
 /obj/structure/chair/office{
@@ -10265,6 +11177,8 @@
 "fJe" = (
 /obj/structure/frame/computer,
 /obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "fJj" = (
@@ -10311,14 +11225,11 @@
 /area/station/commons/dorms/cryo)
 "fLg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
-	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "fLk" = (
 /obj/structure/chair/stool/directional/north,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/carpet/red,
 /area/station/commons/lounge)
 "fLs" = (
@@ -10369,6 +11280,12 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore/lesser)
+"fMo" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "fMs" = (
 /obj/structure/window/reinforced/spawner,
 /obj/item/food/grown/banana/bunch,
@@ -10394,9 +11311,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/mine/production)
 "fNt" = (
@@ -10405,16 +11324,23 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
 "fNB" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/monitoring)
@@ -10493,7 +11419,9 @@
 /area/station/tcommsat/server)
 "fPN" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/starboard/central)
 "fPP" = (
@@ -10527,11 +11455,13 @@
 /area/station/security/brig)
 "fQf" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/camera/directional/south{
 	c_tag = "Science Hallway - South"
 	},
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "fQu" = (
@@ -10572,9 +11502,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
 "fRe" = (
@@ -10589,12 +11521,13 @@
 /area/aegis/surface)
 "fRC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/firealarm/directional/east,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
@@ -10692,6 +11625,8 @@
 "fTI" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "fTX" = (
@@ -10699,7 +11634,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
 "fUt" = (
@@ -10733,6 +11670,14 @@
 "fUM" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/commons/storage/primary)
+"fUQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "fVp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -10744,9 +11689,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "fVs" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "fVt" = (
@@ -10766,6 +11713,9 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
+"fWv" = (
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "fXn" = (
 /obj/structure/chair/office,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -10779,9 +11729,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/dorms/cryo)
 "fXF" = (
@@ -10800,9 +11752,11 @@
 	req_access_txt = "28"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "fYa" = (
@@ -10840,6 +11794,12 @@
 	},
 /turf/open/floor/deadspace/random/golf_gray,
 /area/mine/hydroponics)
+"fYC" = (
+/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "fYH" = (
 /mob/living/simple_animal/slug/glubby,
 /turf/open/floor/wood,
@@ -10859,14 +11819,15 @@
 	dir = 4;
 	name = "Computer Recycling Room"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/mono,
 /area/aegis/mining)
 "fZe" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
 "fZC" = (
@@ -10885,6 +11846,18 @@
 /obj/machinery/light/small/maintenance/directional/south,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
+"fZP" = (
+/obj/structure/chair/office{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "gak" = (
 /obj/structure/table,
 /obj/item/stock_parts/micro_laser{
@@ -10941,15 +11914,19 @@
 /area/station/medical/medbay/aft)
 "gbr" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "gbS" = (
-/obj/structure/lattice,
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/starboard/greater)
 "gcw" = (
 /obj/machinery/door/airlock/mining{
 	dir = 1;
@@ -10958,10 +11935,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/miningoffice)
 "gcA" = (
@@ -10981,6 +11960,17 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
+"gcX" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Cargo Privacy";
+	name = "Cargo Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "gda" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
@@ -11020,7 +12010,9 @@
 "gew" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "geM" = (
@@ -11065,7 +12057,9 @@
 /turf/open/water,
 /area/station/maintenance/port/lesser)
 "gfh" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -11151,9 +12145,11 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "gjc" = (
@@ -11179,6 +12175,8 @@
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "gkf" = (
@@ -11257,12 +12255,17 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "glT" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/junction/yjunction{
 	icon_state = "pipe-y";
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
@@ -11291,6 +12294,19 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/security/brig)
+"gmv" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "gmN" = (
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
@@ -11322,9 +12338,11 @@
 /area/station/hallway/primary/central)
 "goF" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/box,
 /obj/machinery/microscope,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "goK" = (
@@ -11368,11 +12386,15 @@
 	},
 /area/station/hallway/primary/port)
 "gpu" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/mono,
-/area/aegis/mining)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gpv" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse)
 "gpy" = (
@@ -11402,9 +12424,11 @@
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "gqh" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/misc/asteroid,
-/area/station/solars/port/fore)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "gqi" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -11526,6 +12550,9 @@
 "guQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/clothing/costume,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "gva" = (
@@ -11550,6 +12577,17 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/deadspace/mono,
 /area/station/security/medical)
+"gvJ" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Cargo Privacy";
+	name = "Cargo Shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
 "gvY" = (
 /turf/closed/wall/r_wall,
 /area/station/tcommsat/server)
@@ -11564,8 +12602,18 @@
 /obj/item/retractor,
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
+"gwy" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/morgue)
 "gwI" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/white{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/storage)
 "gwJ" = (
@@ -11575,26 +12623,29 @@
 /turf/closed/wall/r_wall,
 /area/station/service/hydroponics/upper)
 "gwR" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/catwalk_floor/iron_dark,
-/area/station/engineering/main)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "gxI" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
 "gxK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gxZ" = (
@@ -11652,7 +12703,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "gzE" = (
@@ -11686,6 +12736,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "gAv" = (
@@ -11698,8 +12751,9 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/male)
 "gAZ" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/components/unary/thermomachine/heater/on{
+	power_setting = 50
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "gBe" = (
@@ -11710,7 +12764,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/modular_computer/console/preset/engineering,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/iron/dark,
 /area/station/engineering/main)
@@ -11756,9 +12809,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "gDA" = (
@@ -11797,12 +12852,14 @@
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "gEb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "gEj" = (
@@ -11815,13 +12872,15 @@
 /turf/open/floor/engine/airless,
 /area/station/engineering/supermatter/room)
 "gEz" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "gER" = (
@@ -11910,9 +12969,11 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/ai_monitored/security/armory)
 "gHU" = (
@@ -11946,9 +13007,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "gKI" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
@@ -11956,10 +13019,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/hallway/secondary/service)
 "gKQ" = (
@@ -12051,12 +13119,20 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
 "gOz" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "gOA" = (
@@ -12087,9 +13163,11 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/yellow/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
 "gPk" = (
@@ -12106,7 +13184,9 @@
 /obj/machinery/telephone/security,
 /obj/machinery/power/data_terminal,
 /obj/machinery/light/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/warden)
 "gPp" = (
@@ -12153,7 +13233,6 @@
 	name = "Bridge"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/tech{
 	dir = 8
 	},
@@ -12162,9 +13241,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "gQs" = (
@@ -12195,9 +13276,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -12230,7 +13313,6 @@
 /area/station/medical/pharmacy)
 "gRt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "gRv" = (
@@ -12238,14 +13320,22 @@
 /turf/open/floor/iron/cafeteria,
 /area/station/commons/dorms/cryo)
 "gRy" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/commons/storage/primary)
 "gRD" = (
 /obj/structure/chair/office{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/checkpoint/customs)
@@ -12279,6 +13369,9 @@
 /obj/machinery/light/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "gTq" = (
@@ -12322,9 +13415,11 @@
 /area/aegis/surface)
 "gUl" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
 "gUo" = (
@@ -12377,9 +13472,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/hallway/secondary/service)
 "gVA" = (
@@ -12389,9 +13486,11 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
 "gVD" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningdock/oresilo)
 "gVS" = (
@@ -12429,7 +13528,6 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "gWu" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
@@ -12440,9 +13538,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
@@ -12453,7 +13553,9 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "gXh" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
+	dir = 8
+	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "gXk" = (
@@ -12478,6 +13580,13 @@
 /obj/machinery/firealarm/directional/east,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/female)
+"gXv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/grimy,
+/area/station/tcommsat/computer)
 "gXB" = (
 /obj/machinery/washing_machine,
 /obj/effect/spawner/random/trash,
@@ -12515,22 +13624,37 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "gYJ" = (
 /turf/open/openspace,
 /area/station/cargo/sorting)
+"gYR" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/hardwood,
+/area/station/command/heads_quarters/captain)
 "gYS" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
@@ -12557,9 +13681,14 @@
 "gZQ" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood/corner,
 /obj/structure/disposalpipe/junction/yjunction,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "hal" = (
@@ -12581,9 +13710,11 @@
 /obj/machinery/holopad,
 /obj/effect/landmark/start/scientist,
 /obj/effect/turf_decal/box/white,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "haz" = (
@@ -12596,8 +13727,10 @@
 /area/station/maintenance/fore/lesser)
 "haR" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "haZ" = (
@@ -12620,9 +13753,11 @@
 /area/station/hallway/primary/central)
 "hbH" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "hbP" = (
@@ -12634,6 +13769,17 @@
 /obj/structure/bed/roller,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"hcd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "hch" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
@@ -12647,7 +13793,6 @@
 	},
 /area/station/hallway/primary/fore)
 "hdz" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/eva)
@@ -12691,7 +13836,9 @@
 	},
 /area/station/medical/medbay/central)
 "heH" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/secondary/exit/departure_lounge)
 "heI" = (
@@ -12727,19 +13874,20 @@
 	name = "Aegis Science"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
 /area/station/science/lobby)
 "hfD" = (
 /obj/structure/disposalpipe/junction/yjunction,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/secondary/exit/departure_lounge)
 "hfM" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	initialize_directions = 8
+/obj/machinery/atmospherics/components/binary/pump{
+	name = "Distro to Waste"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
@@ -12775,14 +13923,19 @@
 "hgU" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "hgV" = (
 /obj/machinery/computer/station_alert,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -12803,11 +13956,19 @@
 /area/station/science/lab)
 "hhx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/plating,
 /area/station/hallway/primary/central)
 "hhC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/warden)
 "hhV" = (
@@ -12920,6 +14081,14 @@
 /obj/effect/decal/cleanable/blood/gibs/old,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"hmT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/mono,
+/area/station/cargo/sorting)
 "hnj" = (
 /obj/structure/stairs/south,
 /turf/open/floor/deadspace/mono,
@@ -13039,20 +14208,37 @@
 	dir = 8
 	},
 /area/station/hallway/primary/aft)
+"hpN" = (
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold/green/visible{
+	dir = 4
+	},
+/turf/open/floor/iron/ported/techfloor_grid,
+/area/station/engineering/supermatter/room)
 "hpQ" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/cable/white{
+	icon_state = "9"
+	},
+/obj/structure/cable/white{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
 "hqb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "hqn" = (
@@ -13060,6 +14246,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "hqp" = (
@@ -13081,7 +14270,6 @@
 "hqS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "hqZ" = (
@@ -13127,7 +14315,9 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "hsj" = (
@@ -13166,15 +14356,19 @@
 /area/aegis/mining)
 "htp" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "hty" = (
 /obj/structure/table,
 /obj/machinery/telephone/research,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "htA" = (
@@ -13233,9 +14427,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 6
-	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
 "huJ" = (
@@ -13276,6 +14467,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/maint_center{
 	dir = 8
 	},
@@ -13311,11 +14505,17 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
 "hvU" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/wood,
-/area/aegis/mining)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/mono,
+/area/station/cargo/sorting)
 "hwp" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/chapel)
 "hwE" = (
@@ -13334,10 +14534,12 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/commons/storage/primary)
 "hwO" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/highcap/five_k/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/engine_smes)
 "hwQ" = (
@@ -13360,16 +14562,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "hxA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
 "hxB" = (
@@ -13377,16 +14583,20 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/bot,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "hxF" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "hxG" = (
@@ -13405,8 +14615,10 @@
 /area/station/medical/medbay/central)
 "hyK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "hyN" = (
@@ -13418,8 +14630,10 @@
 /obj/item/paper_bin,
 /obj/structure/table/wood/fancy/red,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/folder/red,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "hzd" = (
@@ -13456,14 +14670,15 @@
 /area/station/command/heads_quarters/rd)
 "hzT" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "hAa" = (
 /obj/structure/disposalpipe/junction/flip,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "hAg" = (
@@ -13485,7 +14700,9 @@
 "hAM" = (
 /obj/structure/cable/multiz,
 /obj/structure/closet/firecloset,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/central)
 "hAU" = (
@@ -13522,6 +14739,12 @@
 /obj/effect/spawner/random/vending/colavend,
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"hCA" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/cargo/warehouse)
 "hCD" = (
 /obj/structure/window/reinforced/spawner/east,
 /turf/open/water/beach,
@@ -13531,12 +14754,13 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "hCO" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/meter,
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "hCW" = (
@@ -13544,6 +14768,18 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"hCX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "hDd" = (
 /obj/structure/railing/corner{
 	dir = 8
@@ -13552,11 +14788,16 @@
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
 "hDf" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/carpet/red,
-/area/station/security/office)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "hDv" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/customs)
@@ -13574,9 +14815,14 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "hEM" = (
@@ -13606,11 +14852,13 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "hFz" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/greater)
 "hFB" = (
@@ -13619,7 +14867,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "hFC" = (
@@ -13634,6 +14884,14 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"hFT" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/wood,
+/area/station/command/heads_quarters/hos)
 "hFY" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -13660,7 +14918,9 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "hGw" = (
@@ -13668,7 +14928,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
@@ -13705,16 +14964,20 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "hGU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/directional/south,
 /obj/machinery/power/apc/highcap/ten_k/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/monitoring)
 "hGV" = (
 /turf/open/floor/deadspace/random/golf_gray,
 /area/aegis/surface)
 "hHi" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "hHl" = (
@@ -13765,9 +15028,10 @@
 /area/station/security/interrogation)
 "hJs" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "hJv" = (
@@ -13792,7 +15056,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "hJM" = (
@@ -13806,9 +15069,11 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
 "hJT" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
 "hKc" = (
@@ -13832,9 +15097,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -13883,6 +15150,8 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/box,
 /obj/effect/spawner/random/deadspace/ammo,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "hMX" = (
@@ -13973,8 +15242,10 @@
 /area/station/command/heads_quarters/ce)
 "hOT" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/cold/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "hOX" = (
@@ -13993,10 +15264,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "hPr" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "hPv" = (
@@ -14138,8 +15414,10 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "hSA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "hSX" = (
@@ -14251,6 +15529,16 @@
 /obj/machinery/light/small/maintenance/directional/east,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
+"hVO" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/male)
 "hVP" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/smart_cable/color/yellow,
@@ -14371,7 +15659,6 @@
 /area/station/commons/dorms/barracks/male)
 "iae" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "iap" = (
@@ -14396,7 +15683,9 @@
 "iaV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "iba" = (
@@ -14419,9 +15708,11 @@
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "ibV" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
 "icl" = (
@@ -14451,7 +15742,9 @@
 /turf/open/floor/plating,
 /area/aegis/hanger)
 "idt" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "idy" = (
@@ -14462,12 +15755,14 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "idA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "idL" = (
@@ -14509,12 +15804,17 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "iet" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "ieE" = (
@@ -14531,7 +15831,9 @@
 /area/aegis/surface)
 "ieR" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "ieZ" = (
@@ -14574,17 +15876,21 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/lockers)
 "ifS" = (
 /obj/structure/rack,
 /obj/item/gun/grenadelauncher,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/window/reinforced/spawner/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/ai_monitored/security/armory)
 "igu" = (
@@ -14600,8 +15906,10 @@
 /area/station/cargo/office)
 "igw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -14610,9 +15918,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "igF" = (
@@ -14688,7 +15998,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "iiK" = (
@@ -14704,14 +16016,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "ijk" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "ijm" = (
@@ -14772,6 +16091,17 @@
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
+"ijN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "ijZ" = (
 /obj/structure/closet/crate/large/ds,
 /obj/effect/spawner/random/maintenance/two,
@@ -14780,7 +16110,6 @@
 /area/station/cargo/warehouse/upper)
 "ika" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
@@ -14836,15 +16165,20 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "ikZ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "ilk" = (
 /obj/machinery/power/smes,
+/obj/structure/cable/white{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/service/chapel/monastery)
 "ill" = (
@@ -14877,16 +16211,20 @@
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "ilS" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo)
 "ilU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/mine/production)
 "imw" = (
@@ -14923,9 +16261,12 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "imS" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/dark,
-/area/station/hallway/primary/starboard)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "imT" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/chair/sofa/corp/left{
@@ -14950,6 +16291,9 @@
 /area/station/hallway/primary/fore)
 "iof" = (
 /obj/effect/spawner/structure/window/reinforced/tinted/prepainted/daedalus,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/plating,
 /area/station/security/interrogation)
 "ioi" = (
@@ -14962,7 +16306,9 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "iov" = (
@@ -14977,17 +16323,21 @@
 /area/station/medical/chemistry)
 "ioB" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "ioE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/eva)
 "ipf" = (
@@ -15000,19 +16350,34 @@
 /obj/structure/table/wood/poker,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"ipC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "ipE" = (
 /obj/machinery/light_switch/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "ipM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/primary/central/aft)
+"iqd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "iqf" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -15023,6 +16388,12 @@
 	},
 /obj/machinery/light_switch/directional/west{
 	pixel_y = 32
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
@@ -15055,6 +16426,17 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"iri" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/command/bridge)
 "irO" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 4
@@ -15062,14 +16444,18 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "isb" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "isc" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "isj" = (
@@ -15093,9 +16479,11 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "itM" = (
@@ -15134,7 +16522,6 @@
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse)
 "ivq" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/camera/autoname/directional/south,
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -15147,9 +16534,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "ivB" = (
@@ -15177,7 +16566,9 @@
 /area/station/hallway/primary/port)
 "ivX" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/security/range)
 "iwy" = (
@@ -15200,8 +16591,10 @@
 /turf/open/floor/engine/co2,
 /area/station/engineering/atmos)
 "iwD" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/wood,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/carpet/red,
 /area/station/commons/lounge)
 "iwK" = (
 /obj/structure/reagent_dispensers/fueltank,
@@ -15214,9 +16607,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "ixe" = (
@@ -15229,6 +16624,15 @@
 	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
+"ixI" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/hardwood,
+/area/station/command/heads_quarters/captain)
 "iyj" = (
 /obj/structure/kitchenspike,
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
@@ -15238,11 +16642,13 @@
 /area/station/service/kitchen/coldroom)
 "iyS" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "Engineering Security Doors"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
@@ -15323,7 +16729,6 @@
 /area/station/cargo/warehouse/upper)
 "iAC" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/button/door/directional/east{
 	pixel_y = -6;
 	name = "Engineering Lockdown";
@@ -15335,9 +16740,6 @@
 	id = "Secure Storage"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/machinery/light/floor/has_bulb,
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
@@ -15359,6 +16761,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "iAN" = (
@@ -15380,14 +16785,18 @@
 /turf/open/floor/plating,
 /area/station/cargo/storage)
 "iAS" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "iAV" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
 "iBJ" = (
@@ -15417,10 +16826,25 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/commons/dorms/barracks/male)
 "iCe" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse/upper)
+"iCg" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "iCm" = (
 /obj/machinery/light/small/directional/east,
@@ -15452,6 +16876,12 @@
 	dir = 1
 	},
 /area/station/hallway/primary/central/aft)
+"iCO" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "iCX" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 8
@@ -15466,9 +16896,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/hallway/secondary/service)
 "iDw" = (
@@ -15480,9 +16912,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
 "iDB" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse/upper)
 "iDL" = (
@@ -15518,7 +16952,6 @@
 /area/aegis/hanger)
 "iEJ" = (
 /obj/structure/chair/office,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
@@ -15536,9 +16969,14 @@
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
 "iEU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
@@ -15560,9 +16998,11 @@
 /area/station/service/chapel)
 "iFH" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/miningoffice)
 "iFK" = (
@@ -15601,9 +17041,11 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "iGV" = (
@@ -15639,7 +17081,6 @@
 "iHt" = (
 /obj/structure/rack,
 /obj/item/storage/box/teargas,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/storage/box/teargas,
 /obj/item/storage/box/flashbangs{
@@ -15648,6 +17089,9 @@
 	},
 /obj/item/storage/box/stingbangs,
 /obj/structure/window/reinforced/spawner/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/ai_monitored/security/armory)
 "iHw" = (
@@ -15694,6 +17138,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
 "iIl" = (
@@ -15707,13 +17154,18 @@
 	req_access_txt = "69;5";
 	stripe_paint = "#ff9900"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "iIq" = (
 /obj/machinery/light/small/maintenance/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "iIK" = (
@@ -15745,6 +17197,8 @@
 "iIX" = (
 /obj/machinery/rnd/production/fabricator/department/cargo,
 /obj/structure/window/reinforced/spawner/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "iJe" = (
@@ -15766,13 +17220,11 @@
 	},
 /area/station/hallway/secondary/exit/departure_lounge)
 "iJI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "66"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/white,
-/area/station/science/lobby)
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "iJV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/cyan/visible{
 	dir = 4
@@ -15787,9 +17239,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "iKK" = (
@@ -15797,7 +17257,6 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/port/lesser)
 "iKX" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 8
 	},
@@ -15806,14 +17265,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "iKY" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/motion/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "iLg" = (
@@ -15821,8 +17288,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "iLi" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/fore/greater)
 "iLC" = (
@@ -15922,10 +17391,12 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "window command hallway"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/command/bridge)
 "iMB" = (
@@ -16024,9 +17495,11 @@
 /turf/open/misc/asteroid,
 /area/station/solars/port/fore)
 "iPb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -16052,9 +17525,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "iPr" = (
@@ -16076,9 +17551,11 @@
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "iPC" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -16116,12 +17593,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "iQt" = (
@@ -16188,9 +17667,11 @@
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/rd)
 "iSY" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/warden)
 "iTb" = (
@@ -16239,7 +17720,9 @@
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
 "iTY" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/white{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
 "iUl" = (
@@ -16274,16 +17757,17 @@
 /area/station/hallway/primary/central/aft)
 "iVk" = (
 /obj/structure/table,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/telephone/engineering,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/monitoring)
 "iVq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -16467,16 +17951,20 @@
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/female)
 "jaQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "jaR" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/radio/intercom/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "jaS" = (
@@ -16495,10 +17983,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics)
 "jbI" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
 "jbL" = (
@@ -16551,15 +18041,19 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
 "jdI" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/ce)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "jdK" = (
 /obj/machinery/computer/med_data{
 	dir = 4
@@ -16583,12 +18077,20 @@
 /obj/structure/frame/machine,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
-"jeU" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
+"jeQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "129"
 	},
-/obj/structure/lattice,
 /turf/open/misc/asteroid,
+/area/aegis/surface)
+"jeU" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "jfa" = (
 /turf/closed/wall/r_wall,
@@ -16620,10 +18122,15 @@
 /area/station/command/heads_quarters/captain)
 "jgb" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "jgm" = (
@@ -16652,6 +18159,7 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/west,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "jgK" = (
@@ -16679,6 +18187,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
+"jhs" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "jhv" = (
 /obj/structure/railing,
 /turf/open/floor/deadspace/roller,
@@ -16720,7 +18237,6 @@
 /area/mine/storage)
 "jij" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
@@ -16763,9 +18279,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/hallway/secondary/service)
 "jjd" = (
@@ -16792,7 +18310,9 @@
 	color = "#9FED58"
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "jjF" = (
@@ -16811,8 +18331,10 @@
 /area/station/cargo/miningdock/cafeteria)
 "jjN" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "jjQ" = (
@@ -16888,8 +18410,10 @@
 	},
 /area/station/hallway/primary/fore)
 "jlP" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
 "jlY" = (
@@ -16916,6 +18440,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "jmt" = (
@@ -16970,7 +18497,6 @@
 /area/station/tcommsat/computer)
 "jnA" = (
 /obj/effect/landmark/navigate_destination/research,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
@@ -17002,7 +18528,9 @@
 /area/aegis/surface)
 "jnN" = (
 /obj/machinery/firealarm/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/commons/storage/primary)
 "jnY" = (
@@ -17031,7 +18559,7 @@
 	color = "#9FED58"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 5
 	},
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
@@ -17071,9 +18599,11 @@
 /turf/open/floor/plating,
 /area/station/engineering/main)
 "jpj" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/sorting)
 "jpm" = (
@@ -17089,7 +18619,9 @@
 /obj/machinery/light/small/maintenance/directional/north,
 /obj/item/soap,
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/chapel)
 "jpA" = (
@@ -17103,8 +18635,6 @@
 	c_tag = "Cargo Bay - Aft";
 	pixel_x = 14
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "jpN" = (
@@ -17114,11 +18644,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "jpQ" = (
@@ -17143,9 +18675,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "jpV" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/stone,
-/area/aegis/surface)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "jpX" = (
 /obj/structure/rack,
 /obj/item/storage/lunchbox/cec,
@@ -17160,7 +18694,6 @@
 /area/station/engineering/atmos)
 "jqx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/science/research)
 "jqC" = (
@@ -17178,9 +18711,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "jqW" = (
@@ -17247,6 +18782,9 @@
 /obj/item/camera_film,
 /obj/item/camera_film,
 /obj/item/camera_film,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
 "jth" = (
@@ -17263,6 +18801,12 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/newscaster/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "jtu" = (
@@ -17281,6 +18825,14 @@
 /obj/machinery/light/small/directional/east,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"jtJ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "jtP" = (
 /mob/living/simple_animal/drone/classic/scavbot{
 	dir = 4;
@@ -17298,9 +18850,11 @@
 /area/station/science/breakroom)
 "jtU" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
 	},
@@ -17316,9 +18870,11 @@
 	},
 /area/station/hallway/primary/fore)
 "juy" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
 	},
@@ -17331,11 +18887,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "juH" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
+/obj/machinery/atmospherics/components/binary/pump/on{
+	name = "Waste to Filter";
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "jvn" = (
@@ -17374,10 +18929,10 @@
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse/upper)
 "jwt" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "jwz" = (
@@ -17386,15 +18941,25 @@
 	req_access_txt = "3"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/warden)
 "jwI" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/mine/production)
 "jwX" = (
@@ -17411,21 +18976,23 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "jxE" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
 /area/station/hallway/primary/central/aft)
 "jxH" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 8
-	},
 /obj/structure/chair/stool/directional/north,
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "jyl" = (
@@ -17438,16 +19005,23 @@
 "jyw" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "jyy" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
@@ -17501,9 +19075,19 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/iron/stairs,
 /area/aegis/hanger)
+"jAG" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "jAQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/science/server)
 "jAT" = (
@@ -17527,12 +19111,21 @@
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "jBo" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "jBp" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/deadspace/cable_end,
 /area/misc/testroom)
+"jBy" = (
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "jBX" = (
 /obj/structure/window{
 	dir = 4
@@ -17587,13 +19180,14 @@
 	pixel_x = -4;
 	pixel_y = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "jDq" = (
 /obj/machinery/light/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -17639,6 +19233,9 @@
 "jFJ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/checkpoint/science)
 "jFR" = (
@@ -17725,9 +19322,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "jIe" = (
@@ -17746,6 +19345,14 @@
 /obj/effect/spawner/random/engineering/tool,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"jIw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "jIB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -17777,7 +19384,9 @@
 	c_tag = "Science Firing Range";
 	network = list("ss13","rd")
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/engine,
 /area/station/science/misc_lab/range)
 "jIT" = (
@@ -17814,6 +19423,10 @@
 	c_tag = "Aft Starboard Solar Maintenance"
 	},
 /obj/structure/chair/stool/directional/south,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "jKh" = (
@@ -17856,9 +19469,11 @@
 	name = "Church Storage";
 	req_one_access_txt = "27"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/chapel)
 "jKX" = (
@@ -17887,14 +19502,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "jMK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "jML" = (
@@ -17902,7 +19518,9 @@
 	name = "Unisex Restrooms"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/toilet/restrooms)
 "jMQ" = (
@@ -17991,6 +19609,12 @@
 /obj/effect/spawner/random/trash,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"jOM" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "jON" = (
 /obj/item/radio/intercom{
 	dir = 4;
@@ -18083,10 +19707,19 @@
 /obj/structure/weightmachine/stacklifter,
 /turf/open/floor/iron/dark,
 /area/station/maintenance/fore/lesser)
+"jQZ" = (
+/obj/machinery/light/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "jRe" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "jRg" = (
@@ -18124,7 +19757,12 @@
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
 "jSw" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit)
 "jSE" = (
@@ -18139,6 +19777,9 @@
 	},
 /obj/machinery/power/data_terminal,
 /obj/machinery/telephone/command,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
 "jSL" = (
@@ -18155,7 +19796,9 @@
 "jTf" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "jTp" = (
@@ -18171,8 +19814,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
+"jTU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible{
+	dir = 8
+	},
+/obj/machinery/meter/monitored/waste_loop,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "jUL" = (
 /obj/structure/sign/cec/deck{
 	pixel_y = 34
@@ -18355,25 +20008,35 @@
 /area/station/cargo/storage)
 "jYE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "jYG" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "jYM" = (
 /obj/machinery/computer/security,
 /obj/machinery/newscaster/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/checkpoint/customs)
 "jYX" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "jZb" = (
@@ -18383,8 +20046,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "jZs" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
 "jZu" = (
@@ -18494,12 +20159,17 @@
 	input_level = 60000;
 	output_level = 70000
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "kej" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
@@ -18523,7 +20193,6 @@
 	placard_name = "Medical PBX"
 	},
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/newscaster/directional/south,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
@@ -18534,7 +20203,6 @@
 /obj/structure/table/wood,
 /obj/machinery/fax_machine,
 /obj/machinery/airalarm/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
@@ -18550,6 +20218,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/courtroom)
 "kfM" = (
@@ -18690,8 +20361,10 @@
 /turf/open/floor/deadspace/random/slides,
 /area/aegis/mining)
 "kih" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
 "kiq" = (
@@ -18703,11 +20376,16 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "kis" = (
-/obj/structure/rack,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/effect/spawner/random/maintenance,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/grater,
-/area/aegis/mining)
+/area/station/security/brig/upper)
 "kit" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/smart/manifold/yellow/visible{
@@ -18716,8 +20394,10 @@
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "kiA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "kiC" = (
@@ -18800,6 +20480,9 @@
 /obj/machinery/telephone/security,
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/checkpoint/customs)
 "kkf" = (
@@ -18842,6 +20525,7 @@
 "klD" = (
 /obj/structure/table/wood/poker,
 /obj/machinery/roulette,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "klS" = (
@@ -18858,7 +20542,9 @@
 /area/station/commons/dorms/barracks/male)
 "kmy" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "kmF" = (
@@ -18922,7 +20608,6 @@
 /obj/effect/turf_decal/siding/purple/corner{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
@@ -18942,9 +20627,10 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "kpk" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/service/janitor)
+/obj/structure/chair/stool/directional/south,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/wood,
+/area/station/commons/lounge)
 "kpy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -18957,12 +20643,27 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "kpP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "Mining Privacy";
+	name = "Mining Shutters"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/turf/open/floor/plating,
+/area/station/cargo/qm)
+"kqi" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/area/mine/eva)
 "kqt" = (
 /obj/structure/table,
 /obj/item/storage/bag/sheetsnatcher,
@@ -19013,9 +20714,13 @@
 	name = "Front Desk";
 	req_one_access_txt = "50"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "krD" = (
@@ -19028,6 +20733,12 @@
 	},
 /turf/open/floor/iron/dark/side,
 /area/station/hallway/primary/starboard)
+"krG" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "krQ" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/turf_decal/delivery,
@@ -19048,9 +20759,11 @@
 /area/station/commons/dorms/laundry)
 "ksC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/cable_start,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ksD" = (
@@ -19106,12 +20819,16 @@
 /area/station/engineering/atmos)
 "ktR" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
 "ktX" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "ktY" = (
@@ -19161,12 +20878,17 @@
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
 "kvH" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "kvY" = (
@@ -19203,7 +20925,9 @@
 /turf/closed/wall/r_wall,
 /area/station/commons/dorms/laundry)
 "kyb" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "kyd" = (
@@ -19226,6 +20950,12 @@
 "kyD" = (
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
+"kyJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "20"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "kyT" = (
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/maintenance/fore/lesser)
@@ -19265,6 +20995,7 @@
 /area/station/hallway/secondary/exit)
 "kAI" = (
 /obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "kAJ" = (
@@ -19287,12 +21018,17 @@
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "kBD" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "kBN" = (
@@ -19307,9 +21043,22 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"kCr" = (
+/obj/structure/disposalpipe/junction{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "kCt" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "kCF" = (
@@ -19345,17 +21094,24 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "kDx" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "med_md_privacy";
 	name = "privacy shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/cmo)
@@ -19368,7 +21124,6 @@
 /area/station/engineering/storage_shared)
 "kDC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
@@ -19380,19 +21135,32 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
 "kDP" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
+"kEi" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "kEv" = (
 /obj/item/megaphone,
 /obj/structure/table/wood,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
 "kEE" = (
-/obj/structure/reagent_dispensers/watertank,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/fueltank/large,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "kEF" = (
@@ -19425,9 +21193,11 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
@@ -19473,12 +21243,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "kGp" = (
@@ -19550,6 +21325,12 @@
 /obj/machinery/light/small/maintenance/directional/south,
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/port/lesser)
+"kJa" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/checkpoint/customs)
 "kJC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -19617,17 +21398,19 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "kLy" = (
-/obj/structure/table/wood,
-/obj/machinery/telephone/cargo,
 /obj/machinery/requests_console/directional/east{
 	announcementConsole = 1;
 	department = "Quartermaster's Desk";
 	departmentType = 2;
 	name = "Quartermaster's Requests Console"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/obj/structure/table/wood,
+/obj/machinery/telephone/cargo,
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "kLI" = (
@@ -19640,6 +21423,12 @@
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
+"kLN" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "kMd" = (
 /obj/machinery/rnd/destructive_analyzer,
 /obj/effect/turf_decal/stripes/line{
@@ -19712,7 +21501,15 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/server)
 "kOf" = (
@@ -19752,12 +21549,28 @@
 "kOI" = (
 /turf/open/misc/asteroid,
 /area/station/hallway/primary/fore)
+"kPc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "kPe" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/fore/lesser)
 "kPt" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
 "kPv" = (
@@ -19783,7 +21596,9 @@
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/iron/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
 "kPU" = (
@@ -19795,6 +21610,12 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
 "kQi" = (
@@ -19821,6 +21642,13 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
+"kQW" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/tcommsat/server)
 "kRf" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -19891,7 +21719,6 @@
 /obj/machinery/door/airlock/external{
 	name = "Mining Dock Airlock"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/mono,
 /area/mine/eva)
 "kSy" = (
@@ -19900,7 +21727,6 @@
 	name = "Cabin 7"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/ported/lino,
@@ -19918,8 +21744,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
 "kSU" = (
@@ -19999,6 +21827,9 @@
 "kVd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "kVf" = (
@@ -20009,12 +21840,14 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper_multi{
 	cycle_id = "brig-entrance"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
 "kVj" = (
@@ -20025,9 +21858,11 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
 "kVv" = (
@@ -20045,7 +21880,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
 "kVY" = (
@@ -20053,6 +21890,15 @@
 /obj/structure/window/reinforced/spawner/north,
 /turf/open/floor/deadspace/random/golf_gray,
 /area/mine/hydroponics)
+"kWh" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/white{
+	icon_state = "12"
+	},
+/turf/open/floor/carpet/royalblack,
+/area/station/service/chapel/monastery)
 "kWH" = (
 /obj/structure/closet/firecloset,
 /obj/effect/spawner/random/contraband/permabrig_weapon,
@@ -20071,7 +21917,9 @@
 "kXb" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "kXe" = (
@@ -20108,8 +21956,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "kYb" = (
@@ -20141,6 +21991,14 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
+"kYD" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "kYE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -20182,13 +22040,23 @@
 /obj/item/paper_bin,
 /obj/structure/table/reinforced,
 /obj/item/folder/blue,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
+"lab" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock/cafeteria)
 "lao" = (
 /obj/machinery/power/apc/auto_name/directional/west,
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "lav" = (
@@ -20307,8 +22175,10 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "lcV" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/newscaster/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "ldn" = (
@@ -20330,11 +22200,19 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "ldv" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/ce)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "ldC" = (
 /obj/machinery/light/small/directional/north,
 /turf/open/floor/wood,
@@ -20343,9 +22221,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "ldI" = (
@@ -20412,6 +22295,13 @@
 	dir = 1
 	},
 /area/station/cargo/warehouse/upper)
+"lfb" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
 "lfp" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/light/small/directional/north,
@@ -20421,9 +22311,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "lfY" = (
@@ -20437,10 +22329,12 @@
 	name = "Drone Bay";
 	req_access_txt = "31"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "lgw" = (
@@ -20460,6 +22354,9 @@
 	pixel_y = -2
 	},
 /obj/machinery/camera/autoname/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "lgT" = (
@@ -20482,7 +22379,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "lhq" = (
@@ -20513,7 +22412,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "lhH" = (
@@ -20524,7 +22422,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -20565,8 +22462,10 @@
 /turf/open/floor/stone,
 /area/aegis/surface)
 "liE" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/medical/exam_room)
 "liT" = (
@@ -20615,6 +22514,23 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
+"lki" = (
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/monitoring)
+"lks" = (
+/obj/machinery/airalarm/directional/south,
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "lku" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
@@ -20630,9 +22546,11 @@
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "llp" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
 "llB" = (
@@ -20676,9 +22594,14 @@
 /area/station/cargo/warehouse/upper)
 "lmj" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/service/chapel/office)
 "lmo" = (
@@ -20791,8 +22714,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "lpq" = (
@@ -20813,9 +22738,14 @@
 	},
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/mop,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
 "lqF" = (
@@ -20839,16 +22769,21 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/maint_center{
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
 "lrx" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "lrH" = (
@@ -20907,6 +22842,9 @@
 "lue" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "luo" = (
@@ -20928,6 +22866,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 1
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "luJ" = (
@@ -20948,6 +22889,10 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"lvH" = (
+/obj/item/electronics/apc,
+/turf/open/floor/deadspace/grater,
+/area/mine/hydroponics)
 "lwb" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/spawner/random/trash,
@@ -20974,6 +22919,9 @@
 /area/station/commons/dorms/cryo)
 "lwr" = (
 /obj/structure/chair/office,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "lwW" = (
@@ -21010,7 +22958,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "lxS" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -21022,6 +22969,13 @@
 /obj/effect/spawner/random/deadspace/ammo,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"lyc" = (
+/obj/structure/cable/multiz,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "lyn" = (
 /obj/machinery/holopad,
 /turf/open/floor/wood,
@@ -21034,9 +22988,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "lyW" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -21069,13 +23025,15 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "lzq" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "lzS" = (
@@ -21101,9 +23059,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "lAk" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "lAp" = (
@@ -21124,14 +23087,18 @@
 /obj/item/bot_assembly/janibot,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "lAY" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/box/red,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/warden)
 "lBh" = (
@@ -21211,7 +23178,9 @@
 	dir = 5
 	},
 /obj/structure/lattice,
-/turf/open/misc/asteroid,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "lDu" = (
 /turf/open/floor/deadspace/random/golf_brown,
@@ -21246,9 +23215,16 @@
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
-"lEu" = (
-/obj/structure/cable/smart_cable/color/yellow,
+"lEg" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
+"lEu" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
 "lEI" = (
@@ -21383,9 +23359,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "lIE" = (
@@ -21395,7 +23373,6 @@
 	name = "P-Sec Upper Hallway";
 	req_access_txt = "63"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -21488,7 +23465,9 @@
 /area/station/engineering/supermatter/room)
 "lKM" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/security/armory)
 "lKY" = (
@@ -21576,6 +23555,13 @@
 /obj/machinery/airalarm/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"lOe" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/atmos)
 "lOp" = (
 /obj/effect/turf_decal/siding/purple{
 	dir = 10
@@ -21589,9 +23575,11 @@
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
 /obj/machinery/airalarm/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
@@ -21617,8 +23605,21 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/item/folder/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
+"lOI" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/mine/production)
 "lOT" = (
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
@@ -21648,7 +23649,12 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "lQk" = (
@@ -21656,9 +23662,11 @@
 	dir = 1;
 	name = "Enginieering Airlock"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -21743,15 +23751,19 @@
 "lSF" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
 "lSG" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "lSI" = (
@@ -21769,6 +23781,12 @@
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
+"lTn" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "lTt" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster/directional/east,
@@ -21790,7 +23808,6 @@
 /turf/open/floor/engine/cult,
 /area/station/service/library)
 "lTz" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/male)
@@ -21800,6 +23817,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "lUG" = (
@@ -21868,6 +23888,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/central)
 "lXb" = (
@@ -21897,6 +23920,14 @@
 	dir = 4
 	},
 /area/station/hallway/primary/central)
+"lYv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/exam_room)
 "lYG" = (
 /obj/structure/railing,
 /turf/open/openspace,
@@ -21910,9 +23941,11 @@
 /obj/structure/table/glass,
 /obj/machinery/telephone/medical,
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/window/reinforced/spawner/north,
 /obj/item/folder/white,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "lZc" = (
@@ -21951,16 +23984,17 @@
 	pixel_y = 21
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/service/hydroponics)
 "mao" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -21989,6 +24023,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "maU" = (
@@ -21996,9 +24033,11 @@
 	dir = 1;
 	name = "Enginieering Airlock"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
@@ -22020,7 +24059,6 @@
 /area/station/hallway/primary/central)
 "mbF" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -22028,6 +24066,9 @@
 /obj/structure/rack,
 /obj/item/storage/belt/utility,
 /obj/effect/spawner/random/maintenance,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
 "mbL" = (
@@ -22059,9 +24100,11 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "mcZ" = (
@@ -22084,8 +24127,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
@@ -22095,6 +24136,17 @@
 "mdu" = (
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
+"mdw" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/wood,
+/area/station/cargo/qm)
 "mdX" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 10
@@ -22116,6 +24168,16 @@
 /obj/effect/spawner/random/maintenance/three,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
+"mer" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/light/directional/south,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "mew" = (
 /obj/machinery/camera/directional/west{
 	c_tag = "Science Admin";
@@ -22150,9 +24212,11 @@
 /area/station/security/range)
 "mfG" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "mgj" = (
@@ -22172,9 +24236,11 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "mgv" = (
@@ -22210,7 +24276,6 @@
 /area/station/cargo/warehouse/upper)
 "mhg" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
@@ -22311,12 +24376,14 @@
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/supermatter/room)
 "mlt" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "mlw" = (
@@ -22416,6 +24483,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "mnQ" = (
@@ -22446,11 +24516,13 @@
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "mou" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/cryo)
 "moB" = (
 /obj/machinery/door/airlock/hydroponics/glass{
 	name = "Abandoned Hydroponics";
@@ -22459,9 +24531,11 @@
 /turf/open/floor/deadspace/grater,
 /area/mine/hydroponics)
 "moE" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/aft)
 "moF" = (
@@ -22473,6 +24547,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
+"moK" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/service/chapel/monastery)
 "moS" = (
 /obj/structure/table/wood/fancy/cyan,
 /obj/item/folder{
@@ -22484,7 +24564,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
@@ -22497,9 +24576,11 @@
 /area/station/security/range)
 "mpA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
@@ -22553,8 +24634,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
 "mrn" = (
@@ -22595,16 +24681,20 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "msk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
 "msp" = (
@@ -22623,7 +24713,6 @@
 /area/station/service/hydroponics/upper)
 "msD" = (
 /obj/effect/landmark/start/janitor,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
 "msH" = (
@@ -22666,7 +24755,9 @@
 	},
 /area/station/hallway/primary/fore)
 "mtQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/aegis/surface)
 "mui" = (
@@ -22676,9 +24767,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "mun" = (
@@ -22728,9 +24821,11 @@
 	},
 /area/station/hallway/primary/port)
 "mvL" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/closet/secure_closet/ds/detective,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
 "mvU" = (
@@ -22761,10 +24856,12 @@
 	req_access_txt = "22"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/service/chapel/office)
 "mwK" = (
@@ -22792,9 +24889,11 @@
 /area/station/medical/surgery/theatre)
 "mxH" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "mxM" = (
@@ -22873,10 +24972,11 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/purple/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/lab)
 "mBd" = (
@@ -22889,7 +24989,6 @@
 	name = "Aegis Cargo"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -22902,9 +25001,11 @@
 /area/station/command/heads_quarters/rd)
 "mBv" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "mBz" = (
@@ -22914,10 +25015,12 @@
 	req_access_txt = "5"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
 "mCb" = (
@@ -22930,9 +25033,13 @@
 	},
 /area/mine/production)
 "mCd" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/white,
-/area/station/medical/medbay/central)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "mCl" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/east,
@@ -22941,10 +25048,12 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "mCy" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light_switch/directional{
 	pixel_x = -24;
 	pixel_y = -24
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
@@ -22955,6 +25064,16 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/commons/dorms/barracks/male)
+"mCC" = (
+/obj/machinery/light/directional/north,
+/obj/structure/chair{
+	pixel_y = -2
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "mCF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -23007,7 +25126,9 @@
 /area/station/cargo/qm)
 "mCZ" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "mDg" = (
@@ -23023,15 +25144,19 @@
 	dir = 4;
 	id = "forensic_shutters"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/security/detectives_office)
 "mDF" = (
 /obj/structure/table/glass,
 /obj/item/food/grown/poppy/lily,
 /obj/machinery/telephone/service,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/service/hydroponics)
 "mDJ" = (
@@ -23054,7 +25179,9 @@
 "mEu" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "mEz" = (
@@ -23104,9 +25231,11 @@
 /area/station/hallway/secondary/exit)
 "mHD" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "mHG" = (
@@ -23124,6 +25253,16 @@
 	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
+"mIw" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command hallway"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "mIX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -23132,8 +25271,10 @@
 	dir = 8
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/filingcabinet/chestdrawer,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "mIY" = (
@@ -23147,6 +25288,22 @@
 	},
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"mJq" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/light/floor/has_bulb,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "mJt" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /mob/living/simple_animal/butterfly,
@@ -23174,7 +25331,6 @@
 	pixel_x = -4;
 	pixel_y = 6
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "mKH" = (
@@ -23196,10 +25352,15 @@
 	dir = 9
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/item/radio/intercom/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "mLl" = (
@@ -23245,7 +25406,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/secondary/exit/departure_lounge)
 "mLO" = (
@@ -23322,10 +25482,12 @@
 	req_access_txt = "6"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "mNX" = (
@@ -23351,7 +25513,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/light/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "mOr" = (
@@ -23365,8 +25526,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/lockers)
 "mPy" = (
@@ -23385,12 +25551,20 @@
 /turf/closed/wall/r_wall,
 /area/station/science/breakroom)
 "mQm" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/mine/production)
 "mQn" = (
@@ -23402,7 +25576,9 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "Maints Lockdown"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "mQN" = (
@@ -23442,6 +25618,9 @@
 	dir = 8
 	},
 /area/mine/production)
+"mRr" = (
+/turf/open/floor/deadspace/bathroom,
+/area/station/medical/morgue)
 "mRL" = (
 /obj/machinery/sleeper{
 	icon_state = "sleeper";
@@ -23455,9 +25634,11 @@
 	req_access_txt = "61"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "mSl" = (
@@ -23467,6 +25648,15 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/iron/white,
 /area/station/science/research)
+"mSK" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/server)
 "mST" = (
 /obj/machinery/washing_machine,
 /turf/open/floor/iron/showroomfloor,
@@ -23476,10 +25666,13 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/camera/directional/west{
 	c_tag = "Atmospherics - Desk"
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "mTB" = (
@@ -23497,13 +25690,21 @@
 "mUd" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "mUn" = (
 /turf/open/floor/iron/dark/telecomms,
 /area/station/tcommsat/server)
+"mUA" = (
+/obj/structure/cable/yellow{
+	icon_state = "68"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "mUC" = (
 /obj/machinery/door/poddoor,
 /obj/machinery/conveyor{
@@ -23513,7 +25714,9 @@
 /area/station/cargo/warehouse)
 "mUX" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -23525,7 +25728,6 @@
 	},
 /area/station/hallway/primary/starboard)
 "mVI" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -23537,6 +25739,12 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "mVT" = (
@@ -23564,7 +25772,12 @@
 /area/station/security/brig/upper)
 "mWa" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "mWb" = (
@@ -23590,9 +25803,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "mXc" = (
@@ -23613,6 +25828,9 @@
 "mXQ" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "mXV" = (
@@ -23629,9 +25847,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "mYf" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse/upper)
 "mYj" = (
@@ -23690,7 +25910,9 @@
 /obj/structure/cable/multiz,
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/primary/central/aft)
 "mZz" = (
@@ -23698,9 +25920,11 @@
 	name = "Supermatter Engine Control Room";
 	req_access_txt = "10"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/monitoring)
 "mZF" = (
@@ -23753,14 +25977,22 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
 "nav" = (
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "naz" = (
@@ -23769,12 +26001,15 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "naA" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/iron/dark,
-/area/station/hallway/primary/central/aft)
+/area/station/security/brig/upper)
 "naE" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible{
 	dir = 4
@@ -23784,6 +26019,15 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/atmos)
+"naF" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/hallway/primary/port)
 "nbo" = (
 /obj/machinery/mineral/stacking_unit_console{
 	machinedir = 8;
@@ -23792,7 +26036,12 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "nbJ" = (
@@ -23814,12 +26063,14 @@
 	},
 /area/station/security/lockers)
 "nck" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "ncl" = (
@@ -23859,7 +26110,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "ncO" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "ncT" = (
@@ -23935,9 +26188,11 @@
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "ngl" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "ngs" = (
@@ -23946,7 +26201,9 @@
 /area/aegis/surface)
 "ngy" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/medical)
 "ngE" = (
@@ -23982,7 +26239,6 @@
 	c_tag = "Chief Engineer's Office"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -24004,6 +26260,16 @@
 /obj/structure/railing,
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
+"nhW" = (
+/obj/effect/floor_decal/ds/spline/fancy/wood{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/station/service/library)
 "nih" = (
 /obj/structure/rack,
 /obj/item/storage/pill_bottle/iron,
@@ -24028,8 +26294,10 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "nin" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
 "niw" = (
@@ -24106,9 +26374,11 @@
 /area/aegis/surface)
 "nkV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "nlg" = (
@@ -24240,11 +26510,21 @@
 /obj/machinery/camera/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"nqb" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "nqi" = (
 /obj/effect/landmark/start/quartermaster,
 /obj/structure/chair/office,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "nqw" = (
@@ -24262,9 +26542,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "nrk" = (
@@ -24282,7 +26564,6 @@
 /obj/machinery/photocopier,
 /obj/item/toner,
 /obj/item/toner,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "nsl" = (
@@ -24338,7 +26619,6 @@
 /turf/open/misc/beach/sand/coastline_t,
 /area/station/hallway/primary/port)
 "nuf" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
@@ -24380,7 +26660,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/corner,
 /area/station/science/lab)
 "nvP" = (
@@ -24397,9 +26679,11 @@
 	},
 /area/aegis/mining)
 "nwv" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "nww" = (
@@ -24424,8 +26708,16 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "window command blast"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/plating,
 /area/station/command/bridge)
 "nyu" = (
@@ -24446,9 +26738,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
@@ -24458,6 +26752,12 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"nyF" = (
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "nyU" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/qm)
@@ -24488,10 +26788,16 @@
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
 /obj/machinery/telephone/research,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
+"nzv" = (
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/deadspace/grater,
+/area/mine/hydroponics)
 "nzy" = (
 /obj/machinery/atmospherics/components/unary/heat_exchanger{
 	dir = 4
@@ -24506,6 +26812,17 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
+"nzN" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
+"nzU" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "nzW" = (
 /obj/effect/spawner/random/maintenance/two,
 /obj/structure/rack,
@@ -24535,9 +26852,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "nAk" = (
@@ -24572,8 +26891,10 @@
 	c_tag = "Locker Room"
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/closet/masks,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "nAP" = (
@@ -24584,7 +26905,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "nAU" = (
@@ -24614,6 +26934,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/maint_center{
 	dir = 8
 	},
@@ -24635,14 +26958,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "nBX" = (
-/obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
-	dir = 9
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/area/station/command/bridge)
 "nCk" = (
 /obj/effect/turf_decal/box,
 /obj/structure/rack,
@@ -24667,9 +26987,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "nCJ" = (
@@ -24695,9 +27017,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "nDm" = (
@@ -24737,7 +27061,9 @@
 /area/station/commons/dorms/barracks/male)
 "nGf" = (
 /obj/structure/lattice/catwalk,
-/turf/open/misc/asteroid,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "nGk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -24761,9 +27087,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
 "nGT" = (
@@ -24781,9 +27109,14 @@
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "nHp" = (
@@ -24815,14 +27148,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "nHM" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "nIf" = (
@@ -24853,9 +27190,11 @@
 	dir = 4
 	},
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/trunk/multiz/down{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -24936,14 +27275,15 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "nLV" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /turf/open/floor/iron/dark,
@@ -24953,7 +27293,9 @@
 	dir = 6
 	},
 /obj/structure/lattice,
-/turf/open/misc/asteroid,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "nMt" = (
 /obj/machinery/light/directional/north,
@@ -24967,9 +27309,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse)
 "nMG" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
-/area/mine/production)
+/area/station/cargo)
 "nMM" = (
 /obj/machinery/air_sensor/plasma_tank,
 /obj/machinery/camera/directional/east{
@@ -24985,8 +27328,22 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
+"nMY" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "nNi" = (
 /obj/machinery/cryopod{
 	dir = 8
@@ -25029,11 +27386,16 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse)
 "nOt" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -25053,9 +27415,11 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "nOQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/service/chapel)
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "nOX" = (
 /obj/machinery/cryopod,
 /obj/effect/landmark/latejoin,
@@ -25083,7 +27447,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "nPd" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "nPr" = (
@@ -25105,9 +27471,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "nPO" = (
@@ -25117,12 +27485,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
 "nQh" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "nQt" = (
@@ -25227,11 +27597,13 @@
 /turf/open/floor/plating,
 /area/station/security/checkpoint/science)
 "nSK" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/rack,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/mod/control/pre_equipped/ds/patrol,
 /obj/structure/window/reinforced/spawner/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/ai_monitored/security/armory)
 "nTe" = (
@@ -25270,7 +27642,6 @@
 /area/station/maintenance/fore/lesser)
 "nUW" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "nUX" = (
@@ -25293,9 +27664,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "nVr" = (
@@ -25313,6 +27686,14 @@
 	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
+"nVW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/carpet/red,
+/area/station/security/office)
 "nWb" = (
 /obj/item/kirbyplants/random,
 /turf/open/floor/deadspace/random/slides{
@@ -25330,9 +27711,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
 "nWN" = (
@@ -25376,9 +27759,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "nYh" = (
@@ -25419,6 +27800,20 @@
 /obj/effect/spawner/random/trash/food_packaging,
 /turf/open/openspace,
 /area/aegis/surface)
+"nZu" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "miningsecprivacy";
+	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/checkpoint/science)
 "nZH" = (
 /obj/structure/flora/ausbushes/brflowers,
 /mob/living/simple_animal/butterfly,
@@ -25450,6 +27845,14 @@
 /obj/machinery/meter,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"oau" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "oaQ" = (
 /obj/structure/table/glass,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -25467,7 +27870,7 @@
 /area/station/cargo/warehouse/upper)
 "oaV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold/supply/visible{
-	dir = 4
+	dir = 8
 	},
 /obj/machinery/meter/monitored/distro_loop,
 /turf/open/floor/deadspace/random/rectangles,
@@ -25479,6 +27882,9 @@
 "obv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/eva)
 "oby" = (
@@ -25514,11 +27920,15 @@
 /area/station/service/chapel/funeral)
 "ocJ" = (
 /obj/structure/railing,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "ocO" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/misc/ironsand,
 /area/aegis/surface)
 "ocW" = (
@@ -25551,11 +27961,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "odB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/carpet/royalblack,
-/area/station/service/chapel/monastery)
+/obj/item/wallframe/apc,
+/turf/open/floor/deadspace/grater,
+/area/mine/hydroponics)
 "odK" = (
 /obj/machinery/light/small/directional/south,
 /turf/open/floor/wood,
@@ -25564,9 +27972,14 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "odU" = (
@@ -25582,7 +27995,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "oed" = (
@@ -25657,12 +28072,10 @@
 /turf/open/floor/carpet/red,
 /area/station/command/heads_quarters/hos)
 "ogk" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
+	dir = 5
 	},
-/obj/machinery/light/directional/south,
-/obj/machinery/meter,
-/turf/open/floor/iron/ported/techfloor,
+/turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "ogs" = (
 /obj/item/folder/blue,
@@ -25692,7 +28105,6 @@
 /area/station/hallway/primary/port)
 "ohf" = (
 /obj/structure/closet/secure_closet/personal,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/wood,
 /area/aegis/mining)
 "ohM" = (
@@ -25712,16 +28124,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "ohT" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -25734,7 +28150,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "oie" = (
@@ -25754,10 +28172,12 @@
 	name = "Mining Locker Room";
 	req_access_txt = "48"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/mine/living_quarters)
 "ojj" = (
@@ -25821,20 +28241,22 @@
 /obj/structure/chair/office{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
 /area/station/security/checkpoint/science)
 "okQ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "okR" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/airalarm/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/medical/exam_room)
 "olc" = (
@@ -25848,10 +28270,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light_switch/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/checkpoint/customs)
 "ols" = (
@@ -25875,7 +28299,6 @@
 	dir = 4;
 	name = "Auxiliary Storage"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/mono,
 /area/aegis/mining)
 "omr" = (
@@ -25902,6 +28325,9 @@
 /turf/open/floor/deadspace/mono,
 /area/aegis/hanger)
 "omC" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/checkpoint/customs)
 "omF" = (
@@ -25910,11 +28336,23 @@
 	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
+"omM" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "omN" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
 "omO" = (
@@ -25943,9 +28381,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/lockers)
 "ong" = (
@@ -26003,6 +28443,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/commons/dorms/barracks/female)
 "opu" = (
@@ -26058,21 +28501,33 @@
 /area/station/medical/medbay/central)
 "oqy" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/plating,
 /area/station/security/brig)
 "oqA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "oqG" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/miningoffice)
 "oqU" = (
@@ -26220,6 +28675,14 @@
 /obj/effect/turf_decal/box/white,
 /turf/open/floor/deadspace/grater,
 /area/station/medical/morgue)
+"ovv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/morgue)
 "ovA" = (
 /obj/machinery/recharge_station,
 /turf/open/floor/deadspace/mono,
@@ -26233,6 +28696,9 @@
 /area/mine/lobby)
 "ovV" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/checkpoint/science)
 "ovW" = (
@@ -26328,7 +28794,15 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/tcommsat/server)
 "oyz" = (
@@ -26362,9 +28836,11 @@
 /area/station/command/bridge)
 "ozj" = (
 /obj/effect/turf_decal/tile/purple,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "ozm" = (
@@ -26379,9 +28855,11 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "ozr" = (
-/obj/machinery/power/apc/auto_name/directional/south,
-/turf/open/floor/deadspace/grater,
-/area/mine/hydroponics)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/eva)
 "ozw" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -26456,7 +28934,11 @@
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "oCi" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/slides,
 /area/station/cargo/warehouse/upper)
 "oCw" = (
@@ -26474,7 +28956,9 @@
 "oCO" = (
 /obj/machinery/washing_machine,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/laundry)
 "oDd" = (
@@ -26504,7 +28988,6 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
 "oEA" = (
@@ -26515,6 +28998,9 @@
 	c_tag = "Medbay Main Hallway- Surgical Junction"
 	},
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "oET" = (
@@ -26563,6 +29049,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
 "oGx" = (
@@ -26575,7 +29064,12 @@
 /area/station/hallway/primary/central/aft)
 "oGC" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/white{
+	icon_state = "1"
+	},
+/obj/structure/cable/white{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
 "oGW" = (
@@ -26629,12 +29123,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "oIM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "oIR" = (
@@ -26648,7 +29144,9 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
 "oJa" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/medical/coldroom)
 "oJf" = (
@@ -26661,9 +29159,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/cable,
 /area/station/hallway/secondary/exit/departure_lounge)
 "oJH" = (
@@ -26676,7 +29176,9 @@
 /obj/item/stock_parts/cell,
 /obj/item/stack/cable_coil,
 /obj/item/assembly/igniter,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "oJI" = (
@@ -26693,15 +29195,24 @@
 	dir = 1
 	},
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/brig)
+"oJK" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "oKi" = (
 /obj/machinery/light/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
@@ -26717,8 +29228,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/disposal)
 "oKC" = (
@@ -26743,19 +29257,29 @@
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/port/lesser)
 "oMj" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/power/apc/auto_name/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "oMn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "oMt" = (
@@ -26770,9 +29294,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/lockers)
 "oMD" = (
@@ -26804,13 +29330,15 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "oOD" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/medical/glass{
 	name = "Receptionist Room";
 	req_access_txt = "5"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "oOK" = (
@@ -26822,8 +29350,10 @@
 "oOL" = (
 /obj/structure/table/wood/fancy/blue,
 /obj/machinery/telephone/service,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/library)
 "oOP" = (
@@ -26896,19 +29426,23 @@
 	req_access_txt = "20"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/poddoor/preopen{
 	id = "captain hideout";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain)
 "oQX" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
 "oQZ" = (
@@ -26936,6 +29470,9 @@
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "oRx" = (
@@ -27038,9 +29575,11 @@
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/hallway/primary/central)
 "oUk" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "oUu" = (
@@ -27090,12 +29629,14 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
 "oVl" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "oVp" = (
@@ -27121,7 +29662,6 @@
 /area/station/engineering/atmos)
 "oXb" = (
 /obj/structure/table,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/camera{
 	c_tag = "Medical Director's Office";
 	dir = 6;
@@ -27131,6 +29671,9 @@
 /obj/machinery/power/data_terminal,
 /obj/machinery/light/cold/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "oXc" = (
@@ -27140,8 +29683,10 @@
 /area/aegis/mining)
 "oXp" = (
 /obj/machinery/light/small/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /obj/machinery/power/smes,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "oXu" = (
@@ -27198,7 +29743,12 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "oYE" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "oYR" = (
@@ -27228,6 +29778,10 @@
 "oZq" = (
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/hallway/primary/starboard)
 "oZw" = (
@@ -27270,7 +29824,6 @@
 /area/station/cargo/warehouse)
 "paC" = (
 /obj/machinery/light/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
 "pba" = (
@@ -27283,6 +29836,9 @@
 /obj/item/paper_bin,
 /obj/structure/table/wood/fancy/red,
 /obj/item/pen,
+/obj/structure/cable/white{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/service/chapel/monastery)
 "pbp" = (
@@ -27297,7 +29853,9 @@
 /turf/open/floor/deadspace/mono,
 /area/station/cargo)
 "pbI" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
 "pbN" = (
@@ -27339,8 +29897,13 @@
 	pixel_x = 26
 	},
 /obj/machinery/telephone/security,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -27377,8 +29940,7 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "pee" = (
-/obj/machinery/meter/monitored/waste_loop,
-/obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "pev" = (
@@ -27435,12 +29997,11 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "pfG" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/hallway/primary/central)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "pfH" = (
 /obj/machinery/conveyor{
 	dir = 4;
@@ -27472,15 +30033,15 @@
 "pgI" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "pgS" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "phc" = (
@@ -27569,8 +30130,10 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/station/tcommsat/server)
 "pkp" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/holopad,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
 "pkF" = (
@@ -27596,6 +30159,13 @@
 /obj/item/bot_assembly/scavbot,
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
+"plx" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command hallway"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "plB" = (
 /obj/machinery/light/directional/north,
 /turf/open/floor/deadspace/mono,
@@ -27612,9 +30182,11 @@
 	req_access_txt = "70";
 	stripe_paint = "#D381C9"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "plM" = (
@@ -27656,8 +30228,23 @@
 	pixel_x = -26
 	},
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
+"pmj" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "pml" = (
 /obj/effect/turf_decal/siding/wood,
 /turf/open/floor/wood,
@@ -27671,8 +30258,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "pmL" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
 "pmR" = (
@@ -27683,11 +30272,16 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "pmS" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
-/turf/open/floor/iron/ported/techfloor,
-/area/station/engineering/supermatter/room)
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/break_room)
 "pnj" = (
 /obj/structure/railing{
 	dir = 6
@@ -27700,9 +30294,14 @@
 /area/station/security/warden)
 "pnH" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "pnL" = (
@@ -27747,6 +30346,16 @@
 	},
 /turf/open/floor/engine/n2,
 /area/station/engineering/atmos)
+"ppa" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/security/brig)
 "ppE" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
@@ -27765,7 +30374,6 @@
 /obj/machinery/door/poddoor/preopen{
 	id = "window command blast"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/command{
 	name = "Bridge";
 	req_access_txt = "19"
@@ -27777,17 +30385,24 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "pqx" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "prc" = (
@@ -27821,9 +30436,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "prT" = (
@@ -27865,7 +30482,9 @@
 "psI" = (
 /obj/machinery/computer/prisoner/management,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/warden)
 "psK" = (
@@ -27920,15 +30539,24 @@
 	},
 /area/station/hallway/primary/central)
 "pud" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
 "pug" = (
 /obj/machinery/light/directional/south,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"pur" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/maintenance/fore/greater)
 "puN" = (
 /obj/structure/sign/cec/deck{
 	pixel_y = 34
@@ -27969,7 +30597,6 @@
 	id = "forensic_shutters";
 	name = "Privacy Shutters"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/dna_analyzer,
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
@@ -27984,7 +30611,9 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "pwR" = (
@@ -28019,8 +30648,10 @@
 	req_access_txt = "5";
 	stripe_paint = "#52B4E9"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "pxS" = (
@@ -28033,6 +30664,25 @@
 /obj/effect/spawner/random/food_or_drink/snack,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
+"pyb" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command blast"
+	},
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
+"pyd" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/security/brig/upper)
 "pyh" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/hos)
@@ -28044,9 +30694,11 @@
 /obj/structure/table/reinforced,
 /obj/machinery/telephone/cargo,
 /obj/effect/spawner/random/food_or_drink/donkpockets,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "pyD" = (
@@ -28054,6 +30706,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/starboard)
 "pyF" = (
@@ -28068,7 +30723,6 @@
 /area/station/cargo/storage)
 "pyY" = (
 /obj/machinery/computer/communications,
-/obj/item/storage/secure/safe/caps_spare/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "pzk" = (
@@ -28153,12 +30807,20 @@
 	},
 /area/station/security/checkpoint/science)
 "pAx" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/junction/flip{
 	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "pAL" = (
@@ -28206,8 +30868,12 @@
 	},
 /area/aegis/hanger)
 "pCh" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "pCn" = (
@@ -28220,7 +30886,6 @@
 /obj/machinery/power/port_gen/pacman,
 /obj/item/stack/sheet/mineral/plasma/thirty,
 /obj/item/wrench,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/service/chapel/monastery)
 "pCt" = (
@@ -28251,18 +30916,22 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
 "pDo" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
 	name = "Engineering Security Doors"
 	},
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/plating,
 /area/station/engineering/storage_shared)
 "pDD" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -28309,9 +30978,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/miningoffice)
 "pFf" = (
@@ -28319,8 +30990,10 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "pFl" = (
@@ -28357,7 +31030,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
 "pGu" = (
@@ -28365,8 +31040,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "pGC" = (
@@ -28420,6 +31097,13 @@
 /obj/item/wallframe/apc,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"pIq" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
 "pIx" = (
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
@@ -28452,7 +31136,6 @@
 /obj/item/trash/can{
 	pixel_x = -8
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "pIO" = (
@@ -28531,8 +31214,10 @@
 /area/station/medical/medbay/central)
 "pLY" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/toilet/restrooms)
 "pMj" = (
@@ -28577,9 +31262,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/landmark/navigate_destination/tools,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/storage/primary)
 "pMy" = (
@@ -28613,9 +31300,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/science)
 "pNq" = (
@@ -28630,6 +31319,12 @@
 	},
 /turf/open/floor/iron/dark/textured_corner,
 /area/station/medical/medbay/central)
+"pNt" = (
+/obj/effect/spawner/random/structure/grille,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "pNB" = (
 /obj/item/flashlight/flare,
 /obj/item/flashlight/flare,
@@ -28657,8 +31352,10 @@
 	name = "Clothing storage"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "pNV" = (
@@ -28770,13 +31467,17 @@
 	name = "Control Room"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
 "pQk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "pQl" = (
@@ -28793,12 +31494,17 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "pQH" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -28837,10 +31543,12 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "pSn" = (
@@ -28872,7 +31580,9 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "pUq" = (
@@ -28887,7 +31597,9 @@
 /obj/machinery/computer/security/qm{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "pVm" = (
@@ -28909,7 +31621,9 @@
 /area/station/hallway/secondary/exit)
 "pWm" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/misc/testroom)
 "pWn" = (
@@ -28933,6 +31647,21 @@
 /obj/machinery/light/directional/south,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningdock/oresilo)
+"pWF" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "pWI" = (
 /obj/structure/filingcabinet{
 	pixel_x = 3
@@ -29022,9 +31751,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "pYv" = (
@@ -29036,9 +31767,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -29052,9 +31788,11 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "pZg" = (
@@ -29072,8 +31810,10 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood/cee{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/service/chapel/office)
 "pZv" = (
@@ -29081,7 +31821,6 @@
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qam" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/security/brig)
 "qar" = (
@@ -29113,9 +31852,11 @@
 /obj/effect/turf_decal/tile/neutral/half/contrasted{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "qbL" = (
@@ -29152,7 +31893,15 @@
 	id = "Cargo Privacy";
 	name = "Cargo Shutters"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/qm)
 "qct" = (
@@ -29170,9 +31919,11 @@
 "qcz" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qcO" = (
@@ -29244,7 +31995,9 @@
 /obj/structure/table,
 /obj/machinery/telephone/cargo,
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/lobby)
 "qfr" = (
@@ -29263,8 +32016,10 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "qfF" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "qfV" = (
@@ -29280,9 +32035,14 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "qgt" = (
@@ -29307,11 +32067,24 @@
 /obj/machinery/camera/autoname/directional/north,
 /turf/open/floor/deadspace/mono,
 /area/station/medical/exam_room)
+"qgP" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/commons/dorms/barracks/female)
 "qgU" = (
 /obj/machinery/camera/directional/east{
 	c_tag = "Departure Lounge - Starboard Aft"
 	},
 /obj/machinery/light/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit/departure_lounge)
 "qgZ" = (
@@ -29332,7 +32105,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "qho" = (
@@ -29367,9 +32142,17 @@
 /turf/open/floor/deadspace/grater,
 /area/station/hallway/secondary/exit)
 "qhR" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
-/turf/open/floor/deadspace/bathroom,
-/area/mine/production)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/commons/dorms/cryo)
 "qhZ" = (
 /obj/structure/rack,
 /obj/item/clothing/under/rank/medical/scrubs/purple,
@@ -29406,7 +32189,12 @@
 /turf/open/floor/engine/n2o,
 /area/station/engineering/atmos)
 "qjg" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "qjl" = (
@@ -29423,10 +32211,12 @@
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "qkb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "qki" = (
@@ -29449,7 +32239,6 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/medical{
 	name = "Port Operating Room";
 	req_access_txt = "45";
@@ -29458,6 +32247,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "qlb" = (
@@ -29473,7 +32265,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "qli" = (
@@ -29486,9 +32280,14 @@
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "qly" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/golf_brown,
-/area/mine/eva)
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "qlA" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plating,
@@ -29555,9 +32354,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/effect/landmark/navigate_destination,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "qnp" = (
@@ -29570,9 +32371,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -29733,15 +32539,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "qrQ" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "qrX" = (
@@ -29804,12 +32617,14 @@
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse/upper)
 "qtB" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
@@ -29872,7 +32687,6 @@
 /area/station/maintenance/fore/lesser)
 "quD" = (
 /obj/structure/rack,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/item/shield/riot{
 	pixel_x = 3;
@@ -29887,6 +32701,9 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced/spawner/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/ai_monitored/security/armory)
 "quN" = (
@@ -29898,8 +32715,10 @@
 	name = "Solar Access";
 	req_access_txt = "10"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
 "qvr" = (
@@ -30017,16 +32836,20 @@
 /obj/effect/turf_decal/tile/blue/fourcorners,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qyX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "qzA" = (
@@ -30072,12 +32895,9 @@
 /turf/open/floor/iron/norn,
 /area/station/medical/office)
 "qAY" = (
-/obj/effect/turf_decal/siding/purple{
-	dir = 10
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/science/lab)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/slides,
+/area/station/cargo/warehouse)
 "qBi" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table,
@@ -30103,7 +32923,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "qDn" = (
@@ -30169,7 +32991,6 @@
 	name = "First Lieutenant's Office";
 	req_access_txt = "57"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/poddoor/shutters/preopen{
 	dir = 4;
 	id = "FL room"
@@ -30177,6 +32998,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "qEC" = (
@@ -30246,18 +33070,20 @@
 /obj/structure/chair/office{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "qHk" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Waste to Filter";
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/turf/open/floor/deadspace/heavy,
+/area/station/commons/locker)
 "qHm" = (
 /obj/structure/table,
 /obj/effect/spawner/random/entertainment/cigarette_pack,
@@ -30294,7 +33120,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -30328,9 +33156,11 @@
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "qJb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "qJr" = (
@@ -30374,9 +33204,19 @@
 	spawn_loot_count = 2;
 	spawn_loot_split = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
+"qLk" = (
+/obj/effect/turf_decal/tile/neutral/fourcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/engineering/storage/tech)
 "qLm" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
@@ -30424,19 +33264,18 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "qMP" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "ceprivacy";
-	name = "privacy shutter"
+/obj/structure/railing{
+	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
-/area/station/command/heads_quarters/ce)
+/area/station/cargo/warehouse)
 "qMY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment,
@@ -30452,6 +33291,11 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/smooth_large,
 /area/station/service/chapel)
+"qNg" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/plating,
+/area/station/engineering/atmos)
 "qNt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
@@ -30487,12 +33331,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
+"qNQ" = (
+/obj/item/stack/cable_coil/cut,
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "qOa" = (
 /obj/structure/table,
 /turf/open/floor/deadspace/bathroom,
@@ -30541,6 +33391,11 @@
 /obj/structure/closet/secure_closet/ds/engineering_personal,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"qPX" = (
+/obj/effect/spawner/structure/window/reinforced/prepainted/daedalus,
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/station/engineering/atmos/storage/gas)
 "qQg" = (
 /obj/item/kirbyplants,
 /turf/open/floor/iron/dark/side{
@@ -30560,6 +33415,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
@@ -30587,8 +33445,10 @@
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "qRz" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "qRI" = (
@@ -30626,6 +33486,14 @@
 /obj/effect/spawner/structure/window/reinforced/grille,
 /turf/open/floor/plating,
 /area/misc/testroom)
+"qSt" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/medical/break_room)
 "qSB" = (
 /obj/structure/chair/sofa/bench/right{
 	dir = 4
@@ -30651,7 +33519,9 @@
 /area/station/engineering/atmos)
 "qTj" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "qTV" = (
@@ -30683,7 +33553,6 @@
 /area/station/cargo/storage)
 "qUr" = (
 /obj/structure/disposalpipe/junction/yjunction,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "qUA" = (
@@ -30699,7 +33568,6 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
 "qUK" = (
@@ -30714,9 +33582,11 @@
 /area/station/medical/break_room)
 "qUM" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/central)
 "qVj" = (
@@ -30806,16 +33676,20 @@
 	req_one_access_txt = "23;30"
 	},
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/landmark/navigate_destination,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/maintenance/starboard/aft)
 "qXk" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 8
 	},
@@ -30862,9 +33736,11 @@
 "qYZ" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "qZb" = (
@@ -30930,9 +33806,11 @@
 /area/station/service/hydroponics)
 "rbz" = (
 /obj/machinery/camera/motion/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/brig)
 "rbD" = (
@@ -30962,7 +33840,9 @@
 	dir = 8
 	},
 /obj/machinery/telephone/service,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "rca" = (
@@ -31006,6 +33886,12 @@
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
+"rdf" = (
+/obj/structure/cable/yellow{
+	icon_state = "24"
+	},
+/turf/open/floor/plating,
+/area/aegis/surface)
 "rdm" = (
 /obj/structure/railing{
 	dir = 5
@@ -31022,7 +33908,9 @@
 /obj/effect/turf_decal/siding/white{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/side,
 /area/station/science/lab)
 "rdS" = (
@@ -31042,8 +33930,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
 "reC" = (
@@ -31066,7 +33956,9 @@
 /turf/open/floor/stone,
 /area/aegis/surface)
 "rfJ" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo)
 "rfR" = (
@@ -31162,11 +34054,22 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
 "riO" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/science)
 "riQ" = (
@@ -31276,10 +34179,12 @@
 /area/station/cargo/warehouse/upper)
 "rlA" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rlC" = (
@@ -31290,7 +34195,12 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "rlP" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/secondary/exit)
 "rlS" = (
@@ -31300,13 +34210,19 @@
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "rlW" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command blast"
 	},
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "rma" = (
 /obj/machinery/camera/directional/south{
 	c_tag = "Cryo - Left"
@@ -31348,7 +34264,6 @@
 /area/station/maintenance/fore/lesser)
 "rnc" = (
 /obj/effect/landmark/pestspawn,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -31401,9 +34316,13 @@
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
 "rpe" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/grater,
-/area/aegis/mining)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "rpp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -31430,9 +34349,11 @@
 	dir = 4;
 	id = "Psec command"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_gray,
 /area/station/command/heads_quarters/hos)
 "rpS" = (
@@ -31491,8 +34412,20 @@
 /area/station/maintenance/fore/lesser)
 "rrw" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/plating,
 /area/station/cargo/lobby)
+"rrK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/cargo/warehouse)
 "rrP" = (
 /obj/effect/spawner/random/structure/tank_holder,
 /obj/machinery/light_switch/directional/west,
@@ -31538,17 +34471,21 @@
 /obj/machinery/door/airlock/mining{
 	name = "Mining Refining Room"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningdock/oresilo)
 "rtC" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right{
 	dir = 8
 	},
@@ -31565,21 +34502,26 @@
 /area/station/security/lockers)
 "ruf" = (
 /obj/structure/rack,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/effect/spawner/random/medical/medkit,
 /obj/structure/window/reinforced/spawner/east,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/ai_monitored/security/armory)
 "ruh" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "rui" = (
@@ -31593,6 +34535,7 @@
 /obj/structure/closet/secure_closet/psychology,
 /obj/item/clothing/neck/necklace/marker,
 /obj/item/clothing/neck/necklace/marker,
+/obj/machinery/light/directional/east,
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "ruE" = (
@@ -31604,7 +34547,9 @@
 "ruP" = (
 /obj/effect/spawner/random/vending/colavend,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "rva" = (
@@ -31619,6 +34564,12 @@
 /obj/effect/turf_decal/tile/bar,
 /turf/open/floor/iron/white,
 /area/station/commons/lounge)
+"rvn" = (
+/obj/structure/cable/yellow{
+	icon_state = "40"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "rvx" = (
 /obj/structure/table,
 /obj/effect/spawner/random/engineering/tool,
@@ -31654,8 +34605,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "rwS" = (
@@ -31731,9 +34684,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "rzw" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/office)
 "rzy" = (
@@ -31748,9 +34703,11 @@
 	},
 /area/station/hallway/primary/fore)
 "rAb" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "rAl" = (
@@ -31780,7 +34737,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
 	},
@@ -31797,8 +34753,13 @@
 /turf/open/floor/deadspace/grille_spare1,
 /area/mine/storage)
 "rBk" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/white{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/service/chapel/monastery)
 "rBn" = (
@@ -31824,16 +34785,20 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
 "rCd" = (
 /obj/structure/table,
 /obj/machinery/telephone/service,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
@@ -31853,15 +34818,17 @@
 	},
 /area/station/hallway/primary/central/aft)
 "rCI" = (
-/obj/structure/table/reinforced,
-/obj/effect/spawner/random/engineering/tool,
-/obj/effect/spawner/random/engineering/tool,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/maint_center,
-/area/aegis/mining)
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "rCX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
@@ -31890,15 +34857,27 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "rDI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/cable_end,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/maint_center{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "rDN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
@@ -31907,11 +34886,7 @@
 /area/station/engineering/storage_shared)
 "rDV" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for monitoring the engine.";
 	dir = 8;
@@ -31931,13 +34906,14 @@
 /turf/closed/wall/r_wall,
 /area/station/maintenance/solars/port/fore)
 "rEC" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/security/courtroom)
 "rEZ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/yellow/filled/warning{
 	dir = 1
 	},
@@ -31962,9 +34938,14 @@
 /area/station/hallway/primary/fore)
 "rGh" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/secondary/exit/departure_lounge)
 "rGI" = (
@@ -32003,9 +34984,11 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/landmark/pestspawn,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/disposal)
 "rIo" = (
@@ -32025,7 +35008,9 @@
 /area/station/cargo/storage)
 "rIu" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "rIL" = (
@@ -32039,9 +35024,8 @@
 	name = "Cargo Privacy Control";
 	id = "Cargo Privacy"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
@@ -32087,7 +35071,9 @@
 	pixel_y = -3
 	},
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "rJS" = (
@@ -32095,7 +35081,6 @@
 	name = "P-Sec Upper Hallway";
 	req_access_txt = "63"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -32106,11 +35091,13 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/surgery/theatre)
 "rKj" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 5
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/grater,
 /area/station/security/brig/upper)
@@ -32142,9 +35129,11 @@
 /turf/open/floor/deadspace/mono,
 /area/station/cargo)
 "rKO" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "rKS" = (
@@ -32157,13 +35146,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/airlock/security{
 	dir = 1;
 	name = "P-Sec Looker Room";
 	req_one_access_txt = "1;4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/lockers)
@@ -32194,11 +35185,22 @@
 /obj/structure/table,
 /turf/open/floor/iron/white,
 /area/station/maintenance/fore/lesser)
+"rMC" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/grille_spare3,
+/area/station/security/checkpoint/customs)
 "rMK" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "rML" = (
@@ -32241,7 +35243,6 @@
 /area/station/maintenance/port/lesser)
 "rNh" = (
 /obj/machinery/light/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
 "rND" = (
@@ -32255,6 +35256,19 @@
 	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/courtroom)
+"rNT" = (
+/obj/effect/turf_decal/tile/bar/opposingcorners,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/white,
+/area/station/service/kitchen)
 "rOn" = (
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/tcomms,
@@ -32336,12 +35350,17 @@
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
 "rQA" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
 	},
-/obj/structure/lattice,
-/turf/open/misc/asteroid,
-/area/aegis/surface)
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/security/brig/upper)
 "rQK" = (
 /obj/structure/table/reinforced,
 /obj/effect/spawner/random/engineering/tool,
@@ -32399,8 +35418,10 @@
 /obj/machinery/door/airlock/command/glass{
 	name = "Shuttle Bay"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/customs)
 "rTK" = (
@@ -32425,18 +35446,20 @@
 /turf/open/floor/deadspace/grater,
 /area/station/command/bridge)
 "rTT" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/mine/eva)
+/obj/structure/cable/yellow{
+	icon_state = "129"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "rTW" = (
 /obj/machinery/telecomms/server/presets/common,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/station/tcommsat/server)
 "rUa" = (
-/obj/machinery/atmospherics/pipe/smart/simple/dark/visible{
+/obj/machinery/atmospherics/pipe/layer_manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/iron/ported/techfloor,
+/turf/closed/wall/r_wall,
 /area/station/engineering/supermatter/room)
 "rUg" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
@@ -32477,7 +35500,15 @@
 	dir = 5
 	},
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "rVz" = (
@@ -32490,10 +35521,11 @@
 	req_access_txt = "29"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/robotics/mechbay)
 "rVF" = (
@@ -32511,14 +35543,18 @@
 	},
 /area/station/science/lab)
 "rWq" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grille_spare3,
 /area/station/security/checkpoint/customs)
 "rWy" = (
 /obj/machinery/atmospherics/pipe/smart/simple/pink/visible{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "rWC" = (
@@ -32538,11 +35574,10 @@
 /turf/open/floor/plating,
 /area/station/medical/surgery/theatre)
 "rXD" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/maint_right{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "rXE" = (
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
@@ -32599,7 +35634,6 @@
 	},
 /obj/effect/mapping_helpers/airlock/unres,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "saC" = (
@@ -32735,10 +35769,12 @@
 	},
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningoffice)
 "sfP" = (
@@ -32757,8 +35793,10 @@
 /area/station/commons/dorms/barracks/male)
 "sga" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
 "sgo" = (
@@ -32793,11 +35831,25 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
+"shj" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
 "shk" = (
 /obj/machinery/light/small/directional/west,
 /obj/structure/disposalpipe/segment{
@@ -32832,6 +35884,17 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/service/chapel)
+"sis" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/lobby)
 "siV" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/shutters{
@@ -32843,7 +35906,9 @@
 "sjv" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain)
 "sjI" = (
@@ -32863,7 +35928,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/hallway/secondary/exit)
 "sjP" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/security/interrogation)
 "ski" = (
@@ -32883,9 +35953,11 @@
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/toilet/restrooms)
 "sku" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/hallway/primary/central/aft)
 "skN" = (
@@ -32919,6 +35991,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "slN" = (
@@ -32937,7 +36012,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/heavy,
 /area/station/commons/locker)
 "slP" = (
@@ -32947,9 +36024,11 @@
 /area/station/maintenance/port/lesser)
 "smg" = (
 /obj/effect/turf_decal/tile/blue/half/contrasted,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
@@ -33009,6 +36088,9 @@
 /obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/norn,
 /area/station/hallway/primary/central)
 "snw" = (
@@ -33023,9 +36105,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/mine/production)
 "soj" = (
@@ -33035,9 +36122,11 @@
 	},
 /obj/effect/landmark/navigate_destination/tools,
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/norn,
 /area/station/commons/storage/tools)
 "sos" = (
@@ -33099,10 +36188,12 @@
 	req_one_access_txt = "32;19"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "spQ" = (
@@ -33170,15 +36261,19 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "ssE" = (
 /obj/machinery/light/small/maintenance/directional/south,
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/service/chapel/monastery)
 "ssV" = (
@@ -33188,9 +36283,24 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/wood,
 /area/station/commons/lounge)
+"stc" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/command/bridge)
+"stX" = (
+/obj/structure/cable/yellow{
+	icon_state = "132"
+	},
+/turf/open/misc/asteroid,
+/area/aegis/surface)
 "sua" = (
 /obj/machinery/computer/secure_data{
 	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/checkpoint/customs)
@@ -33200,9 +36310,11 @@
 /area/station/engineering/storage_shared)
 "suq" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right{
 	dir = 8
 	},
@@ -33225,6 +36337,22 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
+"svi" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/turf/open/floor/plating,
+/area/station/hallway/secondary/exit)
+"svl" = (
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/norn,
+/area/station/hallway/primary/central)
 "svo" = (
 /obj/structure/rack/shelf,
 /obj/effect/turf_decal/bot_white,
@@ -33287,7 +36415,10 @@
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/misc/asteroid,
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
 /area/aegis/surface)
 "sxb" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5{
@@ -33327,7 +36458,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/security/interrogation)
 "sxJ" = (
@@ -33415,18 +36548,24 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
 "sAF" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "sAH" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "sAQ" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/misc/testroom)
 "sAS" = (
@@ -33449,17 +36588,18 @@
 /area/station/security/brig)
 "sBp" = (
 /obj/effect/turf_decal/tile/yellow/half/contrasted,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "sCc" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/components/unary/passive_vent{
-	dir = 4
+/obj/structure/lattice,
+/turf/open/misc/asteroid{
+	simulated = 0
 	},
-/turf/open/misc/asteroid,
 /area/aegis/surface)
 "sCd" = (
 /obj/structure/closet/crate/large,
@@ -33471,9 +36611,11 @@
 "sCh" = (
 /obj/structure/table,
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/fax_machine,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "sCq" = (
@@ -33522,10 +36664,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/cable/yellow{
 	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
@@ -33545,7 +36689,9 @@
 /area/station/engineering/atmos)
 "sEi" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "sEl" = (
@@ -33555,7 +36701,9 @@
 "sEx" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "sEz" = (
@@ -33583,6 +36731,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "sEW" = (
@@ -33598,6 +36749,13 @@
 "sFi" = (
 /turf/closed/wall/r_wall,
 /area/station/commons/locker)
+"sFy" = (
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "sFB" = (
 /obj/machinery/door/firedoor,
 /obj/effect/spawner/structure/window/reinforced/grille,
@@ -33655,7 +36813,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
@@ -33680,12 +36837,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse/upper)
 "sJD" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "sJI" = (
@@ -33700,7 +36859,6 @@
 /area/aegis/mining)
 "sJV" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -33778,11 +36936,13 @@
 /turf/open/floor/deadspace/random/slides,
 /area/aegis/hanger)
 "sMX" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold/scrubbers/visible,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "sMY" = (
@@ -33813,9 +36973,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
 "sNc" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -33834,9 +36996,11 @@
 	req_access_txt = "48"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/miningoffice)
 "sNO" = (
@@ -33885,14 +37049,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "sPk" = (
-/obj/effect/spawner/structure/window/reinforced/grille,
-/obj/machinery/door/poddoor/preopen{
-	id = "rdoffice";
-	name = "Research Director's Shutters"
-	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/plating,
-/area/station/command/heads_quarters/rd)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "sPH" = (
 /obj/effect/spawner/random/structure/closet_maintenance,
 /obj/effect/turf_decal/bot,
@@ -33980,6 +37139,9 @@
 /obj/item/radio/intercom/directional/east,
 /obj/item/radio/intercom/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "sSP" = (
@@ -34003,8 +37165,10 @@
 /area/station/hallway/primary/central)
 "sTl" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "sTR" = (
@@ -34012,13 +37176,15 @@
 	dir = 1;
 	name = "Bridge"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -34087,14 +37253,19 @@
 "sVe" = (
 /obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "sVh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/storage/toolbox/electrical,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
 "sVq" = (
@@ -34212,9 +37383,11 @@
 /area/station/hallway/primary/central/aft)
 "sXZ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -34230,7 +37403,15 @@
 /area/station/command/heads_quarters/cmo)
 "sYk" = (
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 8
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "sYm" = (
@@ -34252,6 +37433,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
 "sYz" = (
@@ -34264,7 +37448,6 @@
 	name = "Cabin 3"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/ported/lino,
@@ -34282,11 +37465,13 @@
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
 "tak" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "taJ" = (
@@ -34303,10 +37488,12 @@
 /obj/effect/turf_decal/tile/red/half/contrasted{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/firealarm/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "tbB" = (
@@ -34328,18 +37515,25 @@
 /area/station/cargo/warehouse)
 "tcQ" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tcX" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tda" = (
@@ -34403,7 +37597,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
 	req_one_access_txt = "10;24"
@@ -34411,6 +37604,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "tfu" = (
@@ -34424,15 +37620,21 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "tfU" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible/layer5,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "tfW" = (
@@ -34458,7 +37660,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/pharmacy)
 "tgq" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "tgs" = (
@@ -34474,7 +37678,9 @@
 /area/station/science/robotics/mechbay)
 "tgY" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
 "thc" = (
@@ -34565,7 +37771,9 @@
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "tjm" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
 "tjo" = (
@@ -34601,6 +37809,12 @@
 /obj/machinery/computer/med_data,
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"tkH" = (
+/obj/structure/cable/yellow{
+	icon_state = "18"
+	},
+/turf/open/misc/ironsand,
+/area/aegis/surface)
 "tkZ" = (
 /obj/item/stack/rods,
 /turf/open/floor/deadspace/grater,
@@ -34633,6 +37847,9 @@
 /obj/item/paper_bin,
 /obj/item/folder/white,
 /obj/item/pen/blue,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "tmo" = (
@@ -34663,10 +37880,12 @@
 	name = "Quartermaster";
 	req_access_txt = "41"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "tmZ" = (
@@ -34703,10 +37922,12 @@
 "toB" = (
 /obj/structure/table/reinforced,
 /obj/machinery/telephone/security,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig/upper)
 "toS" = (
@@ -34714,6 +37935,15 @@
 /obj/machinery/gibber,
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
+"tpi" = (
+/obj/machinery/modular_computer/console/preset/engineering{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/monitoring)
 "tpk" = (
 /obj/machinery/door/airlock/external{
 	name = "Cave-In Shelter 2"
@@ -34754,12 +37984,9 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/brig)
 "trK" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 6
-	},
-/obj/machinery/meter,
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
+/obj/machinery/light/small/directional/south,
+/turf/open/floor/plating,
+/area/station/service/hydroponics)
 "trL" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -34791,8 +38018,10 @@
 /obj/machinery/power/apc/auto_name/directional/south,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/iv_drip,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/iron/white,
 /area/station/security/medical)
 "ttp" = (
@@ -34803,10 +38032,12 @@
 /turf/open/floor/grass,
 /area/station/hallway/secondary/exit/departure_lounge)
 "ttr" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/button/door/directional/south{
 	id = "Maints Lockdown";
 	name = "Maints Lockdown"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
@@ -34841,9 +38072,11 @@
 	icon_state = "pipe-y";
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "tuv" = (
@@ -34881,6 +38114,9 @@
 /obj/item/computer_hardware/hard_drive/role/quartermaster,
 /obj/item/computer_hardware/hard_drive/role/quartermaster,
 /obj/item/computer_hardware/hard_drive/role/quartermaster,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "tuG" = (
@@ -35040,12 +38276,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "tyE" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/visible{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "tyN" = (
@@ -35071,11 +38309,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
@@ -35101,6 +38341,12 @@
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"tAy" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "tAI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/iron/norn,
@@ -35111,6 +38357,14 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
+"tAZ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/stone,
+/area/aegis/surface)
 "tBf" = (
 /turf/open/floor/iron/dark/side{
 	dir = 4
@@ -35144,6 +38398,20 @@
 /obj/machinery/power/data_terminal,
 /turf/open/floor/deadspace/mono,
 /area/station/command/heads_quarters/hos)
+"tBK" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "tBM" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/slides{
@@ -35155,11 +38423,16 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/surface)
 "tCw" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
@@ -35169,7 +38442,15 @@
 /area/aegis/surface)
 "tCy" = (
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 2
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "tCR" = (
@@ -35223,7 +38504,6 @@
 /area/station/engineering/supermatter/room)
 "tEB" = (
 /obj/structure/table,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/monitoring)
 "tEL" = (
@@ -35262,6 +38542,17 @@
 /obj/item/storage/medkit/surgery,
 /turf/closed/wall/r_wall,
 /area/station/medical/medbay/aft)
+"tGC" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/command/bridge)
 "tHg" = (
 /obj/machinery/light/small/directional/south,
 /obj/machinery/icecream_vat,
@@ -35271,18 +38562,20 @@
 /turf/open/floor/iron/kitchen_coldroom/freezerfloor,
 /area/station/service/kitchen/coldroom)
 "tHh" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/starboard/upper)
 "tHX" = (
 /turf/open/floor/deadspace/bathroom,
 /area/station/commons/dorms/barracks/male)
 "tIj" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/command/bridge)
 "tIu" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/maint_right,
@@ -35301,7 +38594,6 @@
 	},
 /obj/machinery/telephone/research,
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/misc_lab)
 "tJM" = (
@@ -35315,15 +38607,21 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/atmospheric_technician,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "tKq" = (
 /obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "tKw" = (
@@ -35335,7 +38633,6 @@
 "tKA" = (
 /obj/item/restraints/legcuffs/beartrap,
 /obj/item/restraints/legcuffs/beartrap,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/janitor)
 "tKI" = (
@@ -35351,7 +38648,9 @@
 /obj/item/radio/intercom/directional/east,
 /obj/item/pen,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/security/interrogation)
 "tKJ" = (
@@ -35377,6 +38676,17 @@
 /obj/structure/table,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"tLC" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Solar Access";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "tLZ" = (
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
@@ -35385,7 +38695,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/commons/dorms/cryo)
 "tMw" = (
@@ -35398,7 +38710,9 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "tMP" = (
@@ -35415,10 +38729,7 @@
 	name = "Aegis Cargo"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/side{
 	dir = 8
 	},
@@ -35433,12 +38744,16 @@
 	},
 /area/station/hallway/primary/starboard)
 "tNh" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
+/obj/structure/disposalpipe/junction{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/white,
-/area/station/science/research)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "tNI" = (
 /obj/structure/sign/directions/engineering{
 	dir = 4;
@@ -35493,7 +38808,9 @@
 	req_access_txt = "30"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/rd)
 "tQv" = (
@@ -35510,8 +38827,13 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "tQQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/grimy,
 /area/station/tcommsat/computer)
 "tQR" = (
@@ -35566,9 +38888,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "tSh" = (
@@ -35584,7 +38908,9 @@
 /area/station/commons/dorms/barracks/female)
 "tSG" = (
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/white{
+	icon_state = "1"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/storage)
 "tSM" = (
@@ -35598,9 +38924,11 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "tSR" = (
@@ -35614,10 +38942,15 @@
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "tSY" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "tTd" = (
@@ -35628,8 +38961,10 @@
 /area/aegis/surface)
 "tTg" = (
 /obj/machinery/computer/security,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/apc/auto_name/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "tTm" = (
@@ -35641,12 +38976,14 @@
 /turf/open/openspace,
 /area/station/service/chapel)
 "tTv" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "tTR" = (
@@ -35661,6 +38998,18 @@
 /obj/item/storage/box/swabs,
 /turf/open/floor/deadspace/mono,
 /area/station/security/detectives_office)
+"tUq" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable/smart_cable/color/yellow,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/maintenance/starboard/aft)
 "tUB" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/deadspace/random/golf_gray,
@@ -35696,9 +39045,11 @@
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "tVl" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -35709,7 +39060,6 @@
 /turf/open/water,
 /area/station/hallway/primary/aft)
 "tVH" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
@@ -35720,6 +39070,9 @@
 /area/aegis/surface)
 "tWq" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
 /area/station/security/brig)
 "tWL" = (
@@ -35761,6 +39114,20 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
+"tXm" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "window command blast"
+	},
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/plating,
+/area/station/command/bridge)
 "tXB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 1
@@ -35778,7 +39145,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/directional/south,
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
@@ -35791,7 +39157,6 @@
 "tYc" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/keycard_auth/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -35842,9 +39207,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "tZw" = (
@@ -35871,9 +39238,11 @@
 /area/station/hallway/secondary/exit)
 "uaF" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
 "ubd" = (
@@ -35894,7 +39263,6 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron,
 /area/station/service/bar)
 "ubx" = (
@@ -35996,13 +39364,15 @@
 /area/station/engineering/main)
 "ueG" = (
 /obj/structure/table,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/item/multitool/circuit{
 	pixel_x = 7
 	},
 /obj/item/multitool/circuit,
 /obj/item/multitool/circuit{
 	pixel_x = -8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
@@ -36015,6 +39385,20 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
+"ueM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "ufc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -36046,10 +39430,16 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/norn,
 /area/station/service/hydroponics/upper)
+"ugP" = (
+/obj/machinery/atmospherics/pipe/layer_manifold/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "ugU" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/item/stack/ore/iron,
@@ -36071,9 +39461,11 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
 "uhr" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "uhA" = (
@@ -36110,10 +39502,12 @@
 /turf/open/floor/iron/kitchen_coldroom,
 /area/station/medical/coldroom)
 "ujM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "ujU" = (
@@ -36147,7 +39541,6 @@
 	dir = 1
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/engineering{
 	name = "Engine Room";
 	req_one_access_txt = "10;24"
@@ -36155,6 +39548,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "ukB" = (
@@ -36162,6 +39558,9 @@
 /area/station/cargo/drone_bay)
 "ukH" = (
 /obj/machinery/light_switch/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "ukL" = (
@@ -36190,6 +39589,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
+"ulv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/wood,
+/area/station/security/detectives_office)
 "uly" = (
 /obj/structure/table/wood/poker,
 /obj/effect/spawner/random/entertainment/money_large,
@@ -36238,7 +39644,6 @@
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
 /obj/effect/spawner/random/maintenance,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
 "umU" = (
@@ -36344,15 +39749,16 @@
 	name = "Equipment Closet";
 	req_access_txt = "11"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "uor" = (
 /obj/machinery/firealarm/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/hydroponics)
 "uoA" = (
@@ -36376,7 +39782,9 @@
 	id = "ceprivacy";
 	name = "privacy shutter"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
 "upl" = (
@@ -36384,8 +39792,10 @@
 /obj/structure/rack,
 /obj/item/mod/control/pre_equipped/ds/intermediate_engineer,
 /obj/item/mod/control/pre_equipped/ds/intermediate_engineer,
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /obj/item/disk/holodisk/ds13/ce,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "upr" = (
@@ -36394,6 +39804,14 @@
 /obj/effect/spawner/random/entertainment/lighter,
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/brig)
+"upx" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/science/breakroom)
 "upz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -36465,10 +39883,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "ure" = (
@@ -36496,9 +39916,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/checkpoint/customs)
 "ust" = (
@@ -36514,7 +39936,9 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "usC" = (
@@ -36531,9 +39955,11 @@
 /turf/open/misc/asteroid,
 /area/aegis/surface)
 "uta" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "utw" = (
@@ -36588,8 +40014,10 @@
 /area/station/engineering/atmos)
 "uuA" = (
 /obj/item/kirbyplants/photosynthetic,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light_switch/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/hos)
 "uuB" = (
@@ -36603,11 +40031,19 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"uuR" = (
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock/cafeteria)
 "uuS" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 4
+	},
+/turf/open/floor/deadspace/random/maint_center,
+/area/station/security/brig)
 "uvc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -36625,15 +40061,23 @@
 /obj/effect/turf_decal/tile/blue/half/contrasted{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "uvA" = (
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "uvC" = (
@@ -36670,7 +40114,9 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood/corner{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
 "uxv" = (
@@ -36694,9 +40140,15 @@
 /turf/closed/wall/r_wall,
 /area/station/security/interrogation)
 "uyg" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/cable_start,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/effect/spawner/structure/window/reinforced/plasma,
+/obj/structure/cable/red{
+	icon_state = "3"
+	},
+/obj/structure/cable/red{
+	icon_state = "2"
+	},
+/turf/open/floor/plating,
+/area/station/engineering/supermatter/room)
 "uyk" = (
 /obj/effect/turf_decal/box,
 /obj/machinery/vending/hydroseeds,
@@ -36836,7 +40288,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
 "uAN" = (
@@ -36847,7 +40301,15 @@
 /area/station/hallway/primary/central)
 "uBz" = (
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
+/obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
+	dir = 2
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo)
 "uBM" = (
@@ -36870,9 +40332,6 @@
 "uBT" = (
 /obj/structure/chair/stool/directional/north,
 /obj/item/radio/intercom/directional/west,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
-	dir = 4
-	},
 /turf/open/floor/carpet/red,
 /area/station/commons/lounge)
 "uCa" = (
@@ -36886,8 +40345,10 @@
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/maintenance/starboard/greater)
 "uCj" = (
@@ -36914,12 +40375,14 @@
 /turf/open/floor/deadspace/grille_spare2,
 /area/aegis/surface)
 "uCR" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/medbay/aft)
 "uDn" = (
@@ -36945,6 +40408,9 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/range)
 "uEm" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "uEr" = (
@@ -36954,7 +40420,9 @@
 "uFb" = (
 /obj/machinery/power/apc/auto_name/directional/east,
 /obj/structure/table,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/living_quarters)
 "uFg" = (
@@ -36963,11 +40431,23 @@
 "uFs" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
+"uFw" = (
+/obj/effect/turf_decal/box,
+/obj/effect/spawner/random/clothing/wardrobe_closet,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/cargo)
 "uFY" = (
 /obj/machinery/telecomms/processor/preset_three,
 /obj/machinery/camera/directional/north{
@@ -36978,10 +40458,12 @@
 /area/station/tcommsat/server)
 "uGc" = (
 /obj/structure/table/wood,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/item/restraints/handcuffs,
 /obj/machinery/telephone/security,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/wood,
 /area/station/security/detectives_office)
 "uGo" = (
@@ -37001,9 +40483,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lab)
 "uGP" = (
@@ -37011,9 +40495,14 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "uGU" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/break_room)
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/plating,
+/area/station/maintenance/solars/port/fore)
 "uHB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -37028,7 +40517,6 @@
 	req_one_access_txt = "31;48"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
@@ -37041,13 +40529,15 @@
 /area/station/commons/dorms/barracks/female)
 "uIr" = (
 /obj/structure/table/glass,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
 /obj/machinery/telephone/service{
 	friendly_name = "Chemistry";
 	placard_name = "Medical PBX"
 	},
 /obj/machinery/newscaster/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/chemistry)
 "uIw" = (
@@ -37086,10 +40576,15 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "uKm" = (
@@ -37123,14 +40618,18 @@
 	id = "Mining Privacy";
 	name = "Mining Shutters"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/qm)
 "uLE" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
@@ -37143,6 +40642,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/lobby)
 "uME" = (
@@ -37150,18 +40652,22 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/directional/west,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "uMH" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse)
 "uNp" = (
@@ -37169,7 +40675,9 @@
 	name = "Chapel Office Maintenance";
 	req_one_access_txt = "22"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/white{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/monastery)
 "uNu" = (
@@ -37216,7 +40724,6 @@
 	c_tag = "Engineering - Foyer - Shared Storage"
 	},
 /obj/structure/sign/poster/official/random/directional/west,
-/obj/machinery/airalarm/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
 "uOK" = (
@@ -37236,6 +40743,10 @@
 	},
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/service/chapel/monastery)
+"uQc" = (
+/obj/item/stack/cable_coil/cut,
+/turf/open/misc/asteroid,
+/area/station/solars/port/fore)
 "uQf" = (
 /obj/structure/chair/office{
 	dir = 4
@@ -37272,9 +40783,9 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "uQN" = (
-/obj/structure/reagent_dispensers/fueltank/large,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/engineering/atmos)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "uQT" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/structure/window/reinforced/spawner/north,
@@ -37316,11 +40827,16 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/mine/eva)
 "uSd" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/tech{
 	dir = 4
 	},
@@ -37352,7 +40868,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig)
 "uSY" = (
@@ -37427,7 +40945,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
@@ -37483,6 +41000,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
 "uWt" = (
@@ -37535,11 +41055,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/surgery)
 "uXv" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "uXE" = (
@@ -37625,9 +41148,11 @@
 /obj/machinery/door/airlock/maintenance{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/aft)
 "uZP" = (
@@ -37644,12 +41169,14 @@
 /area/station/engineering/atmos/storage/gas)
 "val" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
 "vap" = (
@@ -37659,6 +41186,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden,
 /turf/open/floor/iron/dark/textured,
 /area/station/medical/cryo)
 "vat" = (
@@ -37706,15 +41234,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "vbA" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
 /obj/effect/turf_decal/siding/wood,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "vbE" = (
@@ -37733,6 +41265,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/wood,
 /area/station/command/heads_quarters/cmo)
 "vbY" = (
@@ -37747,9 +41285,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
@@ -37788,7 +41328,9 @@
 /turf/open/floor/iron/ported/lino,
 /area/station/service/library)
 "vet" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/maintenance/department/engine)
 "vew" = (
@@ -37806,7 +41348,9 @@
 /area/station/maintenance/fore/lesser)
 "veP" = (
 /obj/machinery/computer/secure_data,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/security/warden)
 "vfg" = (
@@ -37825,14 +41369,15 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
 "vfu" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "vfL" = (
 /obj/machinery/door/airlock/mining,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
 "vfS" = (
@@ -37869,8 +41414,10 @@
 /turf/open/floor/deadspace/random/golf_brown,
 /area/aegis/mining)
 "vhO" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/service/chapel)
 "vib" = (
@@ -37934,9 +41481,11 @@
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/miningoffice)
 "vky" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "vkH" = (
@@ -37983,10 +41532,12 @@
 	name = "Surgery Observation";
 	stripe_paint = "#DE3A3A"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/medical/surgery/theatre)
 "vld" = (
@@ -38059,21 +41610,31 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vmk" = (
 /turf/closed/wall/r_wall,
 /area/mine/hydroponics)
-"vmK" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+"vmF" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/engineering/main)
+"vmK" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/open/floor/deadspace/random/slides,
+/area/station/cargo/warehouse)
 "vmO" = (
 /obj/machinery/light/directional/north,
 /obj/effect/turf_decal/stripes/line{
@@ -38146,8 +41707,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/siding/blue,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "vqm" = (
@@ -38164,12 +41727,14 @@
 /turf/open/floor/iron/white,
 /area/station/medical/treatment_center)
 "vqr" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/engineering/main)
 "vqw" = (
@@ -38217,9 +41782,14 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/robotics/lab)
 "vsj" = (
@@ -38229,10 +41799,18 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/rd)
 "vsp" = (
@@ -38260,12 +41838,16 @@
 /area/station/engineering/main)
 "vsC" = (
 /obj/machinery/light/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/warehouse)
 "vsE" = (
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/fore/greater)
 "vsH" = (
@@ -38289,6 +41871,10 @@
 "vtr" = (
 /obj/effect/landmark/navigate_destination/cargo,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "vtX" = (
@@ -38320,6 +41906,20 @@
 	dir = 9
 	},
 /area/station/hallway/primary/starboard)
+"vvb" = (
+/obj/structure/disposalpipe/junction{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/white,
+/area/station/medical/medbay/central)
 "vvj" = (
 /turf/open/floor/deadspace/random/maint_center,
 /area/aegis/surface)
@@ -38333,14 +41933,15 @@
 /obj/structure/window/reinforced/spawner/east,
 /obj/item/clothing/mask/gas/clown_hat,
 /obj/structure/closet/secure_closet/personal,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/wood,
 /area/aegis/mining)
 "vvz" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/table,
 /obj/item/stack/splint,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "vvK" = (
@@ -38348,9 +41949,11 @@
 /obj/structure/disposalpipe/junction{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "vwd" = (
@@ -38364,15 +41967,19 @@
 "vwt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "vwz" = (
-/obj/effect/floor_decal/ds/spline/fancy/wood,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/carpet/royalblack,
-/area/station/cargo/lobby)
+/obj/effect/turf_decal/tile/neutral/opposingcorners,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/turf/open/floor/iron/dark,
+/area/station/cargo/miningdock/cafeteria)
 "vwZ" = (
 /obj/structure/sign/cec/deck/research{
 	pixel_y = -32
@@ -38545,17 +42152,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
 "vBz" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Distro to Waste"
-	},
 /obj/machinery/light/small/directional/west,
+/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "vBI" = (
@@ -38676,8 +42283,11 @@
 	dir = 9
 	},
 /obj/effect/landmark/navigate_destination/disposals,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "vFk" = (
@@ -38760,9 +42370,11 @@
 "vHE" = (
 /obj/effect/turf_decal/tile/bar/opposingcorners,
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/service/kitchen)
 "vHV" = (
@@ -38785,7 +42397,12 @@
 /obj/effect/turf_decal/siding/wood{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "vIJ" = (
@@ -38796,17 +42413,24 @@
 /turf/open/floor/plating,
 /area/station/maintenance/port/lesser)
 "vIQ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "vIY" = (
 /obj/machinery/pdapainter,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
 "vJc" = (
@@ -38834,12 +42458,14 @@
 	stripe_paint = "#52B4E9"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/storage)
 "vJE" = (
@@ -38971,12 +42597,14 @@
 "vMD" = (
 /obj/structure/disposalpipe/trunk/multiz,
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4"
 	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
@@ -38987,7 +42615,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
 "vMK" = (
@@ -39015,6 +42645,9 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/structure/disposalpipe/junction/flip,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/commons/dorms/barracks/female)
 "vNo" = (
@@ -39023,7 +42656,9 @@
 "vNC" = (
 /obj/structure/window/reinforced/spawner/west,
 /obj/machinery/light/small/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/engine,
 /area/station/science/misc_lab/range)
 "vNP" = (
@@ -39034,8 +42669,10 @@
 	name = "Cold Storage";
 	req_access_txt = "45"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/kitchen_coldroom,
 /area/station/medical/coldroom)
 "vPr" = (
@@ -39061,15 +42698,25 @@
 	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"vPL" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "vPM" = (
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/hallway/primary/fore)
 "vQc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/morgue)
@@ -39096,9 +42743,11 @@
 	dir = 8
 	},
 /obj/effect/landmark/navigate_destination/library,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/carpet/royalblue,
 /area/station/service/library)
 "vQr" = (
@@ -39136,17 +42785,18 @@
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "vRc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "vRx" = (
@@ -39204,17 +42854,21 @@
 /turf/open/floor/plating,
 /area/station/engineering/supermatter/room)
 "vTd" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tcomms)
 "vTq" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
 /obj/structure/table/reinforced,
 /obj/machinery/telephone/cargo,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/power/data_terminal,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "vTv" = (
@@ -39225,7 +42879,7 @@
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/bridge_pipe/supply/visible,
+/obj/machinery/atmospherics/pipe/bridge_pipe/supply/hidden,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "vTF" = (
@@ -39237,6 +42891,9 @@
 "vTH" = (
 /obj/machinery/keycard_auth,
 /obj/structure/table/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "vTK" = (
@@ -39311,7 +42968,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
 /obj/machinery/power/apc/auto_name/directional/north,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/lobby)
 "vUD" = (
@@ -39323,6 +42982,9 @@
 "vUL" = (
 /obj/machinery/light/directional/north,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/checkpoint/medical)
 "vUM" = (
@@ -39358,15 +43020,22 @@
 /obj/machinery/atmospherics/pipe/multiz/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/multiz/scrubbers/hidden/layer2,
 /obj/structure/cable/multiz,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
 	},
 /area/station/hallway/primary/fore)
 "vVU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "vWg" = (
@@ -39390,14 +43059,18 @@
 /area/station/hallway/primary/central/aft)
 "vYd" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
 "vYt" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
 "vYA" = (
@@ -39459,7 +43132,7 @@
 	icon_state = "12"
 	},
 /obj/structure/cable/yellow{
-	icon_state = "4"
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/engineering/engine_smes)
@@ -39499,14 +43172,22 @@
 /turf/closed/wall/r_wall,
 /area/station/medical/pharmacy)
 "wbX" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/sorting)
 "wcc" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/eva)
 "wce" = (
@@ -39536,13 +43217,25 @@
 /obj/structure/table,
 /obj/machinery/telephone/command,
 /obj/machinery/power/data_terminal,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit)
+"wdC" = (
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/iron/dark/telecomms,
+/area/station/tcommsat/server)
 "wdL" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
 /area/station/engineering/main)
+"wdQ" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/turf/closed/wall/r_wall,
+/area/station/engineering/atmos/storage/gas)
 "wdW" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/cardboard,
@@ -39573,10 +43266,9 @@
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "weG" = (
-/obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
-/obj/machinery/meter,
-/turf/open/floor/iron/ported/techfloor_grid,
-/area/station/engineering/supermatter/room)
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/grater,
+/area/station/cargo/warehouse)
 "weI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/deadspace/mono,
@@ -39608,9 +43300,11 @@
 /area/station/engineering/supermatter/room)
 "wff" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
 	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/service/chapel/office)
@@ -39620,7 +43314,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron,
 /area/station/service/bar)
 "wfv" = (
@@ -39671,15 +43367,23 @@
 /area/station/medical/medbay/central)
 "wgO" = (
 /obj/machinery/holopad,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/checkpoint/customs)
 "wgZ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/library)
 "whl" = (
@@ -39715,6 +43419,15 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
+"wiw" = (
+/obj/effect/turf_decal/bot_white,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "wiB" = (
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/deadspace/grater,
@@ -39756,7 +43469,6 @@
 /area/station/hallway/primary/starboard)
 "wjU" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark,
 /area/station/ai_monitored/command/nuke_storage)
@@ -39804,6 +43516,9 @@
 	pixel_y = -2
 	},
 /obj/machinery/airalarm/directional/north,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "wlw" = (
@@ -39823,8 +43538,10 @@
 /turf/open/floor/stone,
 /area/aegis/surface)
 "wmm" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/range)
 "wmD" = (
@@ -39837,15 +43554,20 @@
 /obj/structure/chair/stool/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "wnd" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
 "wnm" = (
@@ -39879,7 +43601,9 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
 "wov" = (
@@ -39902,21 +43626,28 @@
 /turf/open/floor/plating,
 /area/station/medical/medbay/central)
 "woJ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
 "woN" = (
 /obj/machinery/atmospherics/pipe/smart/simple/cyan/visible{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
@@ -39926,12 +43657,14 @@
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "wpg" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/dark/side{
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/binary/pump/off/scrubbers/visible{
 	dir = 8
 	},
-/area/station/hallway/primary/central)
+/turf/open/floor/iron/ported/techfloor,
+/area/station/engineering/supermatter/room)
 "wpl" = (
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
@@ -39999,8 +43732,10 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/hallway/primary/central)
 "wqG" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
 "wqT" = (
@@ -40014,14 +43749,19 @@
 /turf/open/floor/plating,
 /area/station/cargo/drone_bay)
 "wrl" = (
-/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden{
-	dir = 8
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/ce)
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "wro" = (
 /obj/machinery/power/apc/auto_name/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "1"
+	},
 /turf/open/floor/wood,
 /area/station/medical/psychology)
 "wry" = (
@@ -40036,13 +43776,19 @@
 /obj/machinery/light_switch/directional/north{
 	pixel_x = 9
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/lab)
 "wrD" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
 "wrV" = (
@@ -40093,14 +43839,27 @@
 /turf/open/floor/wood,
 /area/station/cargo/qm)
 "wtM" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/iron/dark,
-/area/station/security/checkpoint/medical)
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/engineering/main)
 "wtN" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain)
@@ -40165,10 +43924,12 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
 "wwj" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/hallway/primary/central/aft)
 "wwt" = (
@@ -40214,11 +43975,32 @@
 /turf/closed/wall/r_wall,
 /area/station/ai_monitored/security/armory)
 "wxK" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/mine/production)
+"wxT" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/station/cargo/qm)
+"wxV" = (
+/obj/effect/turf_decal/bot_white,
+/obj/effect/spawner/random/maintenance,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "wyu" = (
 /obj/structure/rack,
 /obj/item/disk/holodisk/ds13/odd_shanty,
@@ -40266,10 +44048,11 @@
 /turf/open/floor/deadspace/random/maint_center,
 /area/mine/storage)
 "wAN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /obj/machinery/power/solar_control{
-	dir = 1;
-	id = "starboardsolar";
-	name = "Starboard Quarter Solar Control"
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/station/maintenance/solars/port/fore)
@@ -40295,9 +44078,14 @@
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "wAY" = (
@@ -40317,12 +44105,14 @@
 "wBg" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/visible,
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/camera/directional/east{
 	c_tag = "Chapel - Funerary Crypt"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
 	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/chapel/funeral)
@@ -40400,6 +44190,14 @@
 "wEk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
 /turf/open/floor/carpet/royalblack,
 /area/station/cargo/lobby)
@@ -40491,7 +44289,9 @@
 /area/station/security/courtroom)
 "wFK" = (
 /obj/machinery/light/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/medical/exam_room)
 "wFX" = (
@@ -40518,6 +44318,9 @@
 	pixel_x = -4;
 	pixel_y = -7
 	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/cargo/qm)
 "wGQ" = (
@@ -40527,7 +44330,6 @@
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse/upper)
 "wGU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/engineering/glass{
 	name = "Power Monitoring";
 	req_access_txt = "11"
@@ -40535,6 +44337,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/engine_smes)
 "wGW" = (
@@ -40607,8 +44412,10 @@
 /obj/effect/landmark/navigate_destination{
 	location = "Evacuation"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/secondary/exit/departure_lounge)
 "wHL" = (
@@ -40673,7 +44480,6 @@
 /turf/open/floor/deadspace/mono,
 /area/mine/hydroponics)
 "wJx" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -40683,7 +44489,9 @@
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/starboard/central)
 "wKq" = (
@@ -40743,8 +44551,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/status_display/supply{
 	pixel_y = -32
@@ -40772,7 +44578,6 @@
 /area/station/service/hydroponics)
 "wNG" = (
 /obj/effect/turf_decal/siding/purple,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/lab)
 "wNX" = (
@@ -40801,9 +44606,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/hallway/secondary/service)
 "wOR" = (
@@ -40865,7 +44672,9 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/mining)
 "wSD" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/plating,
 /area/station/commons/dorms/cryo)
 "wSF" = (
@@ -40881,9 +44690,14 @@
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "wSH" = (
@@ -40895,9 +44709,11 @@
 /turf/open/floor/plating,
 /area/station/hallway/secondary/service)
 "wSU" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/stone,
 /area/aegis/surface)
 "wTm" = (
@@ -40957,9 +44773,11 @@
 /area/station/engineering/main)
 "wVk" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "wVm" = (
@@ -40980,6 +44798,9 @@
 "wVE" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/brig/upper)
 "wVI" = (
@@ -41047,9 +44868,11 @@
 "wXB" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
@@ -41060,9 +44883,11 @@
 	req_access_txt = "4"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/security/detectives_office)
 "wXI" = (
@@ -41083,7 +44908,9 @@
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 6
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/service/chapel/office)
 "wXR" = (
@@ -41177,8 +45004,13 @@
 "xbh" = (
 /obj/structure/table,
 /obj/item/flashlight/lamp,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "xbk" = (
@@ -41193,9 +45025,11 @@
 /area/station/engineering/break_room)
 "xbH" = (
 /obj/machinery/light/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
 "xbM" = (
@@ -41253,10 +45087,12 @@
 /turf/open/floor/deadspace/grater,
 /area/aegis/hanger)
 "xcO" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/door/firedoor,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grille_spare1,
 /area/station/hallway/primary/central/aft)
 "xdu" = (
@@ -41287,9 +45123,11 @@
 /turf/open/misc/asteroid,
 /area/station/solars/port/fore)
 "xdJ" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/light_switch/directional/south,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/science/robotics/mechbay)
 "xdL" = (
@@ -41310,10 +45148,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/office)
 "xdQ" = (
@@ -41321,14 +45161,15 @@
 	dir = 4
 	},
 /obj/machinery/light/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/secondary/exit/departure_lounge)
 "xdT" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/storage_shared)
@@ -41353,6 +45194,20 @@
 "xeU" = (
 /turf/open/openspace,
 /area/station/cargo/warehouse/upper)
+"xfk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/turf/open/floor/catwalk_floor/iron_dark,
+/area/station/security/brig)
 "xfB" = (
 /obj/structure/rack,
 /obj/effect/turf_decal/box,
@@ -41373,9 +45228,11 @@
 	req_one_access_txt = "1;4"
 	},
 /obj/machinery/door/firedoor,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "xfE" = (
@@ -41415,6 +45272,13 @@
 /obj/item/gun/ballistic/automatic/pistol/rivet,
 /turf/open/floor/plating,
 /area/station/hallway/secondary/exit)
+"xgR" = (
+/obj/structure/railing{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "xhi" = (
 /obj/effect/floor_decal/ds/spline/fancy/wood{
 	dir = 8
@@ -41429,7 +45293,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "xhF" = (
@@ -41450,9 +45313,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -41462,11 +45327,13 @@
 /turf/open/floor/plating,
 /area/aegis/surface)
 "xhP" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "xhS" = (
@@ -41503,9 +45370,11 @@
 /obj/machinery/door/airlock/external{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/mono,
 /area/station/cargo/warehouse/upper)
 "xiy" = (
@@ -41550,36 +45419,62 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/hydroponics/upper)
+"xjG" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/hallway/secondary/exit/departure_lounge)
 "xki" = (
 /obj/structure/disposalpipe/junction/flip{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/light/floor/has_bulb,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/medbay/central)
+"xkv" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/golf_brown,
+/area/station/security/brig/upper)
 "xkM" = (
 /turf/open/floor/deadspace/mono,
 /area/aegis/mining)
 "xkN" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/conveyor{
 	id = "Storage Upper"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/cargo/warehouse/upper)
 "xkP" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen/fountain,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/command/heads_quarters/cmo)
 "xkQ" = (
@@ -41597,18 +45492,22 @@
 	name = "Mining Tool Storage";
 	req_access_txt = "48"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/mono,
 /area/mine/storage)
 "xlo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/miningoffice)
@@ -41694,7 +45593,9 @@
 /area/station/hallway/primary/central/aft)
 "xnC" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/command/heads_quarters/ce)
 "xnE" = (
@@ -41705,6 +45606,9 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -41716,8 +45620,11 @@
 "xnH" = (
 /obj/machinery/holopad,
 /mob/living/simple_animal/sloth/citrus,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "xoi" = (
@@ -41727,7 +45634,9 @@
 "xok" = (
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/iron/dark,
 /area/station/engineering/storage/tech)
 "xoC" = (
@@ -41740,16 +45649,17 @@
 /turf/open/floor/deadspace/mono,
 /area/station/service/kitchen/coldroom)
 "xpF" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
 "xpH" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -41769,6 +45679,9 @@
 /area/station/medical/medbay/central)
 "xqt" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "xqH" = (
@@ -41782,9 +45695,11 @@
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
 "xqL" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/security/brig/upper)
 "xqW" = (
@@ -41807,9 +45722,11 @@
 /area/station/hallway/secondary/exit)
 "xrC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/central)
 "xrV" = (
@@ -41829,9 +45746,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "xsj" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/turf/open/floor/deadspace/cable,
-/area/station/hallway/secondary/exit/departure_lounge)
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
+	dir = 1
+	},
+/turf/open/floor/deadspace/mono,
+/area/station/cargo)
 "xsl" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -41858,7 +45777,12 @@
 /area/station/hallway/primary/central/aft)
 "xsQ" = (
 /obj/effect/turf_decal/tile/neutral/opposingcorners,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/iron/dark,
 /area/station/cargo/miningdock/cafeteria)
 "xsU" = (
@@ -41895,12 +45819,14 @@
 /turf/open/floor/iron/dark,
 /area/station/cargo/office)
 "xtB" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "xtH" = (
@@ -41908,6 +45834,9 @@
 /obj/effect/turf_decal/tile/neutral/fourcorners,
 /obj/item/storage/secure/briefcase,
 /obj/machinery/airalarm/directional/west,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/dark,
 /area/station/command/heads_quarters/ce)
 "xtL" = (
@@ -41929,12 +45858,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/effect/landmark/navigate_destination{
 	location = "Custodial Closet"
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/station/service/janitor)
 "xtQ" = (
@@ -41961,17 +45892,21 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
 "xvI" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
 "xvN" = (
 /obj/effect/turf_decal/tile/blue/anticorner/contrasted{
 	dir = 8
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/firealarm/directional/south,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/medical/surgery/theatre)
 "xvX" = (
@@ -41982,7 +45917,9 @@
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "xwa" = (
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/ported/lino,
 /area/station/service/library)
 "xwn" = (
@@ -42011,10 +45948,10 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/lab)
 "xwJ" = (
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/effect/turf_decal/tile/neutral/fourcorners,
-/turf/open/floor/iron/dark,
-/area/station/science/server)
+/turf/open/misc/asteroid{
+	simulated = 0
+	},
+/area/aegis/surface)
 "xwY" = (
 /obj/effect/landmark/pestspawn,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -42032,13 +45969,18 @@
 /area/station/service/chapel/storage)
 "xxC" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "xxI" = (
 /obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark/side{
 	dir = 4
 	},
@@ -42068,6 +46010,12 @@
 	dir = 1
 	},
 /area/station/security/courtroom)
+"xxW" = (
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/cargo/warehouse)
 "xye" = (
 /obj/item/gps,
 /obj/item/gps,
@@ -42087,14 +46035,18 @@
 /obj/structure/table/wood/fancy/cyan,
 /obj/effect/floor_decal/ds/spline/fancy/wood,
 /obj/item/flashlight/lamp,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/carpet/blue,
 /area/station/service/chapel/office)
 "xyp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/showroomfloor,
 /area/station/commons/dorms/cryo)
 "xyB" = (
@@ -42113,9 +46065,11 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "xyM" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "12"
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/drone_bay)
@@ -42243,12 +46197,14 @@
 /turf/open/floor/deadspace/grater,
 /area/station/maintenance/fore/lesser)
 "xDY" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/medical,
 /area/station/medical/exam_room)
 "xEs" = (
@@ -42256,6 +46212,20 @@
 /obj/effect/turf_decal/box,
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse/upper)
+"xEw" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "5"
+	},
+/turf/open/floor/deadspace/medical,
+/area/station/medical/medbay/aft)
 "xEC" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/monitored/plasma_input{
 	dir = 8
@@ -42268,7 +46238,9 @@
 /area/mine/eva)
 "xFb" = (
 /obj/machinery/power/apc/auto_name/directional/east,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/captain/private)
 "xFe" = (
@@ -42328,17 +46300,24 @@
 /turf/open/floor/deadspace/mono,
 /area/station/security/warden)
 "xHg" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/security/courtroom)
 "xHF" = (
 /obj/machinery/light/directional/east,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/stone,
 /area/aegis/surface)
 "xHG" = (
 /obj/machinery/light/directional/south,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/plating,
 /area/misc/testroom)
 "xHS" = (
@@ -42374,9 +46353,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/sorting)
 "xIC" = (
@@ -42439,9 +46420,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/dark,
 /area/station/science/breakroom)
 "xKg" = (
@@ -42491,17 +46474,21 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/security/brig)
 "xLC" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/poddoor/preopen{
 	id = "miningsecprivacy";
 	name = "privacy shutter"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "8"
 	},
 /turf/open/floor/plating,
 /area/station/security/checkpoint/science)
@@ -42511,7 +46498,9 @@
 /area/aegis/hanger)
 "xLY" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "8"
+	},
 /turf/open/floor/plating,
 /area/station/security/warden)
 "xMe" = (
@@ -42533,9 +46522,11 @@
 /turf/open/floor/plating,
 /area/station/science/robotics/mechbay)
 "xMV" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/slides,
 /area/station/ai_monitored/security/armory)
 "xMZ" = (
@@ -42613,6 +46604,9 @@
 "xPd" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
 "xPq" = (
@@ -42635,7 +46629,12 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/central)
 "xQd" = (
@@ -42662,7 +46661,6 @@
 "xRk" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/carpet/red,
 /area/station/security/office)
 "xRl" = (
@@ -42670,7 +46668,6 @@
 /area/station/science/misc_lab/range)
 "xRu" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/cyan/hidden,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -42779,7 +46776,9 @@
 /obj/machinery/power/terminal{
 	dir = 1
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "2"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "xWB" = (
@@ -42788,7 +46787,6 @@
 /area/station/science/lab)
 "xWV" = (
 /obj/effect/spawner/structure/window/reinforced/grille,
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/station/hallway/primary/central/aft)
@@ -42820,18 +46818,16 @@
 /area/mine/lobby)
 "xYi" = (
 /obj/structure/disposalpipe/segment,
-/obj/structure/cable/smart_cable/color/yellow,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/dark/corner{
 	dir = 8
 	},
 /area/station/hallway/primary/starboard)
 "xYm" = (
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/green/hidden,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
-/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/medical/cryo)
 "xYs" = (
@@ -42881,6 +46877,15 @@
 /obj/effect/spawner/random/entertainment/money_large,
 /turf/open/floor/plating,
 /area/station/maintenance/fore/lesser)
+"xZo" = (
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "10"
+	},
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/command/bridge)
 "xZH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
@@ -42954,7 +46959,9 @@
 /area/station/engineering/atmos/storage/gas)
 "ycm" = (
 /obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "9"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos/storage/gas)
 "ycn" = (
@@ -42989,9 +46996,18 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "19"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/starboard/upper)
+"yeu" = (
+/obj/structure/railing{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/turf/open/floor/plating,
+/area/station/cargo/warehouse)
 "yey" = (
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/deadspace/grater,
@@ -43064,12 +47080,13 @@
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
 "ygs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "5"
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/lobby)
+/area/station/cargo/storage)
 "ygt" = (
 /obj/structure/rack/shelf,
 /obj/item/plate_shard/marker_shard,
@@ -43085,9 +47102,14 @@
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "6"
+	},
 /turf/open/floor/wood,
 /area/station/commons/lounge)
 "ygF" = (
@@ -43109,9 +47131,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable/smart_cable/color/yellow,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/cable/yellow{
+	icon_state = "12"
+	},
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "yhy" = (
@@ -43126,25 +47150,27 @@
 /turf/open/floor/deadspace/grater,
 /area/station/cargo/warehouse)
 "yhZ" = (
-/obj/machinery/atmospherics/pipe/smart/simple/supply/hidden{
-	dir = 6
+/obj/effect/spawner/structure/window/reinforced/grille,
+/obj/structure/cable/yellow{
+	icon_state = "1"
 	},
-/turf/closed/wall/r_wall,
-/area/station/command/heads_quarters/ce)
+/turf/open/floor/plating,
+/area/station/engineering/main)
 "yig" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/flora/rock,
 /turf/open/misc/asteroid,
 /area/station/hallway/primary/fore)
 "yim" = (
-/obj/machinery/atmospherics/pipe/smart/simple/green/visible{
-	dir = 9
-	},
 /obj/machinery/camera/directional/east{
 	c_tag = "Engine Room South";
 	network = list("ss13","engine")
 	},
 /obj/machinery/light/directional/east,
+/obj/machinery/atmospherics/pipe/smart/simple/scrubbers/hidden/layer2{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/smart/simple/green/visible,
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
 "yio" = (
@@ -43230,7 +47256,9 @@
 	c_tag = "Engineering - Foyer"
 	},
 /obj/machinery/power/apc/auto_name/directional/west,
-/obj/structure/cable/smart_cable/color/yellow,
+/obj/structure/cable/yellow{
+	icon_state = "4"
+	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/break_room)
 "ykX" = (
@@ -51510,8 +55538,8 @@ uoP
 trm
 mNO
 mNO
-odB
-efO
+kWh
+moK
 ssE
 jxc
 jgq
@@ -51667,8 +55695,8 @@ iba
 gTe
 mNO
 mNO
-odB
-efO
+kWh
+trm
 trm
 jxc
 jgq
@@ -51824,8 +55852,8 @@ uoP
 trm
 mNO
 mNO
-odB
-efO
+kWh
+trm
 trm
 jxc
 jgq
@@ -51981,8 +56009,8 @@ jxc
 trm
 mNO
 mNO
-odB
-efO
+kWh
+trm
 oAN
 jxc
 oQh
@@ -52040,7 +56068,7 @@ qVP
 qVP
 vYH
 mWa
-wtM
+niV
 teS
 upz
 niV
@@ -53605,7 +57633,7 @@ qVP
 qVP
 qVP
 qVP
-fBC
+cRu
 xUe
 gHU
 ors
@@ -54084,7 +58112,7 @@ qkb
 mNS
 vQc
 aXf
-aXf
+ovv
 qli
 qli
 qli
@@ -54550,7 +58578,7 @@ eAl
 bXp
 yjT
 dAN
-uCR
+xEw
 gGN
 qWI
 utT
@@ -54860,7 +58888,7 @@ lAb
 qgO
 dfD
 ibV
-ibV
+lYv
 xDY
 mBz
 isc
@@ -54869,7 +58897,7 @@ gGN
 qWI
 ofx
 eoV
-jTf
+gwy
 pbI
 ktX
 aaa
@@ -61771,8 +65799,8 @@ qVP
 erk
 erk
 iVy
-jiS
-jiS
+dSu
+frl
 jiS
 jiS
 gRg
@@ -62086,7 +66114,7 @@ erk
 tmo
 ebG
 tDQ
-tSR
+uFw
 wEX
 hBa
 ebG
@@ -62243,8 +66271,8 @@ erk
 erk
 ebG
 ebG
-ebG
-ebG
+nMG
+krG
 ebG
 ebG
 erk
@@ -62714,7 +66742,7 @@ erk
 erk
 ebG
 ebG
-ebG
+nMG
 ebG
 ebG
 ebG
@@ -63185,7 +67213,7 @@ erk
 erk
 xUZ
 ebG
-ebG
+nMG
 ebG
 ebG
 uyM
@@ -63341,8 +67369,8 @@ vAm
 erk
 jiS
 ebG
-ebG
-ebG
+bns
+nMG
 jiS
 jiS
 aIS
@@ -63497,10 +67525,10 @@ etJ
 ulq
 erk
 fkx
+iCO
 ilS
-ilS
-ebG
-jiS
+nMG
+xsj
 erk
 erk
 erk
@@ -63656,8 +67684,8 @@ erk
 jiS
 jiS
 rfJ
-ebG
-jiS
+nMG
+lks
 erk
 qVP
 qVP
@@ -63813,7 +67841,7 @@ erk
 eUJ
 erk
 uBz
-jiS
+frl
 jiS
 erk
 qVP
@@ -71631,7 +75659,7 @@ sCv
 epE
 sCv
 lVh
-sCv
+kLN
 sCv
 kWK
 sCv
@@ -71781,29 +75809,29 @@ qVP
 qVP
 kWK
 sCv
+jpV
 sCv
 sCv
 sCv
 sCv
 sCv
 sCv
-sCv
-sCv
+sPk
 sCv
 kWK
 sCv
 sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
+abd
+weG
+weG
+weG
+weG
+rXD
+sPk
+sPk
+sPk
+sPk
+jOM
 gHW
 tbB
 gHW
@@ -71938,14 +75966,14 @@ qVP
 qVP
 kWK
 goN
+xxW
 goN
 goN
 goN
 goN
 goN
 goN
-goN
-goN
+hCA
 goN
 kWK
 mgm
@@ -71955,7 +75983,7 @@ goN
 goN
 goN
 goN
-goN
+rrK
 goN
 goN
 goN
@@ -72095,14 +76123,14 @@ qVP
 qVP
 kWK
 lDu
-lDu
-lDu
-nOn
-lDu
+aut
 lDu
 nOn
 lDu
 lDu
+nOn
+lDu
+ekY
 lDu
 lTv
 lDu
@@ -72112,7 +76140,7 @@ lDu
 lDu
 lDu
 nOn
-lDu
+csx
 lDu
 nOn
 lDu
@@ -72252,14 +76280,14 @@ qVP
 qVP
 uYj
 mPy
-mPy
-mPy
-uYj
-mPy
+qAY
 mPy
 uYj
 mPy
 mPy
+uYj
+mPy
+vmK
 mPy
 uYj
 mPy
@@ -72269,7 +76297,7 @@ mPy
 mPy
 mPy
 uYj
-mPy
+dQW
 mPy
 uYj
 mPy
@@ -72409,24 +76437,24 @@ rqy
 qVP
 lxi
 mvU
-wwS
-wwS
-wwS
-sCv
-sCv
-wwS
-wwS
-wwS
-wwS
-wwS
-wwS
-wwS
-wwS
-wwS
-wwS
+xgR
 wwS
 wwS
 sCv
+sCv
+wwS
+wwS
+qMP
+wwS
+wwS
+wwS
+wwS
+wwS
+wwS
+wwS
+wwS
+wwS
+rXD
 sCv
 wwS
 wwS
@@ -72566,24 +76594,24 @@ ozq
 pFl
 mUC
 wnU
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
-bmx
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
+dSI
 bmx
 bmx
 bmx
@@ -72723,24 +76751,24 @@ rqy
 qVP
 lxi
 wUu
-gvZ
-gvZ
-gvZ
-sCv
-sCv
-gvZ
-gvZ
-gvZ
-gvZ
-gvZ
-gvZ
-gvZ
-gvZ
-gvZ
-gvZ
+nzN
 gvZ
 gvZ
 sCv
+sCv
+gvZ
+gvZ
+yeu
+gvZ
+gvZ
+gvZ
+gvZ
+gvZ
+gvZ
+gvZ
+gvZ
+gvZ
+rXD
 sCv
 gvZ
 gvZ
@@ -72880,14 +76908,14 @@ qVP
 qVP
 uYj
 goN
-goN
-goN
-uYj
-goN
+hCA
 goN
 uYj
 goN
 goN
+uYj
+goN
+xxW
 goN
 uYj
 goN
@@ -72897,7 +76925,7 @@ goN
 goN
 goN
 uYj
-goN
+rrK
 goN
 uYj
 goN
@@ -73037,14 +77065,14 @@ qVP
 qVP
 kWK
 lDu
-lDu
-lDu
-asE
-lDu
+ekY
 lDu
 asE
 lDu
 lDu
+asE
+lDu
+aut
 lDu
 lTv
 lDu
@@ -73054,7 +77082,7 @@ lDu
 lDu
 lDu
 asE
-lDu
+csx
 lDu
 asE
 lDu
@@ -73194,14 +77222,14 @@ qVP
 qVP
 kWK
 mPy
+vmK
 mPy
 mPy
 mPy
 mPy
 mPy
 mPy
-mPy
-mPy
+qAY
 mPy
 kWK
 aPO
@@ -73211,7 +77239,7 @@ mPy
 mPy
 mPy
 mPy
-mPy
+dQW
 mPy
 mPy
 mPy
@@ -73351,30 +77379,30 @@ qVP
 qVP
 kWK
 sCv
+sPk
 sCv
 sCv
 sCv
 sCv
 sCv
 sCv
-sCv
-sCv
+weG
 sCv
 kWK
 sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
-sCv
+uQN
+sPk
+sPk
+sPk
+sPk
+sPk
+rXD
+weG
+weG
+weG
+weG
+weG
+ipC
 sCv
 sCv
 kWK
@@ -73508,14 +77536,14 @@ qVP
 qVP
 kWK
 sCv
+cxd
 sCv
 sCv
 sCv
 sCv
 sCv
 sCv
-sCv
-sCv
+tAy
 sCv
 kWK
 sCv
@@ -73525,7 +77553,7 @@ cQh
 cQh
 cQh
 sCv
-sCv
+rXD
 sCv
 sCv
 sCv
@@ -73683,16 +77711,16 @@ dqU
 tCy
 cSt
 cSt
-cSt
-cSt
-cSt
-cSt
-cSt
-cSt
-cSt
-cSt
+gqh
+gqh
+gqh
+gqh
+gqh
+gqh
+gqh
+gqh
 aqr
-gpv
+ctn
 sCv
 mHX
 ljF
@@ -76195,7 +80223,7 @@ xVM
 xVM
 xVM
 fQc
-xVM
+naF
 pMt
 gRy
 rwp
@@ -76267,7 +80295,7 @@ qVP
 wSH
 hNO
 iCG
-hvU
+iCG
 iCG
 bnu
 wSH
@@ -76633,10 +80661,10 @@ anE
 nOX
 ijC
 rwR
-aJv
+azW
 hbH
 fXy
-dTk
+hVO
 iYH
 iYH
 iYH
@@ -76811,7 +80839,7 @@ aHO
 aHO
 aHO
 aHO
-cOf
+xRF
 aHO
 iAm
 dYf
@@ -76894,8 +80922,8 @@ qVP
 qVP
 wSH
 hNO
-hvU
-hvU
+iCG
+iCG
 iCG
 bnu
 wSH
@@ -76960,7 +80988,7 @@ mwV
 hfO
 mwV
 mwV
-lTz
+aiW
 mwV
 mwV
 hfO
@@ -77431,7 +81459,7 @@ wbh
 sFi
 dnX
 sNO
-ncO
+qHk
 sNO
 dTJ
 sFi
@@ -77506,17 +81534,17 @@ qVP
 qVP
 qVP
 wSH
-kis
-rpe
-rpe
-rpe
+fLI
+wIC
+wIC
+wIC
 wSH
 aUt
 eHv
 coK
-gpu
-rpe
-rpe
+xkM
+wIC
+wIC
 umN
 wSH
 qVP
@@ -77588,7 +81616,7 @@ nFb
 sFi
 hFa
 sNO
-alq
+guQ
 sNO
 sWE
 sFi
@@ -77666,15 +81694,15 @@ wSH
 osQ
 fLI
 wIC
-rpe
+wIC
 wSH
 cym
-rCI
+rQK
 rQK
 xkM
 xkM
 xkM
-gpu
+xkM
 wSH
 qVP
 wSH
@@ -77745,7 +81773,7 @@ foz
 sFi
 ykX
 sNO
-alq
+guQ
 sNO
 xsV
 sFi
@@ -77888,7 +81916,7 @@ qVP
 anE
 fDg
 mbe
-cUw
+qhR
 wSD
 aqS
 anE
@@ -77980,7 +82008,7 @@ wSH
 gpz
 dEr
 gpz
-gpu
+xkM
 uwB
 jFR
 jFR
@@ -77988,11 +82016,11 @@ tBM
 uwB
 uwB
 uwB
-gpu
+xkM
 wSH
 kZN
 paC
-hUi
+niy
 vfL
 dSg
 qLV
@@ -78137,7 +82165,7 @@ wSH
 wIC
 wIC
 wIC
-hUi
+niy
 niy
 xwY
 niy
@@ -78145,7 +82173,7 @@ niy
 niy
 niy
 niy
-wwt
+eVg
 vld
 pXo
 niy
@@ -78294,7 +82322,7 @@ wSH
 gpz
 gpz
 gpz
-hUi
+niy
 niy
 niy
 niy
@@ -78302,7 +82330,7 @@ niy
 niy
 nww
 niy
-wwt
+eVg
 vld
 niy
 niy
@@ -78373,7 +82401,7 @@ vxt
 sFi
 xqH
 sNO
-ncO
+qHk
 sNO
 jhD
 sFi
@@ -78451,7 +82479,7 @@ wSH
 wIC
 wIC
 wIC
-hUi
+niy
 niy
 niy
 niy
@@ -78459,7 +82487,7 @@ niy
 niy
 nww
 niy
-wwt
+eVg
 vld
 fMZ
 niy
@@ -78608,7 +82636,7 @@ wSH
 gpz
 gpz
 gpz
-hUi
+niy
 wSH
 dnI
 dnI
@@ -78616,7 +82644,7 @@ wSH
 niy
 nww
 niy
-wwt
+eVg
 vld
 bYP
 vhM
@@ -78723,7 +82751,7 @@ bSi
 bat
 bat
 bat
-hwQ
+trK
 uSq
 qVP
 kjv
@@ -78922,7 +82950,7 @@ wSH
 hPU
 hvp
 jvP
-hUi
+niy
 wSH
 uqi
 uqi
@@ -79022,7 +83050,7 @@ cWK
 lPW
 nMS
 nMS
-eyr
+cWK
 gTp
 utU
 lzi
@@ -79148,7 +83176,7 @@ nHL
 azW
 hbH
 dVP
-beQ
+qgP
 jKk
 jKk
 jKk
@@ -79404,11 +83432,11 @@ niy
 oQQ
 wSH
 xkM
-gpu
+xkM
 xkM
 wSH
-ePf
-qLV
+oGx
+bIn
 qzZ
 wSH
 qVP
@@ -79560,7 +83588,7 @@ niy
 niy
 oQQ
 wSH
-dSI
+xbM
 exj
 xbM
 wSH
@@ -79656,7 +83684,7 @@ tyr
 dmW
 hEO
 mui
-vHE
+rNT
 vHE
 eEt
 qYZ
@@ -79952,7 +83980,7 @@ gho
 lfY
 tQS
 xqt
-kpk
+hnk
 czr
 npi
 fki
@@ -80108,7 +84136,7 @@ fnR
 sMY
 tQS
 hnk
-bqd
+eus
 msD
 ayh
 npi
@@ -80118,7 +84146,7 @@ bYo
 kBk
 ruP
 bwu
-jaQ
+hcd
 jaQ
 nAc
 wVk
@@ -80694,11 +84722,11 @@ qVP
 qVP
 wuy
 wuy
-rqy
-rqy
-rqy
-rqy
-rqy
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
 wuy
 wuy
 wuy
@@ -80850,24 +84878,24 @@ wuy
 wuy
 wuy
 wuy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
 wuy
 wuy
 vRZ
@@ -80910,7 +84938,7 @@ mwp
 yfI
 cZh
 uEm
-xRk
+nVW
 xfD
 vky
 dAe
@@ -80922,7 +84950,7 @@ vky
 vky
 vky
 vky
-vky
+nMY
 vky
 tCw
 aQM
@@ -81003,29 +85031,29 @@ qVP
 qVP
 qVP
 wuy
-rqy
-rqy
+xwJ
+xwJ
+ewa
+ewa
+ewa
+ewa
+ewa
+ewa
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
+xwJ
 qnp
-qnp
-qnp
-qnp
-qnp
-qnp
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-rqy
-qnp
-qnp
-qnp
-qnp
-qnp
-qnp
-rqy
-rqy
+ewa
+ewa
+ewa
+ewa
+ewa
+xwJ
+xwJ
 wuy
 vRZ
 bzI
@@ -81066,7 +85094,7 @@ elo
 mwp
 tTg
 blQ
-hDf
+xRk
 xRk
 mwp
 uej
@@ -81160,29 +85188,29 @@ qVP
 qVP
 qVP
 wuy
-rqy
-qnp
+xwJ
+ewa
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-rqy
-rqy
-rqy
+xwJ
+xwJ
+xwJ
 dsu
-rqy
-rqy
-rqy
+xwJ
+xwJ
+xwJ
 nMp
 lCY
 nMp
 lCY
 nMp
 lCY
-qnp
-rqy
+ewa
+xwJ
 wuy
 vRZ
 uho
@@ -81317,29 +85345,29 @@ qVP
 qVP
 qVP
 wuy
-rqy
-qnp
-rQA
+xwJ
+ewa
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-rqy
-rqy
+swY
+swY
+swY
+swY
+xwJ
+xwJ
+xwJ
 nGf
-rqy
-rqy
-rqy
-rQA
+xwJ
+xwJ
+xwJ
 swY
-rQA
-rQA
 swY
-rQA
-qnp
-rqy
+swY
+swY
+swY
+swY
+ewa
+xwJ
 wuy
 vRZ
 ham
@@ -81387,10 +85415,10 @@ qyr
 qyr
 qyr
 bHR
-mWE
-daa
+xfk
+aKG
 tWq
-qSo
+uuS
 cVO
 weY
 qyr
@@ -81474,29 +85502,29 @@ qVP
 qVP
 qVP
 wuy
-rqy
-qnp
-rQA
+xwJ
+ewa
 swY
-rQA
-rQA
 swY
-rQA
-gbS
-gbS
-gbS
+swY
+swY
+swY
+swY
+sCc
+sCc
+sCc
 dsu
-gbS
-gbS
-gbS
-rQA
+sCc
+sCc
+sCc
 swY
-rQA
-rQA
 swY
-rQA
-qnp
-rqy
+swY
+swY
+swY
+swY
+ewa
+xwJ
 wuy
 vRZ
 vRZ
@@ -81631,32 +85659,32 @@ qVP
 qVP
 qVP
 wuy
-rqy
-rqy
-rQA
+xwJ
+xwJ
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-rqy
-rqy
+swY
+swY
+swY
+swY
+xwJ
+xwJ
+xwJ
 nGf
-rqy
-rqy
-rqy
-rQA
+xwJ
+xwJ
+xwJ
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-rqy
+swY
+swY
+swY
+swY
+xwJ
+xwJ
 wuy
-wuy
-wuy
+qVP
+qVP
 vRZ
 cxr
 vRZ
@@ -81697,9 +85725,9 @@ wqD
 bJz
 bJz
 oqy
-oqy
-oqy
-oqy
+ppa
+ppa
+cUc
 bHR
 mWE
 jYt
@@ -81709,7 +85737,7 @@ qyr
 qyr
 qyr
 tfu
-mWE
+tBK
 igw
 fpu
 fpu
@@ -81788,32 +85816,32 @@ qVP
 qVP
 qVP
 wuy
-rqy
-qnp
-rQA
+xwJ
+ewa
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-rqy
-rqy
+swY
+swY
+swY
+swY
+xwJ
+xwJ
+xwJ
 nGf
-rqy
-rqy
-rqy
-rQA
+xwJ
+xwJ
+xwJ
 swY
-rQA
-rQA
 swY
-rQA
-qnp
-rqy
-rqy
+swY
+swY
+swY
+swY
+ewa
+xwJ
 wuy
-wuy
+qVP
+qVP
 vRZ
 gzi
 vRZ
@@ -81849,19 +85877,19 @@ lWL
 qUM
 qUM
 xPJ
-pfG
-pfG
-pfG
-pfG
+qUM
+qUM
+qUM
+qUM
 kVf
 uSt
 kVO
-kVf
+cSQ
 sXZ
 bHX
-daa
+aKG
 tWq
-qSo
+uuS
 dHZ
 weY
 qyr
@@ -81945,32 +85973,32 @@ qVP
 qVP
 qVP
 wuy
-rqy
-qnp
-rQA
+xwJ
+ewa
 swY
-rQA
-rQA
 swY
-rQA
-gbS
-gbS
-gbS
+swY
+swY
+swY
+swY
+sCc
+sCc
+sCc
 dsu
-gbS
-gbS
-gbS
-rQA
+sCc
+sCc
+sCc
 swY
-rQA
-rQA
 swY
-rQA
-qnp
-gbS
-rqy
+swY
+swY
+swY
+swY
+ewa
+sCc
 wuy
-wuy
+qVP
+qVP
 kZJ
 cJh
 kZJ
@@ -82102,32 +86130,32 @@ qVP
 qVP
 qVP
 wuy
-rqy
-qnp
-rQA
+xwJ
+ewa
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-rqy
-rqy
+swY
+swY
+swY
+swY
+xwJ
+xwJ
+xwJ
 nGf
-rqy
-rqy
-rqy
-rQA
+xwJ
+xwJ
+xwJ
 swY
-rQA
-rQA
 swY
-rQA
-qnp
+swY
+swY
+swY
+swY
+ewa
 dsu
-rqy
 wuy
-wuy
+qVP
+qVP
 kZJ
 srA
 kZJ
@@ -82163,7 +86191,7 @@ rcl
 wUC
 aTw
 crJ
-xLY
+eTQ
 svE
 crJ
 crJ
@@ -82180,7 +86208,7 @@ qyr
 qyr
 qyr
 uck
-odO
+kCr
 xIM
 pfC
 pXF
@@ -82259,32 +86287,32 @@ qVP
 qVP
 qVP
 wuy
-rqy
-rqy
-rQA
+xwJ
+xwJ
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-rqy
-rqy
+swY
+swY
+swY
+swY
+xwJ
+xwJ
+xwJ
 nGf
-rqy
-rqy
-rqy
-rQA
+xwJ
+xwJ
+xwJ
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-gbS
-rqy
+swY
+swY
+swY
+swY
+xwJ
+sCc
 wuy
-wuy
+qVP
+qVP
 kZJ
 aWO
 uZr
@@ -82324,15 +86352,15 @@ veP
 esC
 tdg
 dAi
-xLY
+eTQ
 gPB
 qbh
 qbh
 bHR
-mWE
-daa
+tBK
+aKG
 tWq
-qSo
+uuS
 aTa
 weY
 qyr
@@ -82416,31 +86444,31 @@ qVP
 qVP
 qVP
 wuy
-rqy
-rHU
-rQA
+xwJ
+pNt
 swY
-rQA
-rQA
 swY
-rQA
-gbS
-gbS
-gbS
+swY
+swY
+swY
+swY
+sCc
+sCc
+sCc
 dsu
-gbS
-gbS
-gbS
-rQA
+sCc
+sCc
+sCc
 swY
-rQA
-rQA
 swY
-rQA
-rqy
-gbS
-rqy
+swY
+swY
+swY
+swY
+xwJ
+sCc
 wuy
+qVP
 kZJ
 kZJ
 kZJ
@@ -82471,7 +86499,7 @@ kdu
 xlL
 dHH
 eaG
-wpg
+eaG
 kou
 ePW
 sMm
@@ -82486,7 +86514,7 @@ vky
 vky
 vky
 vky
-mWE
+kPc
 lQE
 aII
 iee
@@ -82573,31 +86601,31 @@ qVP
 qVP
 qVP
 wuy
-rqy
-rHU
+xwJ
+pNt
+jhs
 jeU
+qly
 jeU
-jeU
-jeU
-jeU
-jeU
-rqy
-rqy
-rqy
+qly
+jhs
+xwJ
+xwJ
+xwJ
 nGf
-rqy
-rqy
-rqy
+xwJ
+xwJ
+xwJ
+jhs
 jeU
+qly
 jeU
-jeU
-jeU
-jeU
-jeU
+qly
+jhs
 sCc
-gbS
-rqy
+sCc
 wuy
+qVP
 kZJ
 xii
 lUG
@@ -82609,7 +86637,7 @@ daT
 daT
 daT
 idA
-nOQ
+wpl
 jqL
 wpl
 wpl
@@ -82630,7 +86658,7 @@ thc
 pJb
 pJb
 pJb
-pJb
+svl
 mpA
 wUC
 crJ
@@ -82652,11 +86680,11 @@ qyr
 qyr
 uck
 odO
-mWE
-mWE
-mWE
-mWE
-mWE
+hDf
+hDf
+hDf
+hDf
+hDf
 cah
 ioB
 nPD
@@ -82730,13 +86758,13 @@ qVP
 qVP
 qVP
 wuy
-rqy
+wuy
 qQP
 lhT
-lhT
-lhT
-lhT
-lhT
+uyg
+uyg
+uyg
+uyg
 vTc
 qQP
 qQP
@@ -82746,15 +86774,15 @@ qQP
 qQP
 qQP
 pXJ
+iCg
+iCg
+iCg
+iCg
 rgW
-rgW
-rgW
-rgW
-rgW
-iCe
 qQP
 wuy
 wuy
+qVP
 kZJ
 tTm
 vhO
@@ -82800,10 +86828,10 @@ qyr
 qyr
 qyr
 bHR
-mWE
-daa
+tBK
+aKG
 tWq
-qSo
+uuS
 fwd
 weY
 qyr
@@ -82886,14 +86914,14 @@ qVP
 qVP
 qVP
 qVP
-wuy
-wuy
+qVP
+qVP
 qQP
 hBo
 gXh
-dJx
-dJx
-dJx
+aIL
+aIL
+aIL
 nQP
 bwR
 auf
@@ -82904,12 +86932,12 @@ geM
 bwR
 gFk
 gXh
+diA
 gXh
-weG
 gXh
 nJu
-rUa
 qQP
+qVP
 qVP
 qVP
 kZJ
@@ -83064,9 +87092,9 @@ isV
 tXh
 uzD
 bAy
-dAF
+mer
 ogk
-qQP
+qVP
 qVP
 qVP
 eRR
@@ -83221,9 +87249,9 @@ nzy
 sjI
 bIh
 lyZ
-dAF
+wpg
 rUa
-qQP
+qVP
 qVP
 qVP
 eRR
@@ -83240,7 +87268,7 @@ dyb
 aUy
 vQq
 riy
-riy
+nhW
 ayu
 dUo
 bPG
@@ -83259,11 +87287,11 @@ hKc
 xZb
 wce
 fPN
-cPX
+fFe
 wce
 bbh
 hTw
-omF
+fBC
 tml
 rCl
 ifc
@@ -83380,7 +87408,7 @@ kit
 edO
 hCO
 dUe
-qQP
+qVP
 qVP
 qVP
 eRR
@@ -83429,7 +87457,7 @@ nGw
 qyr
 nDq
 xLA
-mWE
+hDf
 ejX
 mfG
 cPn
@@ -83439,7 +87467,7 @@ mfG
 pqx
 mfG
 mfG
-mfG
+wrl
 wmg
 ust
 qyr
@@ -83533,11 +87561,11 @@ fYJ
 bAy
 bVz
 jiK
-trK
+iMZ
 blO
 cTo
-pmS
-qQP
+dUe
+qVP
 qVP
 qVP
 eRR
@@ -83596,7 +87624,7 @@ bNV
 vrG
 bNV
 bNV
-mWE
+oau
 bNV
 bNV
 qyr
@@ -83691,10 +87719,10 @@ qMD
 gGE
 sVe
 yim
-iMZ
+hpN
 dAF
 dOf
-qQP
+qVP
 qVP
 qVP
 eRR
@@ -83851,7 +87879,7 @@ qQP
 qQP
 qQP
 qQP
-qQP
+qVP
 qVP
 qVP
 qVP
@@ -84067,7 +88095,7 @@ qVP
 qVP
 wCo
 gvH
-bul
+bFa
 olT
 jdO
 wCo
@@ -84352,7 +88380,7 @@ dUo
 dUo
 dUo
 vVQ
-uYo
+pWF
 iGp
 dUo
 onl
@@ -84530,7 +88558,7 @@ dmE
 cFv
 crs
 fLg
-xYm
+mou
 dYv
 woI
 qZi
@@ -84804,9 +88832,9 @@ uxc
 wCJ
 vVb
 vVb
-bYx
-bYx
-bYx
+kQW
+kQW
+kQW
 mUn
 mUn
 mUn
@@ -84844,7 +88872,7 @@ azA
 jJt
 lRV
 hNy
-woJ
+hFB
 vCt
 vCt
 vCt
@@ -84939,11 +88967,11 @@ xth
 xth
 xth
 xth
+lfb
 eIL
 eIL
-eIL
-eIL
-eIL
+lki
+imS
 xth
 fdA
 uOG
@@ -84953,7 +88981,7 @@ nLe
 mbF
 sun
 uUt
-uGU
+avK
 wAX
 aNP
 aAq
@@ -84964,7 +88992,7 @@ kPt
 oyt
 egd
 kNZ
-aBf
+wdC
 mUn
 mUn
 mUn
@@ -85099,7 +89127,7 @@ cNx
 aJZ
 llM
 gMP
-llM
+tpi
 tEB
 xth
 rRW
@@ -85116,7 +89144,7 @@ ghX
 ojj
 qAi
 vVb
-tQQ
+gXv
 pWI
 bYx
 bYx
@@ -85138,28 +89166,28 @@ oIb
 jcd
 bPG
 bSP
-cKw
+fsl
 gRf
 mLj
 uME
 nLC
 qyR
 lzq
-cOX
+vvb
 cBm
 xki
-tcX
-tcX
-tcX
+flr
+flr
+flr
 aur
 cOX
-tcX
-tcX
+flr
+flr
 tcQ
 dLA
+flr
 tcX
-tcX
-tcX
+flr
 flr
 vwt
 tup
@@ -85256,7 +89284,7 @@ bUh
 oRx
 tYl
 hpF
-tYl
+fZP
 iVk
 xth
 nCJ
@@ -85268,7 +89296,7 @@ lSF
 gOY
 mHD
 nPN
-wmL
+erO
 icl
 ojj
 tit
@@ -85581,7 +89609,7 @@ iyS
 cLU
 cLU
 ojj
-diA
+hFY
 dEQ
 dJK
 ojj
@@ -85591,8 +89619,8 @@ gFX
 gFX
 gFX
 kih
-aBf
-aBf
+lTn
+jBy
 fsT
 gvY
 qVP
@@ -85608,7 +89636,7 @@ pLY
 ccd
 jML
 cwa
-gDA
+jdI
 jlM
 uwQ
 gqi
@@ -85647,7 +89675,7 @@ qtY
 eet
 vEb
 val
-jRe
+qSt
 jRe
 bfm
 xKp
@@ -85738,7 +89766,7 @@ slG
 fpO
 gsG
 tuG
-kpP
+xbE
 dEQ
 eFo
 iNX
@@ -85877,18 +89905,18 @@ kDP
 kDP
 kDP
 kDP
-gwR
-gwR
+kDP
+kDP
 eCA
 eCA
-eCA
+shj
 eCA
 eCA
 pAx
 gbr
 pSi
 ukz
-pSi
+wtM
 tfP
 hPr
 jgb
@@ -85896,7 +89924,7 @@ fBA
 tfj
 eFj
 mcE
-dEQ
+pmS
 avK
 uiB
 pIx
@@ -86108,15 +90136,15 @@ vmh
 flr
 qcz
 nOt
-tcX
-aur
-tcX
-tcX
-tcX
-tcX
-tcX
-tcX
-tcX
+flr
+mJq
+flr
+flr
+flr
+flr
+flr
+flr
+flr
 kCT
 pWM
 cON
@@ -86266,7 +90294,7 @@ izF
 sPc
 kCq
 kCq
-ffw
+iix
 kCq
 fqY
 kCq
@@ -86343,9 +90371,9 @@ qVP
 gsG
 gsG
 gsG
-ahD
+sFy
 adK
-ahD
+yhZ
 gsG
 gsG
 pMH
@@ -86493,7 +90521,7 @@ rqy
 rqy
 rqy
 rqy
-afp
+gwR
 rqy
 qVP
 qVP
@@ -86512,7 +90540,7 @@ gsG
 gsG
 oBx
 ccb
-aPX
+vmF
 ccb
 ubN
 xnC
@@ -86650,7 +90678,7 @@ qVP
 rqy
 eSR
 rqy
-mtQ
+rdf
 jnM
 qVP
 qVP
@@ -86805,9 +90833,9 @@ qVP
 qVP
 rqy
 rqy
-ocO
-afp
-afp
+tuc
+dMW
+rqy
 srt
 qVP
 qVP
@@ -86960,9 +90988,9 @@ qVP
 rqy
 rqy
 rqy
+rqy
 afp
-afp
-ocO
+rTT
 rqy
 wyu
 qVP
@@ -86992,7 +91020,7 @@ huG
 aYV
 mrm
 upl
-jdI
+upb
 mKE
 jqC
 dEQ
@@ -87031,7 +91059,7 @@ wIJ
 bVx
 kon
 kXC
-qAY
+lOp
 tME
 kky
 kky
@@ -87046,7 +91074,7 @@ sMe
 uvA
 kDx
 bHA
-mCd
+dzC
 vmf
 rKf
 kLx
@@ -87114,10 +91142,10 @@ qVP
 qVP
 rqy
 rqy
-afp
-ocO
-ocO
-afp
+rqy
+tkH
+pfG
+jeQ
 rqy
 rqy
 rqy
@@ -87149,10 +91177,10 @@ rDV
 iAC
 fRC
 bmS
-qMP
+upb
 pIG
 kNf
-avK
+nyF
 lwr
 hPz
 xwH
@@ -87203,7 +91231,7 @@ sMe
 ukH
 kDx
 tKw
-cUc
+kCq
 vJQ
 rKf
 ccq
@@ -87268,10 +91296,10 @@ qVP
 qVP
 rqy
 rqy
-afp
-afp
-afp
-afp
+rqy
+rqy
+rqy
+dMW
 rqy
 qVP
 rqy
@@ -87301,9 +91329,9 @@ gsG
 gsG
 gsG
 djs
-yhZ
-ldv
-wrl
+djs
+djs
+djs
 djs
 djs
 djs
@@ -87425,9 +91453,9 @@ qVP
 rqy
 rqy
 rqy
-afp
 rqy
 rqy
+dMW
 rqy
 qVP
 qVP
@@ -87461,10 +91489,10 @@ cMl
 oaV
 vBz
 pee
-sRF
+ugP
 jgI
 cAY
-sRF
+wdQ
 oTl
 sRF
 sRF
@@ -87493,11 +91521,11 @@ kOI
 aeQ
 bPG
 fVy
-rXD
+jlM
 hfx
 edW
 jnA
-iJI
+qsx
 sav
 ccB
 aaf
@@ -87517,7 +91545,7 @@ yjk
 yjk
 mSl
 yjk
-tNh
+yjk
 lKY
 yjk
 ofv
@@ -87582,8 +91610,8 @@ qVP
 qVP
 rqy
 rqy
-ocO
-rqy
+tuc
+stX
 qVP
 qVP
 qVP
@@ -87613,15 +91641,15 @@ nBT
 iJV
 vtj
 uzW
-nBX
+vPr
 ebH
 fjl
 hfM
-gmn
-sEl
+jTU
+qPX
 tKf
 jYX
-sRF
+nzU
 qoR
 sRF
 keh
@@ -87656,11 +91684,11 @@ qgi
 uMo
 epq
 djC
-tIj
-tIj
-tIj
-tIj
-tIj
+mBv
+mBv
+mBv
+mBv
+mBv
 djC
 maK
 fpH
@@ -87739,8 +91767,8 @@ qVP
 qVP
 rqy
 rqy
-ocO
-rqy
+tuc
+gwR
 qVP
 qVP
 qVP
@@ -87770,11 +91798,11 @@ qxW
 eBE
 gkJ
 vxP
-qJv
-qJv
+ebH
+ebH
+ebH
 gAZ
-gAZ
-qHk
+gmn
 sEl
 vah
 okQ
@@ -87789,7 +91817,7 @@ wDy
 rkU
 vQi
 rkU
-jNC
+jtJ
 pZv
 sxj
 wDV
@@ -87896,8 +91924,8 @@ qVP
 qVP
 rqy
 rqy
-ocO
-ocO
+tuc
+rvn
 qVP
 qVP
 qVP
@@ -87927,9 +91955,9 @@ mpT
 eGf
 gkJ
 jZb
-ebH
+lOe
 kEE
-uQN
+ebH
 kRQ
 juH
 sEl
@@ -87946,7 +91974,7 @@ fDt
 rbK
 rbK
 rbK
-wDy
+fwp
 pZv
 sxj
 eLJ
@@ -88054,8 +92082,8 @@ qVP
 qVP
 qVP
 rqy
-afp
-afp
+rqy
+mUA
 qVP
 qVP
 qVP
@@ -88084,8 +92112,8 @@ anZ
 eGf
 eAg
 sxb
-gkJ
-gkJ
+qNg
+lEg
 gkJ
 eAg
 feG
@@ -88136,7 +92164,7 @@ kgQ
 ukL
 qrJ
 exH
-sPk
+dWP
 kBp
 mIX
 mew
@@ -88144,7 +92172,7 @@ pAY
 bAj
 hzL
 snq
-sPk
+dWP
 ukL
 iPq
 exH
@@ -88212,8 +92240,8 @@ qVP
 qVP
 qVP
 rqy
-afp
-afp
+nOQ
+rqy
 rqy
 rqy
 rqy
@@ -88241,11 +92269,11 @@ aRD
 exz
 hFC
 gQv
-tfU
+fYC
 tfU
 ohb
 ebH
-juH
+mbT
 sRF
 lav
 gzx
@@ -88293,7 +92321,7 @@ aDw
 cXX
 nVp
 exH
-sPk
+dWP
 eFH
 gWE
 nDm
@@ -88301,7 +92329,7 @@ nDm
 nDm
 nDm
 cdJ
-sPk
+dWP
 ukL
 iPq
 exH
@@ -88370,8 +92398,8 @@ rqy
 qVP
 qVP
 rqy
-afp
-afp
+iJI
+ahe
 rqy
 rqy
 rHU
@@ -88528,9 +92556,9 @@ rqy
 qVP
 qVP
 rqy
-afp
-afp
 rqy
+mUA
+kyJ
 rHU
 rqy
 tuc
@@ -88607,7 +92635,7 @@ bVD
 ukL
 qrJ
 exH
-sPk
+dWP
 vMm
 hrU
 xsl
@@ -88615,7 +92643,7 @@ pBd
 jha
 mVT
 plM
-sPk
+dWP
 ukL
 uta
 exH
@@ -88686,10 +92714,10 @@ rqy
 qVP
 qVP
 rqy
-afp
-afp
-afp
-afp
+cNc
+xKg
+ruE
+ieM
 rqy
 rqy
 rqy
@@ -88846,7 +92874,7 @@ qVP
 qVP
 rqy
 rHU
-afp
+gwR
 rqy
 rqy
 rqy
@@ -89003,7 +93031,7 @@ qVP
 qVP
 qVP
 rHU
-afp
+gwR
 rqy
 rqy
 rqy
@@ -89158,9 +93186,9 @@ tuc
 tuc
 qVP
 qVP
-afp
-afp
-afp
+iHy
+ruE
+pmj
 rqy
 rqy
 rqy
@@ -89202,7 +93230,7 @@ rkX
 bkg
 ieE
 ijk
-dlh
+tUq
 rkU
 sxj
 puN
@@ -89315,7 +93343,7 @@ rqy
 rqy
 rqy
 rqy
-afp
+gwR
 rEA
 quR
 rEA
@@ -89344,7 +93372,7 @@ naE
 mCH
 dvF
 hHs
-blf
+dRP
 dwU
 blf
 blf
@@ -89402,7 +93430,7 @@ lxf
 jAQ
 nvn
 iDM
-nkV
+mSK
 rGI
 edX
 all
@@ -89472,9 +93500,9 @@ rqy
 rqy
 rqy
 rqy
-afp
+gwR
 rek
-oYE
+ebA
 jJJ
 wAN
 sIt
@@ -89511,12 +93539,12 @@ mbT
 jpS
 vwd
 jaR
-haR
+qLk
 eYu
 eYu
 qXg
 cAk
-dlh
+tUq
 bvP
 sxj
 eaH
@@ -89557,7 +93585,7 @@ edX
 hNl
 jhV
 bid
-xwJ
+bUP
 nLV
 nkV
 sAH
@@ -89631,13 +93659,13 @@ rqy
 rqy
 ocO
 rEA
-oYE
+uGU
 jBo
 oYE
-quR
-gqh
-gqh
-rqy
+tLC
+ruE
+ruE
+ieM
 rqy
 rqy
 eAg
@@ -89700,11 +93728,11 @@ dHN
 dHN
 kXb
 sTl
+upx
 bcm
-bcm
-bcm
-bcm
-bcm
+upx
+upx
+aEa
 cMP
 cMP
 mhi
@@ -89786,14 +93814,14 @@ qVP
 rqy
 tuc
 tuc
-afp
+gwR
 rEA
 aQr
 oXp
 cuI
 sIt
+qNQ
 rqy
-gqh
 rqy
 rqy
 rqy
@@ -89950,7 +93978,7 @@ rEA
 rEA
 sIt
 rqy
-gqh
+rqy
 rqy
 rqy
 rqy
@@ -90152,7 +94180,7 @@ yio
 yio
 yio
 yio
-jIB
+hCX
 rDZ
 fEk
 vDP
@@ -90318,7 +94346,7 @@ fVs
 sBp
 soj
 juy
-fVy
+rDI
 iGp
 wZK
 snn
@@ -90735,7 +94763,7 @@ xdC
 qxy
 xdC
 xdC
-cWn
+uQc
 cWn
 pjz
 pjz
@@ -90767,12 +94795,12 @@ hHi
 hHi
 rTI
 rWq
-rWq
+rMC
 rWq
 fwj
 qIi
-hDv
-hDv
+kJa
+kJa
 cFk
 faY
 qVP
@@ -91079,14 +95107,14 @@ xJv
 hqp
 xTj
 qwA
-fdT
+svi
 xNF
 eBq
 aKq
 faY
 pDD
 wgO
-hDv
+kJa
 pYw
 faY
 fPT
@@ -91262,7 +95290,7 @@ kyw
 gNo
 rAl
 uXc
-xLC
+jAG
 fDQ
 riO
 pkp
@@ -91362,7 +95390,7 @@ rqy
 rqy
 rqy
 rqy
-rqy
+qNQ
 rqy
 iHy
 skX
@@ -91393,7 +95421,7 @@ uaC
 hqp
 xgO
 kAv
-fdT
+dDE
 wcV
 jSw
 rQc
@@ -91405,7 +95433,7 @@ olg
 faY
 otF
 rkU
-jNC
+efO
 rkU
 rkU
 gmN
@@ -91551,9 +95579,9 @@ hqp
 kAg
 pug
 akZ
-fdT
-fdT
-fdT
+pIq
+gmv
+oJK
 faY
 ktR
 bbF
@@ -91576,7 +95604,7 @@ kxK
 kgC
 iTo
 uXc
-xLC
+nZu
 pcA
 bVG
 qhu
@@ -91835,7 +95863,7 @@ pPU
 pPU
 bPy
 rqy
-rqy
+qNQ
 rqy
 rqy
 rqy
@@ -91995,7 +96023,7 @@ rqy
 rqy
 rqy
 rqy
-rqy
+qNQ
 qxy
 qbl
 akZ
@@ -92033,7 +96061,7 @@ iel
 iel
 iel
 iel
-iel
+gpu
 eCC
 njj
 wYA
@@ -92057,7 +96085,7 @@ qDb
 iae
 kDC
 iae
-rlW
+iae
 uHI
 jij
 vFj
@@ -92190,7 +96218,7 @@ odc
 odc
 odc
 odc
-iJv
+rpe
 tXH
 njj
 ncl
@@ -92201,7 +96229,7 @@ ayy
 arg
 dQk
 bgx
-imS
+iov
 xQK
 dAY
 izs
@@ -92211,18 +96239,18 @@ ayy
 liT
 vlR
 mdg
-fwp
-fwp
-fwp
-fwp
-feD
-qcv
+emH
+emH
+emH
+emH
+jCn
+swv
 szo
-qcv
-qcv
-qcv
-qcv
-qcv
+swv
+swv
+swv
+swv
+swv
 prQ
 qcv
 qcv
@@ -92347,7 +96375,7 @@ fqc
 rgE
 jiI
 ttp
-swD
+heH
 mLN
 njj
 bev
@@ -92357,7 +96385,7 @@ izk
 ayy
 tmQ
 iov
-imS
+iov
 sAo
 sAo
 dki
@@ -92504,7 +96532,7 @@ uxN
 uxN
 uxN
 uxN
-iel
+gpu
 eCC
 njj
 tNe
@@ -92531,7 +96559,7 @@ xhi
 mdX
 trT
 bNt
-swv
+szo
 cxD
 swv
 swv
@@ -92661,7 +96689,7 @@ iJv
 iJv
 iJv
 iJv
-iJv
+rpe
 aWW
 jfn
 bev
@@ -92679,8 +96707,8 @@ sAo
 xQK
 xYi
 tMU
-vmK
-vmK
+iae
+iae
 nXM
 qnk
 oys
@@ -92694,7 +96722,7 @@ icC
 icC
 itU
 icC
-tKq
+tNh
 swv
 tij
 pvL
@@ -92818,7 +96846,7 @@ iXU
 ivg
 iXU
 ueC
-swD
+xjG
 hfD
 wHF
 cvC
@@ -92834,11 +96862,11 @@ dZO
 sAo
 sAo
 oZq
-sAo
+ffw
 rrw
-emH
+sis
 vtr
-emH
+kEi
 lOB
 cgv
 wEk
@@ -92851,7 +96879,7 @@ xnH
 epg
 ngl
 ngl
-tZt
+ueM
 swv
 tij
 pvL
@@ -92975,7 +97003,7 @@ iel
 iel
 iel
 iel
-iel
+gpu
 eCC
 jfn
 bev
@@ -92993,13 +97021,13 @@ sAo
 kYq
 cCP
 mBt
-iae
+ckc
 fzw
 xew
 eGW
 wMP
 uWl
-vwz
+ikq
 trT
 bBh
 wXZ
@@ -93091,7 +97119,7 @@ qxy
 xdC
 xdC
 cWn
-cWn
+uQc
 pjz
 pjz
 qxy
@@ -93132,7 +97160,7 @@ odc
 odc
 odc
 odc
-iJv
+rpe
 aWW
 njj
 tNe
@@ -93289,7 +97317,7 @@ eqv
 mCl
 pLg
 fal
-swD
+heH
 mLN
 njj
 bev
@@ -93307,7 +97335,7 @@ sej
 lmF
 aLW
 ayy
-pWp
+mCC
 tVH
 tMP
 vrC
@@ -93446,7 +97474,7 @@ uxN
 uxN
 uxN
 uxN
-iel
+gpu
 xdQ
 njj
 ncl
@@ -93466,7 +97494,7 @@ krF
 ayy
 wlv
 tVH
-ygs
+rpp
 emH
 emH
 emH
@@ -93603,7 +97631,7 @@ iJv
 iJv
 iJv
 iJv
-iJv
+rpe
 aWW
 njj
 fjW
@@ -93629,21 +97657,21 @@ mhg
 iae
 iae
 uHI
-uuS
-uuS
-uuS
-uuS
-uuS
-uuS
-uuS
+icC
+icC
+icC
+icC
+icC
+icC
+icC
 tKq
-szo
-szo
-szo
-szo
-szo
-szo
-szo
+ngl
+ngl
+ngl
+ngl
+ngl
+ngl
+ygs
 jpF
 shR
 oQR
@@ -93755,11 +97783,11 @@ uaC
 jfn
 swD
 maA
-rDI
-xsj
-xsj
-xsj
-uyg
+cyG
+iXU
+iXU
+iXU
+ueC
 heH
 mLN
 njj
@@ -93788,9 +97816,9 @@ lLU
 nyU
 nyU
 nyU
+gvJ
 qcm
-qcm
-qcm
+gcX
 nyU
 eFY
 tZt
@@ -93800,8 +97828,8 @@ evb
 swv
 xFe
 ghq
-evb
-szo
+wiw
+swv
 shR
 lXt
 wRX
@@ -93913,23 +97941,23 @@ jfn
 iel
 hKR
 cpt
-iel
+rCI
 qgU
-iel
-iel
-iel
+rCI
+rCI
+fMo
 dtP
 njj
 qwK
-kyb
+gbS
 kyb
 pmL
 vNP
 rsD
 eHS
 cCT
-rKt
-rKt
+aJv
+aJv
 ldF
 rKt
 hSX
@@ -93957,7 +97985,7 @@ xFe
 swv
 xFe
 swv
-xFe
+wxV
 ngl
 qno
 qbt
@@ -94083,11 +98111,11 @@ smm
 vqx
 vNP
 xYb
-chP
 rKt
 rKt
 rKt
-ldF
+rKt
+aHu
 mNP
 mNP
 rUg
@@ -94096,26 +98124,26 @@ cMn
 lkQ
 lVO
 nHM
-xsQ
+vwz
 xsQ
 jyy
 nyU
 brk
 syb
 pCw
-oUk
+mdw
 oUk
 tmW
 ngl
-tZt
+ldv
 xFe
 swv
 evb
 swv
 evb
 swv
-xFe
-mou
+omM
+swv
 shR
 qIY
 wjU
@@ -94240,7 +98268,7 @@ smm
 smm
 vNP
 fKL
-chP
+rKt
 rKt
 rKt
 ouE
@@ -94249,12 +98277,12 @@ rKt
 rKt
 sAu
 xYG
-cMn
+dJx
 vkm
 lVO
 kiq
 jjG
-xzt
+uuR
 uTS
 cHJ
 hpz
@@ -94265,14 +98293,14 @@ fXF
 nyU
 swv
 pYT
-uuS
-uuS
-uuS
+icC
+icC
+icC
 sJV
-uuS
-uuS
+icC
+icC
 ciy
-mou
+swv
 shR
 eIw
 llB
@@ -94406,12 +98434,12 @@ rKt
 rKt
 rUg
 piI
-cMn
+dJx
 igF
 lVO
 vpw
 sVG
-xzt
+uuR
 sIH
 uLy
 mCX
@@ -94568,9 +98596,9 @@ tXl
 lVO
 dsg
 imT
-xzt
+uuR
 sIH
-uLy
+cjf
 wGC
 fts
 lue
@@ -94725,12 +98753,12 @@ lVO
 lVO
 iaO
 iaO
-xzt
+uuR
 sIH
-uLy
+kpP
 sUB
 xMe
-dym
+wxT
 rIL
 kLy
 nyU
@@ -94882,7 +98910,7 @@ pzZ
 lVO
 fLK
 xzt
-xzt
+uuR
 sIH
 nyU
 nyU
@@ -95028,7 +99056,7 @@ qVP
 qVP
 lVO
 hvQ
-hvQ
+ode
 xlo
 fZe
 fZe
@@ -95038,7 +99066,7 @@ oqG
 vYd
 sfB
 vvK
-mUd
+lab
 mUd
 hGw
 lLU
@@ -95130,7 +99158,7 @@ vmk
 vmk
 vmk
 qVP
-qVP
+rqy
 rfo
 rfo
 qVP
@@ -95184,9 +99212,9 @@ qVP
 qVP
 qVP
 lVO
-ode
+hvQ
 nuf
-ewa
+hvQ
 hvQ
 hvQ
 mCU
@@ -95369,7 +99397,7 @@ qBi
 ijm
 txt
 jpj
-jpj
+hvU
 piB
 piB
 txt
@@ -95436,12 +99464,12 @@ fnQ
 vNo
 ekT
 knS
-vNo
+lvH
 vNo
 rpH
 vNo
 vNo
-ozr
+vNo
 vmk
 qVP
 rqy
@@ -95504,8 +99532,8 @@ jpa
 ney
 mRg
 cxq
-rAb
-wxK
+kYD
+jIw
 xUf
 xOZ
 qpB
@@ -95525,7 +99553,7 @@ hvt
 owQ
 nZZ
 txt
-jpj
+hmT
 sQY
 gYJ
 gYJ
@@ -95597,7 +99625,7 @@ vNo
 lqL
 vNo
 vNo
-vNo
+odB
 vNo
 vmk
 koO
@@ -95818,7 +99846,7 @@ lRA
 xTy
 vUf
 eph
-mQm
+fNb
 eph
 xUf
 lsI
@@ -95975,7 +100003,7 @@ hRA
 xTy
 vUf
 eph
-mQm
+fNb
 eph
 xUf
 lsI
@@ -96066,7 +100094,7 @@ fnQ
 knS
 vNo
 vNo
-vNo
+nzv
 beo
 xZO
 lPd
@@ -96132,7 +100160,7 @@ hRA
 ney
 ghr
 eph
-mQm
+fNb
 eph
 eRc
 xOZ
@@ -96289,7 +100317,7 @@ hRA
 ucK
 vUf
 eph
-mQm
+fNb
 eph
 xUf
 iYK
@@ -96445,7 +100473,7 @@ oQX
 hJT
 xkY
 lyW
-wxK
+lOI
 mQm
 rAb
 sNc
@@ -97544,9 +101572,9 @@ oYm
 dZR
 xlt
 tAk
-abd
+fDi
 ixd
-pAS
+bWg
 xUf
 cpf
 bLY
@@ -98324,9 +102352,9 @@ qVP
 qVP
 xlt
 bum
-qhR
-qYJ
 uhl
+qYJ
+dGD
 xlt
 rcd
 uQt
@@ -98486,9 +102514,9 @@ wTQ
 drM
 xlt
 cxa
-nMG
+eph
 wxK
-pAS
+feD
 sxh
 cpf
 gTq
@@ -98800,7 +102828,7 @@ qVP
 qVP
 cEn
 xEP
-rTT
+dOB
 dOB
 wcc
 dOB
@@ -99114,7 +103142,7 @@ qVP
 qVP
 cEn
 eSF
-qly
+bBT
 bBT
 dLg
 lSI
@@ -99271,9 +103299,9 @@ qVP
 qVP
 cEn
 ioE
-rTT
-dOB
-wcc
+ozr
+ozr
+kqi
 dOB
 cEn
 jIo
@@ -99428,7 +103456,7 @@ qVP
 qVP
 cEn
 vGG
-qly
+bBT
 bBT
 dLg
 dOB
@@ -99585,7 +103613,7 @@ qVP
 qVP
 cEn
 mdf
-qly
+bBT
 bBT
 dLg
 uie
@@ -99742,7 +103770,7 @@ qVP
 qVP
 cEn
 xEP
-rTT
+dOB
 dOB
 obv
 dOB
@@ -100056,9 +104084,9 @@ qVP
 rqy
 rqy
 muO
-jpV
 rfo
-aQP
+nqb
+iqd
 muO
 rqy
 rfo
@@ -100213,8 +104241,8 @@ qVP
 rqy
 rqy
 rqy
-jpV
 rfo
+chP
 aQP
 rqy
 rqy
@@ -100370,8 +104398,8 @@ qVP
 rqy
 rqy
 rqy
-jpV
 rfo
+chP
 aQP
 rqy
 rqy
@@ -100527,8 +104555,8 @@ qVP
 qVP
 rqy
 rqy
-jpV
 rfo
+chP
 aQP
 rqy
 rqy
@@ -100684,8 +104712,8 @@ qVP
 qVP
 qVP
 rqy
-jpV
 rfo
+chP
 aQP
 rqy
 rqy
@@ -100841,8 +104869,8 @@ qVP
 qVP
 rqy
 rqy
-jpV
 rfo
+chP
 aQP
 rqy
 rqy
@@ -100998,8 +105026,8 @@ qVP
 qVP
 rqy
 rqy
-jpV
 rfo
+chP
 aQP
 rqy
 rqy
@@ -101155,8 +105183,8 @@ qVP
 qVP
 qVP
 rqy
-jpV
 rfo
+chP
 aQP
 bbq
 rqy
@@ -101312,8 +105340,8 @@ qVP
 qVP
 rqy
 rqy
-jpV
 rfo
+chP
 aQP
 bbq
 rqy
@@ -101469,8 +105497,8 @@ qVP
 rqy
 jKh
 rqy
-jpV
 rfo
+chP
 aQP
 bbq
 rqy
@@ -101626,8 +105654,8 @@ rqy
 rqy
 rqy
 rqy
-jpV
 rfo
+chP
 aQP
 rqy
 rqy
@@ -101783,9 +105811,9 @@ bbq
 bbq
 rqy
 rqy
-jpV
+rfo
 xHF
-aQP
+tAZ
 rqy
 rqy
 rqy
@@ -101940,9 +105968,9 @@ rfo
 rfo
 rfo
 rfo
-jpV
+rfo
 bPH
-aQP
+mCd
 rfo
 rfo
 rfo
@@ -102097,9 +106125,9 @@ rfo
 rfo
 rfo
 rfo
-jpV
+rfo
 bPH
-aQP
+mCd
 rfo
 rfo
 rfo
@@ -102254,9 +106282,9 @@ bbq
 bbq
 rqy
 rqy
-jpV
-iRK
-aQP
+rfo
+jQZ
+iqd
 rqy
 rqy
 rqy
@@ -102411,8 +106439,8 @@ rqy
 rqy
 rqy
 rqy
-jpV
 rfo
+chP
 aQP
 rqy
 rqy
@@ -102568,7 +106596,7 @@ rqy
 rqy
 rqy
 rqy
-jpV
+rfo
 wSU
 aQP
 bbq
@@ -104767,7 +108795,7 @@ xvI
 xvI
 xvI
 xvI
-xvI
+iCe
 lxu
 lxu
 lxu
@@ -104924,7 +108952,7 @@ oaR
 oaR
 lxu
 lxu
-xvI
+chN
 lxu
 lxu
 qef
@@ -110417,7 +114445,7 @@ wuy
 kBk
 dlm
 fLk
-uFg
+iwD
 uFg
 lse
 lse
@@ -110891,9 +114919,9 @@ wuy
 kBk
 tUT
 pOx
-rJc
-iwD
-iwD
+atK
+noU
+noU
 oyK
 kBk
 wuy
@@ -111048,7 +115076,7 @@ wuy
 kBk
 avB
 pOx
-vlp
+kpk
 dRt
 bUr
 noU
@@ -111687,8 +115715,8 @@ tcx
 lMF
 gUT
 cPy
-sjv
-eIj
+aZz
+gYR
 sjv
 uAD
 aRk
@@ -111845,7 +115873,7 @@ lMF
 unu
 thP
 eIj
-cPy
+ixI
 wtN
 hwG
 lSo
@@ -112012,7 +116040,7 @@ pyk
 pvH
 pYv
 aLQ
-qfF
+ulv
 pAc
 bOE
 nRK
@@ -112307,7 +116335,7 @@ ong
 ong
 ong
 ong
-nyo
+pyb
 fIk
 xpQ
 iOi
@@ -112316,8 +116344,8 @@ qUK
 qUK
 rsk
 rKO
-nPd
-dZB
+dQi
+mIw
 kGY
 kZg
 uSd
@@ -112464,7 +116492,7 @@ ong
 ong
 ong
 ong
-nyo
+tXm
 bqk
 sRj
 hQq
@@ -112472,9 +116500,9 @@ hQq
 sRj
 gva
 dhn
-rKO
-dQi
-dZB
+tGC
+stc
+bKt
 kGY
 kZg
 uSd
@@ -112483,8 +116511,8 @@ pyk
 wuy
 wuy
 jfa
-vVU
-wVE
+xkv
+vPL
 wuT
 wuT
 mkD
@@ -112623,7 +116651,7 @@ ong
 ong
 nyo
 vTH
-sRj
+tIj
 qrX
 nDr
 sRj
@@ -112631,7 +116659,7 @@ gva
 aqO
 xpF
 dQi
-dZB
+fyB
 kGY
 kZg
 uSd
@@ -112640,7 +116668,7 @@ pyk
 wuy
 wuy
 jfa
-idt
+xQj
 wVE
 xQj
 grS
@@ -112778,9 +116806,9 @@ ong
 ong
 ong
 ong
-nyo
+rlW
 eHr
-sRj
+nBX
 dzm
 xtQ
 sRj
@@ -112935,9 +116963,9 @@ ozh
 ozh
 ozh
 ozh
-nyo
+aUO
 dUU
-sRj
+nBX
 bPD
 bPD
 sRj
@@ -113102,7 +117130,7 @@ mYe
 gva
 gEz
 dQi
-dZB
+plx
 kGY
 kZg
 uSd
@@ -113249,9 +117277,9 @@ wZN
 wZN
 wZN
 wZN
-nyo
+pyb
 bgk
-qjg
+nBX
 hQq
 hQq
 sRj
@@ -113268,7 +117296,7 @@ pyk
 vfS
 xQj
 xQj
-idt
+xQj
 wVE
 xQj
 qHm
@@ -113406,9 +117434,9 @@ ong
 ong
 ong
 ong
-nyo
+tXm
 vCL
-qjg
+nBX
 nOI
 awd
 sRj
@@ -113425,7 +117453,7 @@ pyk
 kQI
 xQj
 xQj
-idt
+xQj
 wVE
 xQj
 vCp
@@ -113565,7 +117593,7 @@ ong
 ong
 nyo
 vTH
-qjg
+eSQ
 xmx
 iRu
 sRj
@@ -113573,7 +117601,7 @@ gva
 dQi
 bHF
 dQi
-dZB
+mIw
 kGY
 kZg
 aTj
@@ -113720,16 +117748,16 @@ ong
 ong
 ong
 ong
-nyo
+rlW
 xYs
-qjg
+nBX
 bPD
 bPD
 sRj
 gva
 dwy
-bHF
-dQi
+iri
+stc
 dZB
 kGY
 kZg
@@ -113877,17 +117905,17 @@ ong
 ong
 ong
 ong
-nyo
+aUO
 bfG
-qjg
+xZo
 bbp
+cKw
 qjg
-qjg
-qjg
+cKw
 ocJ
-bHF
-nPd
-dZB
+cAL
+dQi
+fyB
 kGY
 kZg
 aTj
@@ -114054,7 +118082,7 @@ kRE
 bmz
 bmz
 bmz
-jbI
+rQA
 jbI
 jbI
 jbI
@@ -114217,7 +118245,7 @@ mpQ
 mpQ
 eJO
 mpQ
-eYM
+ijN
 bCA
 qhL
 qhL
@@ -114373,7 +118401,7 @@ pyh
 ctS
 ctS
 pyh
-mpQ
+lyc
 eYM
 jfa
 czR
@@ -114531,7 +118559,7 @@ qGr
 qQy
 pyh
 mpQ
-eYM
+ijN
 mpQ
 mpQ
 mpQ
@@ -114682,15 +118710,15 @@ aDi
 jlE
 pyh
 hyP
-lAk
+hFT
 hch
 hch
 hQX
 pyh
 mpQ
-eYM
+kis
 xbH
-eWW
+pyd
 eWW
 uUC
 mpQ
@@ -114820,7 +118848,7 @@ bRD
 aFR
 tHh
 ydj
-fAI
+bEp
 bbC
 uDQ
 mos
@@ -115002,7 +119030,7 @@ sxJ
 jXz
 pyh
 mpQ
-eYM
+fUQ
 cPJ
 tdy
 hFz
@@ -115153,8 +119181,8 @@ qMo
 qMo
 qMo
 qMo
-qMo
-qMo
+pyh
+pyh
 pyh
 pyh
 pyh
@@ -115310,7 +119338,7 @@ iIS
 oxZ
 iIS
 krr
-dSu
+mpQ
 naA
 mpQ
 mpQ
@@ -115319,7 +119347,7 @@ mpQ
 xpH
 cPJ
 vsE
-iLi
+pur
 bmZ
 cPJ
 wuy
@@ -115469,10 +119497,10 @@ bvM
 rJS
 dpc
 dpc
-jbI
-jbI
-jbI
-jbI
+dpc
+dpc
+dpc
+dpc
 ivq
 cPJ
 evB
@@ -115624,7 +119652,7 @@ oKi
 xsP
 xRH
 krr
-dSu
+mpQ
 bBI
 mpQ
 mpQ
@@ -115781,8 +119809,8 @@ qMo
 qMo
 qMo
 qMo
-qMo
-qMo
+jfa
+jfa
 jfa
 jfa
 jfa


### PR DESCRIPTION
See PR #228, I had to migrate to this PR due to a goof of my own creation.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

- Sets SM cooling room turfs to unsimulated
- Changes SM waste filter to filter into waste loop
- Remaps majority of non-hallway rooms with manual cables
- Moves some 'incoming' atmos pipes around in atmos so they aren't in CE's room
- Switches waste loop thermo-machine to on and at 50% power due to SM filter going into waste loop
- Tweaks cryo pipes to include a filter

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
