### PR TITLE
Fire Extinguisher-mageddon

### DIFF
--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -2189,6 +2189,10 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/service/chapel)
+"bdJ" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/miningdock/oresilo)
 "bdN" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
@@ -2527,6 +2531,12 @@
 	},
 /turf/open/floor/iron/dark,
 /area/station/science/server)
+"bmj" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/deadspace/random/slides{
+	dir = 8
+	},
+/area/station/hallway/secondary/command)
 "bmx" = (
 /obj/machinery/conveyor{
 	id = "Lower Marker Conveyor"
@@ -3855,10 +3865,6 @@
 	},
 /turf/open/floor/engine/airless,
 /area/station/engineering/supermatter/room)
-"bTL" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/deadspace/random/maint_left,
-/area/station/hallway/primary/fore)
 "bTQ" = (
 /obj/machinery/conveyor{
 	id = "Storage Upper"
@@ -4263,12 +4269,6 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/engine/cult,
 /area/station/service/library)
-"cdm" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
-	},
-/area/station/hallway/secondary/exit/departure_lounge)
 "cdo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/hardwood,
@@ -6361,12 +6361,6 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/fore/lesser)
-"djc" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/deadspace/random/slides{
-	dir = 8
-	},
-/area/station/hallway/secondary/command)
 "djs" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/ce)
@@ -6646,12 +6640,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
-"dqv" = (
-/obj/structure/extinguisher_cabinet/directional/south,
-/turf/open/floor/deadspace/random/maint_right{
-	dir = 8
-	},
-/area/station/hallway/primary/fore)
 "dqU" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/grater,
@@ -8963,12 +8951,6 @@
 /obj/machinery/meter,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
-"eAT" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/dark/side{
-	dir = 8
-	},
-/area/station/hallway/primary/starboard)
 "eAV" = (
 /obj/machinery/light/floor/has_bulb,
 /obj/structure/cable/yellow{
@@ -9984,7 +9966,6 @@
 "eZT" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/closet/secure_closet/personal,
-/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "eZW" = (
@@ -11669,10 +11650,6 @@
 	dir = 8
 	},
 /area/station/hallway/primary/fore)
-"fWt" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/deadspace/random/maint_right,
-/area/station/hallway/primary/fore)
 "fWv" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/food_or_drink/booze,
@@ -12942,10 +12919,6 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/aegis/surface)
-"gJm" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/deadspace/med/side_med,
-/area/station/medical/medbay/central)
 "gKc" = (
 /obj/structure/table,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -12987,6 +12960,13 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/iron/ported/lino,
 /area/station/commons/dorms/barracks/female)
+"gLx" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "gMl" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -15519,10 +15499,6 @@
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
-"hXM" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/miningdock/oresilo)
 "hXP" = (
 /mob/living/simple_animal/mouse/gray,
 /turf/open/floor/plating,
@@ -16493,13 +16469,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/security/range)
-"iwo" = (
-/obj/structure/cable/yellow{
-	icon_state = "3"
-	},
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/deadspace/random/slides,
-/area/station/hallway/secondary/exit/departure_lounge)
 "iwy" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/disposalpipe/segment{
@@ -17421,6 +17390,12 @@
 	},
 /turf/open/misc/asteroid,
 /area/station/solars/port/fore)
+"iOx" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/hallway/primary/starboard)
 "iPb" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/scrubbers/hidden/layer2,
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
@@ -18087,6 +18062,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/hardwood,
 /area/station/command/heads_quarters/hop)
+"jgT" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/deadspace/med/r_medside,
+/area/station/medical/medbay/central)
 "jha" = (
 /obj/structure/window/reinforced/tinted{
 	dir = 4
@@ -20020,6 +19999,10 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"kcf" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/deadspace/med/l_medside,
+/area/station/medical/medbay/central)
 "kcj" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags,
@@ -21125,7 +21108,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -23026,6 +23008,12 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/catwalk_floor/iron_dark,
 /area/station/maintenance/fore/lesser)
+"lAA" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/deadspace/random/slides{
+	dir = 8
+	},
+/area/station/security/brig)
 "lAK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -23783,12 +23771,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/deadspace/bathroom,
 /area/mine/production)
-"lVb" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/iron/dark/side{
-	dir = 1
-	},
-/area/station/hallway/primary/starboard)
 "lVc" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -24751,12 +24733,6 @@
 	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
-"muK" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/deadspace/random/slides{
-	dir = 4
-	},
-/area/mine/production)
 "muO" = (
 /obj/machinery/light/small/red/directional/west,
 /turf/open/misc/asteroid,
@@ -25283,6 +25259,12 @@
 /obj/effect/spawner/random/maintenance,
 /turf/open/misc/asteroid,
 /area/aegis/surface)
+"mKc" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/hallway/primary/central/aft)
 "mKE" = (
 /obj/item/cigbutt,
 /obj/structure/table/reinforced,
@@ -26147,6 +26129,12 @@
 "ney" = (
 /turf/closed/wall,
 /area/mine/storage)
+"neS" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/hallway/primary/starboard)
 "nfc" = (
 /obj/effect/landmark{
 	name = "ShuttleRepairPart"
@@ -26977,12 +26965,6 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
-"nCH" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/deadspace/random/slides{
-	dir = 1
-	},
-/area/station/hallway/primary/central/aft)
 "nCJ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -27034,6 +27016,11 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/command/bridge)
+"nDy" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "nDA" = (
 /turf/open/floor/iron/dark,
 /area/station/security/interrogation)
@@ -29034,6 +29021,10 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/heads_quarters/ce)
+"oGo" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/miningoffice)
 "oGx" = (
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
@@ -29891,6 +29882,12 @@
 	dir = 8
 	},
 /area/station/security/checkpoint/science)
+"pcH" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "pcX" = (
 /obj/structure/railing{
 	dir = 6
@@ -31171,10 +31168,6 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
-"pKL" = (
-/obj/structure/closet/firecloset/full,
-/turf/open/floor/deadspace/random/rectangles,
-/area/mine/eva)
 "pKM" = (
 /obj/machinery/camera/emp_proof/directional/east,
 /turf/open/floor/iron/ported/techfloor_grid,
@@ -31389,6 +31382,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/deadspace/random/slides,
 /area/station/security/brig)
 "pOK" = (
@@ -32888,7 +32882,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
-/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "qDn" = (
@@ -33854,12 +33847,6 @@
 	},
 /turf/open/openspace,
 /area/station/command/bridge)
-"rdq" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/deadspace/random/maint_left{
-	dir = 4
-	},
-/area/station/hallway/primary/fore)
 "rdy" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/deadspace/random/slides{
@@ -33883,10 +33870,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/starboard)
-"rdT" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/deadspace/med/r_medside,
-/area/station/medical/medbay/central)
 "rek" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall,
@@ -34220,6 +34203,10 @@
 	dir = 1
 	},
 /area/aegis/hanger)
+"rmF" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/deadspace/med/side_med,
+/area/station/medical/medbay/central)
 "rmW" = (
 /obj/effect/decal/cleanable/blood,
 /obj/item/storage/book/bible/unitology,
@@ -34239,12 +34226,6 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
-"rnn" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/deadspace/random/maint_left{
-	dir = 4
-	},
-/area/station/hallway/primary/port)
 "rnx" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/miningoffice)
@@ -34514,10 +34495,6 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
-"ruu" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/deadspace/med/l_medside,
-/area/station/medical/medbay/central)
 "ruB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -35408,6 +35385,12 @@
 /obj/effect/spawner/random/deadspace/rig/scaf,
 /turf/open/floor/deadspace/mono,
 /area/aegis/surface)
+"rTq" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/deadspace/random/maint_left{
+	dir = 4
+	},
+/area/station/hallway/primary/fore)
 "rTI" = (
 /obj/machinery/door/airlock/command/glass{
 	name = "Shuttle Bay"
@@ -35664,6 +35647,12 @@
 /obj/structure/chair/wood,
 /turf/open/floor/wood,
 /area/station/maintenance/fore/lesser)
+"sbJ" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/deadspace/random/maint_left{
+	dir = 4
+	},
+/area/station/hallway/primary/port)
 "sbW" = (
 /obj/machinery/light/small/directional/east,
 /turf/open/floor/deadspace/bathroom,
@@ -35673,10 +35662,6 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
-"scw" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/miningoffice)
 "scx" = (
 /obj/structure/cable/yellow{
 	icon_state = "6"
@@ -37838,6 +37823,13 @@
 	},
 /turf/open/misc/ironsand,
 /area/aegis/surface)
+"tkP" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "tkZ" = (
 /obj/item/stack/rods,
 /turf/open/floor/deadspace/grater,
@@ -38700,10 +38692,6 @@
 /obj/structure/table,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
-"tLi" = (
-/obj/structure/extinguisher_cabinet/directional/east,
-/turf/open/floor/deadspace/random/slides,
-/area/station/security/brig)
 "tLC" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Solar Access";
@@ -39899,12 +39887,6 @@
 /obj/machinery/light,
 /turf/open/floor/stone,
 /area/aegis/surface)
-"uqA" = (
-/obj/structure/extinguisher_cabinet/directional/north,
-/turf/open/floor/deadspace/random/slides{
-	dir = 8
-	},
-/area/station/security/brig)
 "uqH" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -40735,13 +40717,6 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
-"uNJ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/iron/white,
-/area/station/science/research)
 "uNS" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/maint_left,
@@ -41360,6 +41335,10 @@
 /obj/structure/chair/sofa/bench/right,
 /turf/open/floor/deadspace/random/maint_left,
 /area/station/hallway/primary/central)
+"ved" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/deadspace/random/slides,
+/area/station/security/brig)
 "veo" = (
 /turf/closed/wall,
 /area/station/commons/dorms/barracks/male)
@@ -42180,6 +42159,12 @@
 /obj/machinery/autolathe,
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/maintenance/port/lesser)
+"vAt" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/deadspace/random/maint_right{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "vAI" = (
 /obj/structure/window/reinforced/spawner/west,
 /turf/open/floor/grass,
@@ -42282,6 +42267,10 @@
 "vDQ" = (
 /turf/closed/wall,
 /area/aegis/hanger)
+"vDR" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/eva)
 "vDX" = (
 /obj/item/statuebust,
 /obj/effect/landmark/observer_start,
@@ -44402,10 +44391,6 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
-"wHh" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/deadspace/random/rectangles,
-/area/station/cargo/storage)
 "wHi" = (
 /obj/structure/sign/directions/engineering{
 	dir = 1;
@@ -44899,10 +44884,6 @@
 /obj/structure/disposalpipe/trunk/multiz,
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/fore)
-"wXr" = (
-/obj/structure/extinguisher_cabinet/directional/west,
-/turf/open/floor/deadspace/random/rectangles,
-/area/mine/living_quarters)
 "wXz" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -81811,7 +81792,7 @@ bau
 lYR
 foz
 npi
-rnn
+sbJ
 iwy
 gQw
 uoA
@@ -85138,7 +85119,7 @@ bNV
 mWE
 bNV
 bNV
-tLi
+ved
 daa
 xZi
 qVP
@@ -85440,7 +85421,7 @@ qyr
 qyr
 qyr
 qyr
-uqA
+lAA
 xfk
 aKG
 tWq
@@ -87461,7 +87442,7 @@ bQx
 nKJ
 nKJ
 nKJ
-fWt
+nKJ
 bQx
 bPG
 ihj
@@ -87646,7 +87627,7 @@ ajU
 bNV
 bNV
 bNV
-tLi
+bNV
 vrG
 bNV
 bNV
@@ -88560,7 +88541,7 @@ bze
 vPM
 vPM
 vPM
-bTL
+vPM
 bze
 kBN
 gDA
@@ -89365,7 +89346,7 @@ mEk
 beN
 pxO
 beN
-rdT
+jgT
 oqn
 mNu
 beN
@@ -89504,7 +89485,7 @@ vEo
 mXs
 mYP
 jcd
-rdq
+rTq
 gDA
 jlM
 pEr
@@ -89966,7 +89947,7 @@ gFX
 gFX
 gFX
 gFX
-rdq
+bPG
 fVy
 jlM
 jcd
@@ -90011,7 +89992,7 @@ xyB
 moU
 eVM
 xyB
-ruu
+kcf
 xyB
 xyB
 bAQ
@@ -90441,7 +90422,7 @@ bPG
 aoS
 jlM
 bze
-bTL
+vPM
 cgw
 vPM
 vPM
@@ -90471,7 +90452,7 @@ iup
 iup
 iup
 iup
-gJm
+rmF
 bPk
 qZi
 rKf
@@ -91567,7 +91548,7 @@ yjk
 yjk
 yjk
 yjk
-uNJ
+tkP
 yjk
 mSl
 yjk
@@ -92016,7 +91997,7 @@ sLa
 nWd
 utw
 bZu
-rdq
+rTq
 fVy
 iGp
 uIz
@@ -94530,7 +94511,7 @@ nke
 psZ
 bPG
 fVy
-dqv
+vAt
 wZK
 etG
 mHG
@@ -95771,7 +95752,7 @@ iJv
 iJv
 xhK
 bvr
-cdm
+pcH
 iJv
 iPb
 iJv
@@ -95971,7 +95952,7 @@ icC
 icC
 icC
 vJE
-wHh
+swv
 trT
 rqy
 qVP
@@ -96097,7 +96078,7 @@ dxn
 ayy
 vux
 qSB
-eAT
+iOx
 uMl
 kuI
 xcg
@@ -97346,7 +97327,7 @@ fal
 heH
 mLN
 njj
-lVb
+neS
 jlu
 sAo
 izk
@@ -97967,7 +97948,7 @@ jfn
 iel
 hKR
 cpt
-iwo
+gLx
 qgU
 rCI
 rCI
@@ -98321,7 +98302,7 @@ swv
 pYT
 icC
 icC
-icC
+nDy
 sJV
 icC
 icC
@@ -99238,7 +99219,7 @@ qVP
 qVP
 qVP
 rnx
-scw
+oGo
 nuf
 hvQ
 hvQ
@@ -99560,13 +99541,13 @@ mRg
 cxq
 kYD
 jIw
-muK
+xUf
 xOZ
 qpB
 gdz
 aRn
 pss
-wXr
+osC
 qpB
 xOZ
 qVP
@@ -101607,7 +101588,7 @@ bLY
 aRF
 kqt
 vCd
-hXM
+bdJ
 agb
 kHT
 qVP
@@ -102857,7 +102838,7 @@ xEP
 dOB
 dOB
 wcc
-pKL
+vDR
 cEn
 kVv
 omd
@@ -103799,7 +103780,7 @@ xEP
 dOB
 dOB
 obv
-pKL
+vDR
 cEn
 kVv
 omd
@@ -118884,7 +118865,7 @@ agX
 cdo
 qiP
 tPF
-djc
+bmj
 kZg
 aTj
 rXE
@@ -119352,7 +119333,7 @@ iIS
 iIS
 qSL
 oxZ
-nCH
+mKc
 vYb
 iIK
 hQd

--- a/_maps/map_files/AegisVII/AegisVII.dmm
+++ b/_maps/map_files/AegisVII/AegisVII.dmm
@@ -429,6 +429,7 @@
 /area/mine/production)
 "all" = (
 /obj/machinery/light/small/directional/north,
+/obj/machinery/airalarm/directional/north,
 /turf/open/floor/engine,
 /area/station/science/misc_lab/range)
 "alq" = (
@@ -3854,6 +3855,10 @@
 	},
 /turf/open/floor/engine/airless,
 /area/station/engineering/supermatter/room)
+"bTL" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/deadspace/random/maint_left,
+/area/station/hallway/primary/fore)
 "bTQ" = (
 /obj/machinery/conveyor{
 	id = "Storage Upper"
@@ -4258,6 +4263,12 @@
 /obj/item/radio/intercom/directional/north,
 /turf/open/floor/engine/cult,
 /area/station/service/library)
+"cdm" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/hallway/secondary/exit/departure_lounge)
 "cdo" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/hardwood,
@@ -4655,6 +4666,7 @@
 /area/station/hallway/secondary/exit/departure_lounge)
 "cpC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
 	},
@@ -6349,6 +6361,12 @@
 /obj/machinery/light/small/directional/west,
 /turf/open/floor/iron,
 /area/station/maintenance/fore/lesser)
+"djc" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/deadspace/random/slides{
+	dir = 8
+	},
+/area/station/hallway/secondary/command)
 "djs" = (
 /turf/closed/wall/r_wall,
 /area/station/command/heads_quarters/ce)
@@ -6628,6 +6646,12 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/iron/dark,
 /area/station/medical/break_room)
+"dqv" = (
+/obj/structure/extinguisher_cabinet/directional/south,
+/turf/open/floor/deadspace/random/maint_right{
+	dir = 8
+	},
+/area/station/hallway/primary/fore)
 "dqU" = (
 /obj/machinery/light/directional/east,
 /turf/open/floor/deadspace/grater,
@@ -8939,6 +8963,12 @@
 /obj/machinery/meter,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
+"eAT" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/dark/side{
+	dir = 8
+	},
+/area/station/hallway/primary/starboard)
 "eAV" = (
 /obj/machinery/light/floor/has_bulb,
 /obj/structure/cable/yellow{
@@ -9954,6 +9984,7 @@
 "eZT" = (
 /obj/structure/window/reinforced/spawner/east,
 /obj/structure/closet/secure_closet/personal,
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/storage)
 "eZW" = (
@@ -11310,6 +11341,7 @@
 /area/station/service/bar)
 "fOy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4,
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/deadspace/random/slides{
 	dir = 8
 	},
@@ -11636,6 +11668,10 @@
 /turf/open/floor/deadspace/random/maint_center{
 	dir = 8
 	},
+/area/station/hallway/primary/fore)
+"fWt" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/deadspace/random/maint_right,
 /area/station/hallway/primary/fore)
 "fWv" = (
 /obj/structure/rack,
@@ -12906,6 +12942,10 @@
 /obj/structure/rack,
 /turf/open/floor/plating,
 /area/aegis/surface)
+"gJm" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/deadspace/med/side_med,
+/area/station/medical/medbay/central)
 "gKc" = (
 /obj/structure/table,
 /turf/open/floor/deadspace/random/golf_brown,
@@ -15309,6 +15349,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "hTa" = (
@@ -15478,6 +15519,10 @@
 	},
 /turf/open/floor/iron/ported/techfloor,
 /area/station/engineering/supermatter/room)
+"hXM" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/miningdock/oresilo)
 "hXP" = (
 /mob/living/simple_animal/mouse/gray,
 /turf/open/floor/plating,
@@ -16448,6 +16493,13 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/security/range)
+"iwo" = (
+/obj/structure/cable/yellow{
+	icon_state = "3"
+	},
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/deadspace/random/slides,
+/area/station/hallway/secondary/exit/departure_lounge)
 "iwy" = (
 /obj/effect/decal/cleanable/generic,
 /obj/structure/disposalpipe/segment{
@@ -16992,6 +17044,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/deadspace/random/maint_left{
 	dir = 4
 	},
@@ -19224,6 +19277,7 @@
 /obj/effect/turf_decal/tile/yellow/half/contrasted{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/commons/storage/tools)
 "jIP" = (
@@ -21071,6 +21125,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/deadspace/random/slides{
 	dir = 1
 	},
@@ -22275,6 +22330,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "lhH" = (
@@ -23727,6 +23783,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2,
 /turf/open/floor/deadspace/bathroom,
 /area/mine/production)
+"lVb" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/iron/dark/side{
+	dir = 1
+	},
+/area/station/hallway/primary/starboard)
 "lVc" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -24689,6 +24751,12 @@
 	},
 /turf/open/floor/iron/ported/techfloor_grid,
 /area/station/engineering/supermatter/room)
+"muK" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/deadspace/random/slides{
+	dir = 4
+	},
+/area/mine/production)
 "muO" = (
 /obj/machinery/light/small/red/directional/west,
 /turf/open/misc/asteroid,
@@ -26909,6 +26977,12 @@
 	},
 /turf/open/floor/carpet/red,
 /area/station/service/chapel)
+"nCH" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/deadspace/random/slides{
+	dir = 1
+	},
+/area/station/hallway/primary/central/aft)
 "nCJ" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/rack,
@@ -27552,6 +27626,7 @@
 /area/station/maintenance/fore/lesser)
 "nVa" = (
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/deadspace/random/slides,
 /area/station/hallway/primary/central/aft)
 "nVj" = (
@@ -28596,6 +28671,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 8
 	},
+/obj/structure/extinguisher_cabinet/directional/north,
 /turf/open/floor/deadspace/random/rectangles,
 /area/mine/lobby)
 "ovV" = (
@@ -31095,6 +31171,10 @@
 /obj/effect/spawner/random/structure/closet_maintenance,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/greater)
+"pKL" = (
+/obj/structure/closet/firecloset/full,
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/eva)
 "pKM" = (
 /obj/machinery/camera/emp_proof/directional/east,
 /turf/open/floor/iron/ported/techfloor_grid,
@@ -32808,6 +32888,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer2{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/cargo/lobby)
 "qDn" = (
@@ -33773,6 +33854,12 @@
 	},
 /turf/open/openspace,
 /area/station/command/bridge)
+"rdq" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/deadspace/random/maint_left{
+	dir = 4
+	},
+/area/station/hallway/primary/fore)
 "rdy" = (
 /obj/machinery/airalarm/directional/west,
 /turf/open/floor/deadspace/random/slides{
@@ -33796,6 +33883,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/starboard)
+"rdT" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/deadspace/med/r_medside,
+/area/station/medical/medbay/central)
 "rek" = (
 /obj/structure/sign/warning/electricshock,
 /turf/closed/wall,
@@ -34148,6 +34239,12 @@
 	},
 /turf/open/floor/deadspace/random/golf_brown,
 /area/station/cargo/warehouse/upper)
+"rnn" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/deadspace/random/maint_left{
+	dir = 4
+	},
+/area/station/hallway/primary/port)
 "rnx" = (
 /turf/closed/wall/r_wall,
 /area/station/cargo/miningoffice)
@@ -34417,6 +34514,10 @@
 /obj/item/radio/intercom/directional/east,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/command/bridge)
+"ruu" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/deadspace/med/l_medside,
+/area/station/medical/medbay/central)
 "ruB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer4{
 	dir = 1
@@ -34559,6 +34660,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 6
 	},
+/obj/structure/extinguisher_cabinet/directional/south,
 /turf/open/floor/iron/white,
 /area/station/science/research)
 "rzc" = (
@@ -34849,6 +34951,7 @@
 /turf/open/floor/iron/dark,
 /area/station/science/server)
 "rHx" = (
+/obj/machinery/airalarm/directional/west,
 /turf/open/floor/iron/white,
 /area/station/science/misc_lab)
 "rHS" = (
@@ -35570,6 +35673,10 @@
 /obj/machinery/atmospherics/pipe/smart/manifold4w/supply/hidden/layer4,
 /turf/open/floor/deadspace/random/maint_center,
 /area/station/commons/dorms/barracks/female)
+"scw" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/miningoffice)
 "scx" = (
 /obj/structure/cable/yellow{
 	icon_state = "6"
@@ -37026,6 +37133,7 @@
 "sRJ" = (
 /obj/machinery/camera/autoname/directional/east,
 /obj/machinery/airalarm/directional/south,
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/deadspace/random/slides{
 	dir = 4
 	},
@@ -38592,6 +38700,10 @@
 /obj/structure/table,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/main)
+"tLi" = (
+/obj/structure/extinguisher_cabinet/directional/east,
+/turf/open/floor/deadspace/random/slides,
+/area/station/security/brig)
 "tLC" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Solar Access";
@@ -39787,6 +39899,12 @@
 /obj/machinery/light,
 /turf/open/floor/stone,
 /area/aegis/surface)
+"uqA" = (
+/obj/structure/extinguisher_cabinet/directional/north,
+/turf/open/floor/deadspace/random/slides{
+	dir = 8
+	},
+/area/station/security/brig)
 "uqH" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -40617,6 +40735,13 @@
 /obj/structure/filingcabinet,
 /turf/open/floor/plating,
 /area/station/maintenance/starboard/upper)
+"uNJ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/iron/white,
+/area/station/science/research)
 "uNS" = (
 /obj/machinery/light/directional/west,
 /turf/open/floor/deadspace/random/maint_left,
@@ -42897,6 +43022,7 @@
 /obj/structure/chair/sofa/bench/left{
 	dir = 4
 	},
+/obj/structure/extinguisher_cabinet/directional/west,
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/hallway/primary/central)
 "vUT" = (
@@ -43576,6 +43702,7 @@
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/engineering/atmos)
 "wpD" = (
+/obj/structure/extinguisher_cabinet/directional/east,
 /turf/open/floor/deadspace/med/corner_interior{
 	dir = 1
 	},
@@ -44275,6 +44402,10 @@
 	},
 /turf/open/floor/deadspace/random/rectangles,
 /area/station/maintenance/department/engine)
+"wHh" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/deadspace/random/rectangles,
+/area/station/cargo/storage)
 "wHi" = (
 /obj/structure/sign/directions/engineering{
 	dir = 1;
@@ -44768,6 +44899,10 @@
 /obj/structure/disposalpipe/trunk/multiz,
 /turf/open/floor/deadspace/mono,
 /area/station/hallway/primary/fore)
+"wXr" = (
+/obj/structure/extinguisher_cabinet/directional/west,
+/turf/open/floor/deadspace/random/rectangles,
+/area/mine/living_quarters)
 "wXz" = (
 /obj/structure/rack,
 /obj/effect/spawner/random/maintenance/two,
@@ -81676,7 +81811,7 @@ bau
 lYR
 foz
 npi
-itM
+rnn
 iwy
 gQw
 uoA
@@ -85003,7 +85138,7 @@ bNV
 mWE
 bNV
 bNV
-bNV
+tLi
 daa
 xZi
 qVP
@@ -85305,7 +85440,7 @@ qyr
 qyr
 qyr
 qyr
-bHR
+uqA
 xfk
 aKG
 tWq
@@ -87326,7 +87461,7 @@ bQx
 nKJ
 nKJ
 nKJ
-nKJ
+fWt
 bQx
 bPG
 ihj
@@ -87511,7 +87646,7 @@ ajU
 bNV
 bNV
 bNV
-bNV
+tLi
 vrG
 bNV
 bNV
@@ -88425,7 +88560,7 @@ bze
 vPM
 vPM
 vPM
-vPM
+bTL
 bze
 kBN
 gDA
@@ -89230,7 +89365,7 @@ mEk
 beN
 pxO
 beN
-beN
+rdT
 oqn
 mNu
 beN
@@ -89369,7 +89504,7 @@ vEo
 mXs
 mYP
 jcd
-bPG
+rdq
 gDA
 jlM
 pEr
@@ -89831,7 +89966,7 @@ gFX
 gFX
 gFX
 gFX
-bPG
+rdq
 fVy
 jlM
 jcd
@@ -89876,7 +90011,7 @@ xyB
 moU
 eVM
 xyB
-xyB
+ruu
 xyB
 xyB
 bAQ
@@ -90306,7 +90441,7 @@ bPG
 aoS
 jlM
 bze
-vPM
+bTL
 cgw
 vPM
 vPM
@@ -90336,7 +90471,7 @@ iup
 iup
 iup
 iup
-enP
+gJm
 bPk
 qZi
 rKf
@@ -91432,7 +91567,7 @@ yjk
 yjk
 yjk
 yjk
-yjk
+uNJ
 yjk
 mSl
 yjk
@@ -91881,7 +92016,7 @@ sLa
 nWd
 utw
 bZu
-bPG
+rdq
 fVy
 iGp
 uIz
@@ -94395,7 +94530,7 @@ nke
 psZ
 bPG
 fVy
-jlM
+dqv
 wZK
 etG
 mHG
@@ -95636,7 +95771,7 @@ iJv
 iJv
 xhK
 bvr
-iJv
+cdm
 iJv
 iPb
 iJv
@@ -95836,7 +95971,7 @@ icC
 icC
 icC
 vJE
-swv
+wHh
 trT
 rqy
 qVP
@@ -95962,7 +96097,7 @@ dxn
 ayy
 vux
 qSB
-uMl
+eAT
 uMl
 kuI
 xcg
@@ -97211,7 +97346,7 @@ fal
 heH
 mLN
 njj
-bev
+lVb
 jlu
 sAo
 izk
@@ -97832,7 +97967,7 @@ jfn
 iel
 hKR
 cpt
-rCI
+iwo
 qgU
 rCI
 rCI
@@ -99103,7 +99238,7 @@ qVP
 qVP
 qVP
 rnx
-hvQ
+scw
 nuf
 hvQ
 hvQ
@@ -99425,13 +99560,13 @@ mRg
 cxq
 kYD
 jIw
-xUf
+muK
 xOZ
 qpB
 gdz
 aRn
 pss
-osC
+wXr
 qpB
 xOZ
 qVP
@@ -101472,7 +101607,7 @@ bLY
 aRF
 kqt
 vCd
-xZf
+hXM
 agb
 kHT
 qVP
@@ -102722,7 +102857,7 @@ xEP
 dOB
 dOB
 wcc
-dOB
+pKL
 cEn
 kVv
 omd
@@ -103664,7 +103799,7 @@ xEP
 dOB
 dOB
 obv
-dOB
+pKL
 cEn
 kVv
 omd
@@ -118749,7 +118884,7 @@ agX
 cdo
 qiP
 tPF
-kGY
+djc
 kZg
 aTj
 rXE
@@ -119217,7 +119352,7 @@ iIS
 iIS
 qSL
 oxZ
-iIS
+nCH
 vYb
 iIK
 hQd


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Noticed a lack of fire safety which is probably breaking a few codes, so I called over a few friends to install some of these new fancy extinguisher cabinets on the walls.


## Why It's Good For The Game
We don't like fires ):<

## Changelog

<!-- If your PR modifies aspects of the game that can be concretely observed by players or admins you should add a changelog. If your change does NOT meet this description, remove this section. Be sure to properly mark your PRs to prevent unnecessary GBP loss. You can read up on GBP and it's effects on PRs in the tgstation guides for contributors. Please note that maintainers freely reserve the right to remove and add tags should they deem it appropriate. You can attempt to finagle the system all you want, but it's best to shoot for clear communication right off the bat. -->

adds fire extinguishers (:
mostly to main hall, but also a few in med, sec, science, mining, and evac.

## Fire_log
Log #12139: 
TG sector: Currently on fire, 
Goon sector: Currently experiencing hell,
Fulp sector: Is quote "So on fire, that our server had to be replaced for the 6th time this week".
DS13 sector: Not on fire??? 
Note: (Ask Dave if the machines broken again)

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
